### PR TITLE
[Supplier] Just scaffold the Supplier module without any params 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -114,6 +114,9 @@ import (
 	pocketmodulekeeper "pocket/x/pocket/keeper"
 	pocketmoduletypes "pocket/x/pocket/types"
 
+	suppliermodule "pocket/x/supplier"
+	suppliermodulekeeper "pocket/x/supplier/keeper"
+	suppliermoduletypes "pocket/x/supplier/types"
 	// this line is used by starport scaffolding # stargate/app/moduleImport
 
 	appparams "pocket/app/params"
@@ -176,6 +179,7 @@ var (
 		vesting.AppModuleBasic{},
 		consensus.AppModuleBasic{},
 		pocketmodule.AppModuleBasic{},
+		suppliermodule.AppModuleBasic{},
 		// this line is used by starport scaffolding # stargate/app/moduleBasic
 	)
 
@@ -189,6 +193,7 @@ var (
 		stakingtypes.NotBondedPoolName: {authtypes.Burner, authtypes.Staking},
 		govtypes.ModuleName:            {authtypes.Burner},
 		ibctransfertypes.ModuleName:    {authtypes.Minter, authtypes.Burner},
+		suppliermoduletypes.ModuleName: {authtypes.Minter, authtypes.Burner, authtypes.Staking},
 		// this line is used by starport scaffolding # stargate/app/maccPerms
 	}
 )
@@ -252,6 +257,8 @@ type App struct {
 	ScopedICAHostKeeper  capabilitykeeper.ScopedKeeper
 
 	PocketKeeper pocketmodulekeeper.Keeper
+
+	SupplierKeeper suppliermodulekeeper.Keeper
 	// this line is used by starport scaffolding # stargate/app/keeperDeclaration
 
 	// mm is the module manager
@@ -299,6 +306,7 @@ func New(
 		feegrant.StoreKey, evidencetypes.StoreKey, ibctransfertypes.StoreKey, icahosttypes.StoreKey,
 		capabilitytypes.StoreKey, group.StoreKey, icacontrollertypes.StoreKey, consensusparamtypes.StoreKey,
 		pocketmoduletypes.StoreKey,
+		suppliermoduletypes.StoreKey,
 		// this line is used by starport scaffolding # stargate/app/storeKey
 	)
 	tkeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
@@ -529,6 +537,16 @@ func New(
 	)
 	pocketModule := pocketmodule.NewAppModule(appCodec, app.PocketKeeper, app.AccountKeeper, app.BankKeeper)
 
+	app.SupplierKeeper = *suppliermodulekeeper.NewKeeper(
+		appCodec,
+		keys[suppliermoduletypes.StoreKey],
+		keys[suppliermoduletypes.MemStoreKey],
+		app.GetSubspace(suppliermoduletypes.ModuleName),
+
+		app.BankKeeper,
+	)
+	supplierModule := suppliermodule.NewAppModule(appCodec, app.SupplierKeeper, app.AccountKeeper, app.BankKeeper)
+
 	// this line is used by starport scaffolding # stargate/app/keeperDefinition
 
 	/**** IBC Routing ****/
@@ -591,6 +609,7 @@ func New(
 		transferModule,
 		icaModule,
 		pocketModule,
+		supplierModule,
 		// this line is used by starport scaffolding # stargate/app/appModule
 
 		crisis.NewAppModule(app.CrisisKeeper, skipGenesisInvariants, app.GetSubspace(crisistypes.ModuleName)), // always be last to make sure that it checks for all invariants and not only part of them
@@ -624,6 +643,7 @@ func New(
 		vestingtypes.ModuleName,
 		consensusparamtypes.ModuleName,
 		pocketmoduletypes.ModuleName,
+		suppliermoduletypes.ModuleName,
 		// this line is used by starport scaffolding # stargate/app/beginBlockers
 	)
 
@@ -650,6 +670,7 @@ func New(
 		vestingtypes.ModuleName,
 		consensusparamtypes.ModuleName,
 		pocketmoduletypes.ModuleName,
+		suppliermoduletypes.ModuleName,
 		// this line is used by starport scaffolding # stargate/app/endBlockers
 	)
 
@@ -681,6 +702,7 @@ func New(
 		vestingtypes.ModuleName,
 		consensusparamtypes.ModuleName,
 		pocketmoduletypes.ModuleName,
+		suppliermoduletypes.ModuleName,
 		// this line is used by starport scaffolding # stargate/app/initGenesis
 	}
 	app.mm.SetOrderInitGenesis(genesisModuleOrder...)
@@ -906,6 +928,7 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 	paramsKeeper.Subspace(icacontrollertypes.SubModuleName)
 	paramsKeeper.Subspace(icahosttypes.SubModuleName)
 	paramsKeeper.Subspace(pocketmoduletypes.ModuleName)
+	paramsKeeper.Subspace(suppliermoduletypes.ModuleName)
 	// this line is used by starport scaffolding # stargate/app/paramSubspace
 
 	return paramsKeeper

--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -46473,6 +46473,42 @@ paths:
                   additionalProperties: {}
       tags:
         - Query
+  /pocket/supplier/params:
+    get:
+      summary: Parameters queries the parameters of the module.
+      operationId: PocketSupplierParams
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              params:
+                description: params holds all the parameters of this module.
+                type: object
+            description: >-
+              QueryParamsResponse is response type for the Query/Params RPC
+              method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    '@type':
+                      type: string
+                  additionalProperties: {}
+      tags:
+        - Query
 definitions:
   cosmos.auth.v1beta1.AddressBytesToStringResponse:
     type: object
@@ -75216,6 +75252,16 @@ definitions:
     type: object
     description: Params defines the parameters for the module.
   pocket.pocket.QueryParamsResponse:
+    type: object
+    properties:
+      params:
+        description: params holds all the parameters of this module.
+        type: object
+    description: QueryParamsResponse is response type for the Query/Params RPC method.
+  pocket.supplier.Params:
+    type: object
+    description: Params defines the parameters for the module.
+  pocket.supplier.QueryParamsResponse:
     type: object
     properties:
       params:

--- a/proto/pocket/supplier/genesis.proto
+++ b/proto/pocket/supplier/genesis.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+package pocket.supplier;
+
+import "gogoproto/gogo.proto";
+import "pocket/supplier/params.proto";
+
+option go_package = "pocket/x/supplier/types";
+
+// GenesisState defines the supplier module's genesis state.
+message GenesisState {
+  Params params = 1 [(gogoproto.nullable) = false];
+}

--- a/proto/pocket/supplier/params.proto
+++ b/proto/pocket/supplier/params.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+package pocket.supplier;
+
+import "gogoproto/gogo.proto";
+
+option go_package = "pocket/x/supplier/types";
+
+// Params defines the parameters for the module.
+message Params {
+  option (gogoproto.goproto_stringer) = false;
+  
+}

--- a/proto/pocket/supplier/query.proto
+++ b/proto/pocket/supplier/query.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+package pocket.supplier;
+
+import "gogoproto/gogo.proto";
+import "google/api/annotations.proto";
+import "cosmos/base/query/v1beta1/pagination.proto";
+import "pocket/supplier/params.proto";
+
+option go_package = "pocket/x/supplier/types";
+
+// Query defines the gRPC querier service.
+service Query {
+  // Parameters queries the parameters of the module.
+  rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
+    option (google.api.http).get = "/pocket/supplier/params";
+  }
+}
+
+// QueryParamsRequest is request type for the Query/Params RPC method.
+message QueryParamsRequest {}
+
+// QueryParamsResponse is response type for the Query/Params RPC method.
+message QueryParamsResponse {
+  // params holds all the parameters of this module.
+  Params params = 1 [(gogoproto.nullable) = false];
+}

--- a/proto/pocket/supplier/tx.proto
+++ b/proto/pocket/supplier/tx.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+package pocket.supplier;
+
+option go_package = "pocket/x/supplier/types";
+
+// Msg defines the Msg service.
+service Msg {}

--- a/testutil/keeper/supplier.go
+++ b/testutil/keeper/supplier.go
@@ -1,0 +1,53 @@
+package keeper
+
+import (
+	"testing"
+
+	tmdb "github.com/cometbft/cometbft-db"
+	"github.com/cometbft/cometbft/libs/log"
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/store"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	typesparams "github.com/cosmos/cosmos-sdk/x/params/types"
+	"github.com/stretchr/testify/require"
+	"pocket/x/supplier/keeper"
+	"pocket/x/supplier/types"
+)
+
+func SupplierKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
+	storeKey := sdk.NewKVStoreKey(types.StoreKey)
+	memStoreKey := storetypes.NewMemoryStoreKey(types.MemStoreKey)
+
+	db := tmdb.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db)
+	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
+	stateStore.MountStoreWithDB(memStoreKey, storetypes.StoreTypeMemory, nil)
+	require.NoError(t, stateStore.LoadLatestVersion())
+
+	registry := codectypes.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(registry)
+
+	paramsSubspace := typesparams.NewSubspace(cdc,
+		types.Amino,
+		storeKey,
+		memStoreKey,
+		"SupplierParams",
+	)
+	k := keeper.NewKeeper(
+		cdc,
+		storeKey,
+		memStoreKey,
+		paramsSubspace,
+		nil,
+	)
+
+	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
+
+	// Initialize params
+	k.SetParams(ctx, types.DefaultParams())
+
+	return k, ctx
+}

--- a/x/supplier/client/cli/query.go
+++ b/x/supplier/client/cli/query.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"fmt"
+	// "strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	// "github.com/cosmos/cosmos-sdk/client/flags"
+	// sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"pocket/x/supplier/types"
+)
+
+// GetQueryCmd returns the cli query commands for this module
+func GetQueryCmd(queryRoute string) *cobra.Command {
+	// Group supplier queries under a subcommand
+	cmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      fmt.Sprintf("Querying commands for the %s module", types.ModuleName),
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	cmd.AddCommand(CmdQueryParams())
+	// this line is used by starport scaffolding # 1
+
+	return cmd
+}

--- a/x/supplier/client/cli/query_params.go
+++ b/x/supplier/client/cli/query_params.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+
+	"pocket/x/supplier/types"
+)
+
+func CmdQueryParams() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "params",
+		Short: "shows the parameters of the module",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			res, err := queryClient.Params(cmd.Context(), &types.QueryParamsRequest{})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/supplier/client/cli/tx.go
+++ b/x/supplier/client/cli/tx.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	// "github.com/cosmos/cosmos-sdk/client/flags"
+	"pocket/x/supplier/types"
+)
+
+var (
+	DefaultRelativePacketTimeoutTimestamp = uint64((time.Duration(10) * time.Minute).Nanoseconds())
+)
+
+const (
+	flagPacketTimeoutTimestamp = "packet-timeout-timestamp"
+	listSeparator              = ","
+)
+
+// GetTxCmd returns the transaction commands for this module
+func GetTxCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      fmt.Sprintf("%s transactions subcommands", types.ModuleName),
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	// this line is used by starport scaffolding # 1
+
+	return cmd
+}

--- a/x/supplier/genesis.go
+++ b/x/supplier/genesis.go
@@ -1,0 +1,23 @@
+package supplier
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"pocket/x/supplier/keeper"
+	"pocket/x/supplier/types"
+)
+
+// InitGenesis initializes the module's state from a provided genesis state.
+func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
+	// this line is used by starport scaffolding # genesis/module/init
+	k.SetParams(ctx, genState.Params)
+}
+
+// ExportGenesis returns the module's exported genesis
+func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
+	genesis := types.DefaultGenesis()
+	genesis.Params = k.GetParams(ctx)
+
+	// this line is used by starport scaffolding # genesis/module/export
+
+	return genesis
+}

--- a/x/supplier/genesis_test.go
+++ b/x/supplier/genesis_test.go
@@ -1,0 +1,29 @@
+package supplier_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	keepertest "pocket/testutil/keeper"
+	"pocket/testutil/nullify"
+	"pocket/x/supplier"
+	"pocket/x/supplier/types"
+)
+
+func TestGenesis(t *testing.T) {
+	genesisState := types.GenesisState{
+		Params: types.DefaultParams(),
+
+		// this line is used by starport scaffolding # genesis/test/state
+	}
+
+	k, ctx := keepertest.SupplierKeeper(t)
+	supplier.InitGenesis(ctx, *k, genesisState)
+	got := supplier.ExportGenesis(ctx, *k)
+	require.NotNil(t, got)
+
+	nullify.Fill(&genesisState)
+	nullify.Fill(got)
+
+	// this line is used by starport scaffolding # genesis/test/assert
+}

--- a/x/supplier/keeper/keeper.go
+++ b/x/supplier/keeper/keeper.go
@@ -1,0 +1,51 @@
+package keeper
+
+import (
+	"fmt"
+
+	"github.com/cometbft/cometbft/libs/log"
+	"github.com/cosmos/cosmos-sdk/codec"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	"pocket/x/supplier/types"
+)
+
+type (
+	Keeper struct {
+		cdc        codec.BinaryCodec
+		storeKey   storetypes.StoreKey
+		memKey     storetypes.StoreKey
+		paramstore paramtypes.Subspace
+
+		bankKeeper types.BankKeeper
+	}
+)
+
+func NewKeeper(
+	cdc codec.BinaryCodec,
+	storeKey,
+	memKey storetypes.StoreKey,
+	ps paramtypes.Subspace,
+
+	bankKeeper types.BankKeeper,
+) *Keeper {
+	// set KeyTable if it has not already been set
+	if !ps.HasKeyTable() {
+		ps = ps.WithKeyTable(types.ParamKeyTable())
+	}
+
+	return &Keeper{
+		cdc:        cdc,
+		storeKey:   storeKey,
+		memKey:     memKey,
+		paramstore: ps,
+
+		bankKeeper: bankKeeper,
+	}
+}
+
+func (k Keeper) Logger(ctx sdk.Context) log.Logger {
+	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
+}

--- a/x/supplier/keeper/msg_server.go
+++ b/x/supplier/keeper/msg_server.go
@@ -1,0 +1,17 @@
+package keeper
+
+import (
+	"pocket/x/supplier/types"
+)
+
+type msgServer struct {
+	Keeper
+}
+
+// NewMsgServerImpl returns an implementation of the MsgServer interface
+// for the provided Keeper.
+func NewMsgServerImpl(keeper Keeper) types.MsgServer {
+	return &msgServer{Keeper: keeper}
+}
+
+var _ types.MsgServer = msgServer{}

--- a/x/supplier/keeper/msg_server_test.go
+++ b/x/supplier/keeper/msg_server_test.go
@@ -1,0 +1,23 @@
+package keeper_test
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	keepertest "pocket/testutil/keeper"
+	"pocket/x/supplier/keeper"
+	"pocket/x/supplier/types"
+)
+
+func setupMsgServer(t testing.TB) (types.MsgServer, context.Context) {
+	k, ctx := keepertest.SupplierKeeper(t)
+	return keeper.NewMsgServerImpl(*k), sdk.WrapSDKContext(ctx)
+}
+
+func TestMsgServer(t *testing.T) {
+	ms, ctx := setupMsgServer(t)
+	require.NotNil(t, ms)
+	require.NotNil(t, ctx)
+}

--- a/x/supplier/keeper/params.go
+++ b/x/supplier/keeper/params.go
@@ -1,0 +1,16 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"pocket/x/supplier/types"
+)
+
+// GetParams get all parameters as types.Params
+func (k Keeper) GetParams(ctx sdk.Context) types.Params {
+	return types.NewParams()
+}
+
+// SetParams set the params
+func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
+	k.paramstore.SetParamSet(ctx, &params)
+}

--- a/x/supplier/keeper/params_test.go
+++ b/x/supplier/keeper/params_test.go
@@ -1,0 +1,18 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	testkeeper "pocket/testutil/keeper"
+	"pocket/x/supplier/types"
+)
+
+func TestGetParams(t *testing.T) {
+	k, ctx := testkeeper.SupplierKeeper(t)
+	params := types.DefaultParams()
+
+	k.SetParams(ctx, params)
+
+	require.EqualValues(t, params, k.GetParams(ctx))
+}

--- a/x/supplier/keeper/query.go
+++ b/x/supplier/keeper/query.go
@@ -1,0 +1,7 @@
+package keeper
+
+import (
+	"pocket/x/supplier/types"
+)
+
+var _ types.QueryServer = Keeper{}

--- a/x/supplier/keeper/query_params.go
+++ b/x/supplier/keeper/query_params.go
@@ -1,0 +1,19 @@
+package keeper
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"pocket/x/supplier/types"
+)
+
+func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	return &types.QueryParamsResponse{Params: k.GetParams(ctx)}, nil
+}

--- a/x/supplier/keeper/query_params_test.go
+++ b/x/supplier/keeper/query_params_test.go
@@ -1,0 +1,21 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	testkeeper "pocket/testutil/keeper"
+	"pocket/x/supplier/types"
+)
+
+func TestParamsQuery(t *testing.T) {
+	keeper, ctx := testkeeper.SupplierKeeper(t)
+	wctx := sdk.WrapSDKContext(ctx)
+	params := types.DefaultParams()
+	keeper.SetParams(ctx, params)
+
+	response, err := keeper.Params(wctx, &types.QueryParamsRequest{})
+	require.NoError(t, err)
+	require.Equal(t, &types.QueryParamsResponse{Params: params}, response)
+}

--- a/x/supplier/module.go
+++ b/x/supplier/module.go
@@ -1,0 +1,148 @@
+package supplier
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	// this line is used by starport scaffolding # 1
+
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/spf13/cobra"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"pocket/x/supplier/client/cli"
+	"pocket/x/supplier/keeper"
+	"pocket/x/supplier/types"
+)
+
+var (
+	_ module.AppModule      = AppModule{}
+	_ module.AppModuleBasic = AppModuleBasic{}
+)
+
+// ----------------------------------------------------------------------------
+// AppModuleBasic
+// ----------------------------------------------------------------------------
+
+// AppModuleBasic implements the AppModuleBasic interface that defines the independent methods a Cosmos SDK module needs to implement.
+type AppModuleBasic struct {
+	cdc codec.BinaryCodec
+}
+
+func NewAppModuleBasic(cdc codec.BinaryCodec) AppModuleBasic {
+	return AppModuleBasic{cdc: cdc}
+}
+
+// Name returns the name of the module as a string
+func (AppModuleBasic) Name() string {
+	return types.ModuleName
+}
+
+// RegisterLegacyAminoCodec registers the amino codec for the module, which is used to marshal and unmarshal structs to/from []byte in order to persist them in the module's KVStore
+func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+	types.RegisterCodec(cdc)
+}
+
+// RegisterInterfaces registers a module's interface types and their concrete implementations as proto.Message
+func (a AppModuleBasic) RegisterInterfaces(reg cdctypes.InterfaceRegistry) {
+	types.RegisterInterfaces(reg)
+}
+
+// DefaultGenesis returns a default GenesisState for the module, marshalled to json.RawMessage. The default GenesisState need to be defined by the module developer and is primarily used for testing
+func (AppModuleBasic) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+	return cdc.MustMarshalJSON(types.DefaultGenesis())
+}
+
+// ValidateGenesis used to validate the GenesisState, given in its json.RawMessage form
+func (AppModuleBasic) ValidateGenesis(cdc codec.JSONCodec, config client.TxEncodingConfig, bz json.RawMessage) error {
+	var genState types.GenesisState
+	if err := cdc.UnmarshalJSON(bz, &genState); err != nil {
+		return fmt.Errorf("failed to unmarshal %s genesis state: %w", types.ModuleName, err)
+	}
+	return genState.Validate()
+}
+
+// RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module
+func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
+	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
+}
+
+// GetTxCmd returns the root Tx command for the module. The subcommands of this root command are used by end-users to generate new transactions containing messages defined in the module
+func (a AppModuleBasic) GetTxCmd() *cobra.Command {
+	return cli.GetTxCmd()
+}
+
+// GetQueryCmd returns the root query command for the module. The subcommands of this root command are used by end-users to generate new queries to the subset of the state defined by the module
+func (AppModuleBasic) GetQueryCmd() *cobra.Command {
+	return cli.GetQueryCmd(types.StoreKey)
+}
+
+// ----------------------------------------------------------------------------
+// AppModule
+// ----------------------------------------------------------------------------
+
+// AppModule implements the AppModule interface that defines the inter-dependent methods that modules need to implement
+type AppModule struct {
+	AppModuleBasic
+
+	keeper        keeper.Keeper
+	accountKeeper types.AccountKeeper
+	bankKeeper    types.BankKeeper
+}
+
+func NewAppModule(
+	cdc codec.Codec,
+	keeper keeper.Keeper,
+	accountKeeper types.AccountKeeper,
+	bankKeeper types.BankKeeper,
+) AppModule {
+	return AppModule{
+		AppModuleBasic: NewAppModuleBasic(cdc),
+		keeper:         keeper,
+		accountKeeper:  accountKeeper,
+		bankKeeper:     bankKeeper,
+	}
+}
+
+// RegisterServices registers a gRPC query service to respond to the module-specific gRPC queries
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
+	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+}
+
+// RegisterInvariants registers the invariants of the module. If an invariant deviates from its predicted value, the InvariantRegistry triggers appropriate logic (most often the chain will be halted)
+func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+
+// InitGenesis performs the module's genesis initialization. It returns no validator updates.
+func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) []abci.ValidatorUpdate {
+	var genState types.GenesisState
+	// Initialize global index to index in genesis state
+	cdc.MustUnmarshalJSON(gs, &genState)
+
+	InitGenesis(ctx, am.keeper, genState)
+
+	return []abci.ValidatorUpdate{}
+}
+
+// ExportGenesis returns the module's exported genesis state as raw JSON bytes.
+func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
+	genState := ExportGenesis(ctx, am.keeper)
+	return cdc.MustMarshalJSON(genState)
+}
+
+// ConsensusVersion is a sequence number for state-breaking change of the module. It should be incremented on each consensus-breaking change introduced by the module. To avoid wrong/empty versions, the initial version should be set to 1
+func (AppModule) ConsensusVersion() uint64 { return 1 }
+
+// BeginBlock contains the logic that is automatically triggered at the beginning of each block
+func (am AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
+
+// EndBlock contains the logic that is automatically triggered at the end of each block
+func (am AppModule) EndBlock(_ sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
+	return []abci.ValidatorUpdate{}
+}

--- a/x/supplier/module_simulation.go
+++ b/x/supplier/module_simulation.go
@@ -1,0 +1,64 @@
+package supplier
+
+import (
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/cosmos/cosmos-sdk/x/simulation"
+	"pocket/testutil/sample"
+	suppliersimulation "pocket/x/supplier/simulation"
+	"pocket/x/supplier/types"
+)
+
+// avoid unused import issue
+var (
+	_ = sample.AccAddress
+	_ = suppliersimulation.FindAccount
+	_ = simulation.MsgEntryKind
+	_ = baseapp.Paramspace
+	_ = rand.Rand{}
+)
+
+const (
+// this line is used by starport scaffolding # simapp/module/const
+)
+
+// GenerateGenesisState creates a randomized GenState of the module.
+func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
+	accs := make([]string, len(simState.Accounts))
+	for i, acc := range simState.Accounts {
+		accs[i] = acc.Address.String()
+	}
+	supplierGenesis := types.GenesisState{
+		Params: types.DefaultParams(),
+		// this line is used by starport scaffolding # simapp/module/genesisState
+	}
+	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&supplierGenesis)
+}
+
+// RegisterStoreDecoder registers a decoder.
+func (am AppModule) RegisterStoreDecoder(_ sdk.StoreDecoderRegistry) {}
+
+// ProposalContents doesn't return any content functions for governance proposals.
+func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedProposalContent {
+	return nil
+}
+
+// WeightedOperations returns the all the gov module operations with their respective weights.
+func (am AppModule) WeightedOperations(simState module.SimulationState) []simtypes.WeightedOperation {
+	operations := make([]simtypes.WeightedOperation, 0)
+
+	// this line is used by starport scaffolding # simapp/module/operation
+
+	return operations
+}
+
+// ProposalMsgs returns msgs used for governance proposals for simulations.
+func (am AppModule) ProposalMsgs(simState module.SimulationState) []simtypes.WeightedProposalMsg {
+	return []simtypes.WeightedProposalMsg{
+		// this line is used by starport scaffolding # simapp/module/OpMsg
+	}
+}

--- a/x/supplier/simulation/helpers.go
+++ b/x/supplier/simulation/helpers.go
@@ -1,0 +1,15 @@
+package simulation
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+)
+
+// FindAccount find a specific address from an account list
+func FindAccount(accs []simtypes.Account, address string) (simtypes.Account, bool) {
+	creator, err := sdk.AccAddressFromBech32(address)
+	if err != nil {
+		panic(err)
+	}
+	return simtypes.FindAccount(accs, creator)
+}

--- a/x/supplier/types/codec.go
+++ b/x/supplier/types/codec.go
@@ -1,0 +1,23 @@
+package types
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	// this line is used by starport scaffolding # 1
+	"github.com/cosmos/cosmos-sdk/types/msgservice"
+)
+
+func RegisterCodec(cdc *codec.LegacyAmino) {
+	// this line is used by starport scaffolding # 2
+}
+
+func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+	// this line is used by starport scaffolding # 3
+
+	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
+}
+
+var (
+	Amino     = codec.NewLegacyAmino()
+	ModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
+)

--- a/x/supplier/types/errors.go
+++ b/x/supplier/types/errors.go
@@ -1,0 +1,12 @@
+package types
+
+// DONTCOVER
+
+import (
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+// x/supplier module sentinel errors
+var (
+	ErrSample = sdkerrors.Register(ModuleName, 1100, "sample error")
+)

--- a/x/supplier/types/expected_keepers.go
+++ b/x/supplier/types/expected_keepers.go
@@ -1,0 +1,18 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+)
+
+// AccountKeeper defines the expected account keeper used for simulations (noalias)
+type AccountKeeper interface {
+	GetAccount(ctx sdk.Context, addr sdk.AccAddress) types.AccountI
+	// Methods imported from account should be defined here
+}
+
+// BankKeeper defines the expected interface needed to retrieve account balances.
+type BankKeeper interface {
+	SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
+	// Methods imported from bank should be defined here
+}

--- a/x/supplier/types/genesis.go
+++ b/x/supplier/types/genesis.go
@@ -1,0 +1,24 @@
+package types
+
+import (
+// this line is used by starport scaffolding # genesis/types/import
+)
+
+// DefaultIndex is the default global index
+const DefaultIndex uint64 = 1
+
+// DefaultGenesis returns the default genesis state
+func DefaultGenesis() *GenesisState {
+	return &GenesisState{
+		// this line is used by starport scaffolding # genesis/types/default
+		Params: DefaultParams(),
+	}
+}
+
+// Validate performs basic genesis state validation returning an error upon any
+// failure.
+func (gs GenesisState) Validate() error {
+	// this line is used by starport scaffolding # genesis/types/validate
+
+	return gs.Params.Validate()
+}

--- a/x/supplier/types/genesis_test.go
+++ b/x/supplier/types/genesis_test.go
@@ -1,0 +1,41 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"pocket/x/supplier/types"
+)
+
+func TestGenesisState_Validate(t *testing.T) {
+	tests := []struct {
+		desc     string
+		genState *types.GenesisState
+		valid    bool
+	}{
+		{
+			desc:     "default is valid",
+			genState: types.DefaultGenesis(),
+			valid:    true,
+		},
+		{
+			desc:     "valid genesis state",
+			genState: &types.GenesisState{
+
+				// this line is used by starport scaffolding # types/genesis/validField
+			},
+			valid: true,
+		},
+		// this line is used by starport scaffolding # types/genesis/testcase
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := tc.genState.Validate()
+			if tc.valid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}

--- a/x/supplier/types/keys.go
+++ b/x/supplier/types/keys.go
@@ -1,0 +1,19 @@
+package types
+
+const (
+	// ModuleName defines the module name
+	ModuleName = "supplier"
+
+	// StoreKey defines the primary module store key
+	StoreKey = ModuleName
+
+	// RouterKey defines the module's message routing key
+	RouterKey = ModuleName
+
+	// MemStoreKey defines the in-memory store key
+	MemStoreKey = "mem_supplier"
+)
+
+func KeyPrefix(p string) []byte {
+	return []byte(p)
+}

--- a/x/supplier/types/params.go
+++ b/x/supplier/types/params.go
@@ -1,0 +1,39 @@
+package types
+
+import (
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	"gopkg.in/yaml.v2"
+)
+
+var _ paramtypes.ParamSet = (*Params)(nil)
+
+// ParamKeyTable the param key table for launch module
+func ParamKeyTable() paramtypes.KeyTable {
+	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
+}
+
+// NewParams creates a new Params instance
+func NewParams() Params {
+	return Params{}
+}
+
+// DefaultParams returns a default set of parameters
+func DefaultParams() Params {
+	return NewParams()
+}
+
+// ParamSetPairs get the params.ParamSet
+func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
+	return paramtypes.ParamSetPairs{}
+}
+
+// Validate validates the set of params
+func (p Params) Validate() error {
+	return nil
+}
+
+// String implements the Stringer interface.
+func (p Params) String() string {
+	out, _ := yaml.Marshal(p)
+	return string(out)
+}

--- a/x/supplier/types/types.go
+++ b/x/supplier/types/types.go
@@ -1,0 +1,1 @@
+package types


### PR DESCRIPTION
## Summary

Ran the following command:

```
ignite scaffold module supplier --dep bank
```

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Oct 23 17:38 UTC
This pull request introduces several changes across multiple files:

1. In the file "msg_server.go":
   - A new file "msg_server.go" has been added to the "x/supplier/keeper/" directory.
   - The file includes a new package declaration for "keeper".
   - An import statement has been added for the "types" package in "pocket/x/supplier".
   - A new type "msgServer" has been defined, which embeds the "Keeper" struct.
   - The function "NewMsgServerImpl" has been defined, which takes a "Keeper" parameter and returns an implementation of the "MsgServer" interface.
   - The implementation of "NewMsgServerImpl" returns an instance of the "msgServer" struct with the "Keeper" field set to the provided keeper.
   - The "msgServer" struct has been marked as implementing the "MsgServer" interface defined in the "types" package.

2. In the file "query.go":
   - A new file named `query.go` has been added to the `x/supplier/keeper` package.
   - It includes a package declaration, an import statement, and a variable declaration.
   - The variable `Keeper` is assigned as the implementation of the `QueryServer` interface defined in the `types` package.

3. In the file "genesis.go":
   - The file `genesis.go` has been added with the following changes:
   - Imports have been added.
   - A constant `DefaultIndex` has been declared.
   - The function `DefaultGenesis` has been implemented, which returns the default genesis state.
   - The function `Validate` has been implemented to perform basic genesis state validation.

4. In the file `x/supplier/types/expected_keepers.go`:
   - The diff of the file `x/supplier/types/expected_keepers.go` includes the addition of two interface definitions: `AccountKeeper` and `BankKeeper`.
   - These interfaces have methods that are expected to be implemented for simulations related to accounts and account balances respectively.
   - The methods imported from `x/auth/types` and `github.com/cosmos/cosmos-sdk/x/auth` should be defined in the `AccountKeeper` interface.
   - The methods imported from `github.com/cosmos/cosmos-sdk/types` and `github.com/cosmos/cosmos-sdk/x/bank` should be defined in the `BankKeeper` interface.

5. In the file `x/supplier/module_simulation.go`:
   - This file diff includes several changes related to the addition of a new module called "supplier".
   - Various changes have been made, including imports, definition of module components, and integration into the existing application.

6. In the file `testutil/keeper/supplier.go`:
   - This file diff introduces a new file called `supplier.go` in the `testutil/keeper` package.
   - It contains a function `SupplierKeeper` that returns an instance of `keeper.Keeper` and an instance of `sdk.Context`.

7. In the file `x/supplier/types/keys.go`:
   - Summary of changes in `x/supplier/types/keys.go` includes the addition of a new file `keys.go` in the `x/supplier/types` directory.
   - A function `KeyPrefix` is defined that takes a string parameter `p` and returns a byte slice.

8. In the file `x/supplier/module_simulation.go`:
   - The file `x/supplier/module_simulation.go` is a new file that has been added.
   - It contains implementations related to the simulation of the `supplier` module.

9. In the file `x/supplier/client/cli/query_params.go`:
   - This is a new file called `query_params.go` in the `x/supplier/client/cli` package.
   - It contains a command function called `CmdQueryParams` that sets up a Cobra command to query the parameters of the module.

10. In the file `x/supplier/client/cli/tx.go`:
    - This file, `tx.go`, is a new file that has been added to the `x/supplier/client/cli` package.
    - It contains the implementation of transaction commands for the `supplier` module.

11. In the file `keeper.go`:
    - The diff of the file `keeper.go` includes the addition of a new file "keeper.go" and several changes.

12. In the file `app.go`:
    - Summary: This file contains the code related to the genesis state initialization and exporting in the `supplier` module.

13. In the file `tx.proto`:
    - Summary: This diff introduces a new file called `tx.proto` in the `proto/pocket/supplier` directory.

14. In the file `x/supplier/module.go`:
    - Summary: This file diff introduces a new module called "supplier" in the "x/supplier" package.

15. In the file `openapi.yml`:
    - The file `openapi.yml` has changes related to the addition of a new path `/pocket/supplier/params` in the API specification.

16. In the file `genesis.proto`:
    - This is a diff for a new file called `genesis.proto` that
<!-- reviewpad:summarize:end -->

## Issue

Part of #7

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make test_all_unit`
- [x] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
