### PR TITLE
[Supplier] Scaffolded the Supplier type (without CRUD messages) and nothing else

### DIFF
--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -46581,6 +46581,167 @@ paths:
                   additionalProperties: {}
       tags:
         - Query
+  /pocket/supplier/supplier:
+    get:
+      operationId: PocketSupplierSupplierAll
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              supplier:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    address:
+                      type: string
+              pagination:
+                type: object
+                properties:
+                  next_key:
+                    type: string
+                    format: byte
+                    description: |-
+                      next_key is the key to be passed to PageRequest.key to
+                      query the next page most efficiently. It will be empty if
+                      there are no more results.
+                  total:
+                    type: string
+                    format: uint64
+                    title: >-
+                      total is total number of results available if
+                      PageRequest.count_total
+
+                      was set, its value is undefined otherwise
+                description: >-
+                  PageResponse is to be embedded in gRPC response messages where
+                  the
+
+                  corresponding request message has used PageRequest.
+
+                   message SomeResponse {
+                           repeated Bar results = 1;
+                           PageResponse page = 2;
+                   }
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    '@type':
+                      type: string
+                  additionalProperties: {}
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /pocket/supplier/supplier/{address}:
+    get:
+      summary: Queries a list of Supplier items.
+      operationId: PocketSupplierSupplier
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              supplier:
+                type: object
+                properties:
+                  address:
+                    type: string
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    '@type':
+                      type: string
+                  additionalProperties: {}
+      parameters:
+        - name: address
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
 definitions:
   cosmos.auth.v1beta1.AddressBytesToStringResponse:
     type: object
@@ -75353,6 +75514,50 @@ definitions:
   pocket.supplier.Params:
     type: object
     description: Params defines the parameters for the module.
+  pocket.supplier.QueryAllSupplierResponse:
+    type: object
+    properties:
+      supplier:
+        type: array
+        items:
+          type: object
+          properties:
+            address:
+              type: string
+      pagination:
+        type: object
+        properties:
+          next_key:
+            type: string
+            format: byte
+            description: |-
+              next_key is the key to be passed to PageRequest.key to
+              query the next page most efficiently. It will be empty if
+              there are no more results.
+          total:
+            type: string
+            format: uint64
+            title: >-
+              total is total number of results available if
+              PageRequest.count_total
+
+              was set, its value is undefined otherwise
+        description: |-
+          PageResponse is to be embedded in gRPC response messages where the
+          corresponding request message has used PageRequest.
+
+           message SomeResponse {
+                   repeated Bar results = 1;
+                   PageResponse page = 2;
+           }
+  pocket.supplier.QueryGetSupplierResponse:
+    type: object
+    properties:
+      supplier:
+        type: object
+        properties:
+          address:
+            type: string
   pocket.supplier.QueryParamsResponse:
     type: object
     properties:
@@ -75360,3 +75565,8 @@ definitions:
         description: params holds all the parameters of this module.
         type: object
     description: QueryParamsResponse is response type for the Query/Params RPC method.
+  pocket.supplier.Supplier:
+    type: object
+    properties:
+      address:
+        type: string

--- a/proto/pocket/supplier/genesis.proto
+++ b/proto/pocket/supplier/genesis.proto
@@ -1,12 +1,16 @@
 syntax = "proto3";
+
 package pocket.supplier;
 
 import "gogoproto/gogo.proto";
 import "pocket/supplier/params.proto";
+import "pocket/supplier/supplier.proto";
 
 option go_package = "pocket/x/supplier/types";
 
 // GenesisState defines the supplier module's genesis state.
 message GenesisState {
-  Params params = 1 [(gogoproto.nullable) = false];
+           Params   params       = 1 [(gogoproto.nullable) = false];
+  repeated Supplier supplierList = 2 [(gogoproto.nullable) = false];
 }
+

--- a/proto/pocket/supplier/query.proto
+++ b/proto/pocket/supplier/query.proto
@@ -1,26 +1,58 @@
 syntax = "proto3";
+
 package pocket.supplier;
 
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 import "pocket/supplier/params.proto";
+import "pocket/supplier/supplier.proto";
 
 option go_package = "pocket/x/supplier/types";
 
 // Query defines the gRPC querier service.
 service Query {
+  
   // Parameters queries the parameters of the module.
-  rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
+  rpc Params (QueryParamsRequest) returns (QueryParamsResponse) {
     option (google.api.http).get = "/pocket/supplier/params";
+  
+  }
+  
+  // Queries a list of Supplier items.
+  rpc Supplier    (QueryGetSupplierRequest) returns (QueryGetSupplierResponse) {
+    option (google.api.http).get = "/pocket/supplier/supplier/{address}";
+  
+  }
+  rpc SupplierAll (QueryAllSupplierRequest) returns (QueryAllSupplierResponse) {
+    option (google.api.http).get = "/pocket/supplier/supplier";
+  
   }
 }
-
 // QueryParamsRequest is request type for the Query/Params RPC method.
 message QueryParamsRequest {}
 
 // QueryParamsResponse is response type for the Query/Params RPC method.
 message QueryParamsResponse {
+  
   // params holds all the parameters of this module.
   Params params = 1 [(gogoproto.nullable) = false];
 }
+
+message QueryGetSupplierRequest {
+  string address = 1;
+}
+
+message QueryGetSupplierResponse {
+  Supplier supplier = 1 [(gogoproto.nullable) = false];
+}
+
+message QueryAllSupplierRequest {
+  cosmos.base.query.v1beta1.PageRequest pagination = 1;
+}
+
+message QueryAllSupplierResponse {
+  repeated Supplier                               supplier   = 1 [(gogoproto.nullable) = false];
+           cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+

--- a/proto/pocket/supplier/supplier.proto
+++ b/proto/pocket/supplier/supplier.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package pocket.supplier;
+
+option go_package = "pocket/x/supplier/types";
+
+message Supplier {
+  string address = 1; 
+  
+}
+

--- a/x/supplier/client/cli/query.go
+++ b/x/supplier/client/cli/query.go
@@ -25,6 +25,8 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 	}
 
 	cmd.AddCommand(CmdQueryParams())
+	cmd.AddCommand(CmdListSupplier())
+	cmd.AddCommand(CmdShowSupplier())
 	// this line is used by starport scaffolding # 1
 
 	return cmd

--- a/x/supplier/client/cli/query_supplier.go
+++ b/x/supplier/client/cli/query_supplier.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+
+	"pocket/x/supplier/types"
+)
+
+func CmdListSupplier() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list-supplier",
+		Short: "list all supplier",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryAllSupplierRequest{
+				Pagination: pageReq,
+			}
+
+			res, err := queryClient.SupplierAll(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddPaginationFlagsToCmd(cmd, cmd.Use)
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdShowSupplier() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show-supplier [address]",
+		Short: "shows a supplier",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			argAddress := args[0]
+
+			params := &types.QueryGetSupplierRequest{
+				Address: argAddress,
+			}
+
+			res, err := queryClient.Supplier(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/supplier/client/cli/query_supplier_test.go
+++ b/x/supplier/client/cli/query_supplier_test.go
@@ -1,0 +1,160 @@
+package cli_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	tmcli "github.com/cometbft/cometbft/libs/cli"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"pocket/testutil/network"
+	"pocket/testutil/nullify"
+	"pocket/x/supplier/client/cli"
+	"pocket/x/supplier/types"
+)
+
+// Prevent strconv unused error
+var _ = strconv.IntSize
+
+func networkWithSupplierObjects(t *testing.T, n int) (*network.Network, []types.Supplier) {
+	t.Helper()
+	cfg := network.DefaultConfig()
+	state := types.GenesisState{}
+	for i := 0; i < n; i++ {
+		supplier := types.Supplier{
+			Address: strconv.Itoa(i),
+		}
+		nullify.Fill(&supplier)
+		state.SupplierList = append(state.SupplierList, supplier)
+	}
+	buf, err := cfg.Codec.MarshalJSON(&state)
+	require.NoError(t, err)
+	cfg.GenesisState[types.ModuleName] = buf
+	return network.New(t, cfg), state.SupplierList
+}
+
+func TestShowSupplier(t *testing.T) {
+	net, objs := networkWithSupplierObjects(t, 2)
+
+	ctx := net.Validators[0].ClientCtx
+	common := []string{
+		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+	}
+	tests := []struct {
+		desc      string
+		idAddress string
+
+		args []string
+		err  error
+		obj  types.Supplier
+	}{
+		{
+			desc:      "found",
+			idAddress: objs[0].Address,
+
+			args: common,
+			obj:  objs[0],
+		},
+		{
+			desc:      "not found",
+			idAddress: strconv.Itoa(100000),
+
+			args: common,
+			err:  status.Error(codes.NotFound, "not found"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			args := []string{
+				tc.idAddress,
+			}
+			args = append(args, tc.args...)
+			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowSupplier(), args)
+			if tc.err != nil {
+				stat, ok := status.FromError(tc.err)
+				require.True(t, ok)
+				require.ErrorIs(t, stat.Err(), tc.err)
+			} else {
+				require.NoError(t, err)
+				var resp types.QueryGetSupplierResponse
+				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+				require.NotNil(t, resp.Supplier)
+				require.Equal(t,
+					nullify.Fill(&tc.obj),
+					nullify.Fill(&resp.Supplier),
+				)
+			}
+		})
+	}
+}
+
+func TestListSupplier(t *testing.T) {
+	net, objs := networkWithSupplierObjects(t, 5)
+
+	ctx := net.Validators[0].ClientCtx
+	request := func(next []byte, offset, limit uint64, total bool) []string {
+		args := []string{
+			fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+		}
+		if next == nil {
+			args = append(args, fmt.Sprintf("--%s=%d", flags.FlagOffset, offset))
+		} else {
+			args = append(args, fmt.Sprintf("--%s=%s", flags.FlagPageKey, next))
+		}
+		args = append(args, fmt.Sprintf("--%s=%d", flags.FlagLimit, limit))
+		if total {
+			args = append(args, fmt.Sprintf("--%s", flags.FlagCountTotal))
+		}
+		return args
+	}
+	t.Run("ByOffset", func(t *testing.T) {
+		step := 2
+		for i := 0; i < len(objs); i += step {
+			args := request(nil, uint64(i), uint64(step), false)
+			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListSupplier(), args)
+			require.NoError(t, err)
+			var resp types.QueryAllSupplierResponse
+			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.LessOrEqual(t, len(resp.Supplier), step)
+			require.Subset(t,
+				nullify.Fill(objs),
+				nullify.Fill(resp.Supplier),
+			)
+		}
+	})
+	t.Run("ByKey", func(t *testing.T) {
+		step := 2
+		var next []byte
+		for i := 0; i < len(objs); i += step {
+			args := request(next, 0, uint64(step), false)
+			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListSupplier(), args)
+			require.NoError(t, err)
+			var resp types.QueryAllSupplierResponse
+			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.LessOrEqual(t, len(resp.Supplier), step)
+			require.Subset(t,
+				nullify.Fill(objs),
+				nullify.Fill(resp.Supplier),
+			)
+			next = resp.Pagination.NextKey
+		}
+	})
+	t.Run("Total", func(t *testing.T) {
+		args := request(nil, 0, uint64(len(objs)), true)
+		out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListSupplier(), args)
+		require.NoError(t, err)
+		var resp types.QueryAllSupplierResponse
+		require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+		require.NoError(t, err)
+		require.Equal(t, len(objs), int(resp.Pagination.Total))
+		require.ElementsMatch(t,
+			nullify.Fill(objs),
+			nullify.Fill(resp.Supplier),
+		)
+	})
+}

--- a/x/supplier/genesis.go
+++ b/x/supplier/genesis.go
@@ -8,6 +8,10 @@ import (
 
 // InitGenesis initializes the module's state from a provided genesis state.
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
+	// Set all the supplier
+	for _, elem := range genState.SupplierList {
+		k.SetSupplier(ctx, elem)
+	}
 	// this line is used by starport scaffolding # genesis/module/init
 	k.SetParams(ctx, genState.Params)
 }
@@ -17,6 +21,7 @@ func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
 	genesis.Params = k.GetParams(ctx)
 
+	genesis.SupplierList = k.GetAllSupplier(ctx)
 	// this line is used by starport scaffolding # genesis/module/export
 
 	return genesis

--- a/x/supplier/genesis_test.go
+++ b/x/supplier/genesis_test.go
@@ -14,6 +14,14 @@ func TestGenesis(t *testing.T) {
 	genesisState := types.GenesisState{
 		Params: types.DefaultParams(),
 
+		SupplierList: []types.Supplier{
+			{
+				Address: "0",
+			},
+			{
+				Address: "1",
+			},
+		},
 		// this line is used by starport scaffolding # genesis/test/state
 	}
 
@@ -25,5 +33,6 @@ func TestGenesis(t *testing.T) {
 	nullify.Fill(&genesisState)
 	nullify.Fill(got)
 
+	require.ElementsMatch(t, genesisState.SupplierList, got.SupplierList)
 	// this line is used by starport scaffolding # genesis/test/assert
 }

--- a/x/supplier/keeper/query_supplier.go
+++ b/x/supplier/keeper/query_supplier.go
@@ -1,0 +1,57 @@
+package keeper
+
+import (
+	"context"
+
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"pocket/x/supplier/types"
+)
+
+func (k Keeper) SupplierAll(goCtx context.Context, req *types.QueryAllSupplierRequest) (*types.QueryAllSupplierResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
+	var suppliers []types.Supplier
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	store := ctx.KVStore(k.storeKey)
+	supplierStore := prefix.NewStore(store, types.KeyPrefix(types.SupplierKeyPrefix))
+
+	pageRes, err := query.Paginate(supplierStore, req.Pagination, func(key []byte, value []byte) error {
+		var supplier types.Supplier
+		if err := k.cdc.Unmarshal(value, &supplier); err != nil {
+			return err
+		}
+
+		suppliers = append(suppliers, supplier)
+		return nil
+	})
+
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &types.QueryAllSupplierResponse{Supplier: suppliers, Pagination: pageRes}, nil
+}
+
+func (k Keeper) Supplier(goCtx context.Context, req *types.QueryGetSupplierRequest) (*types.QueryGetSupplierResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	val, found := k.GetSupplier(
+		ctx,
+		req.Address,
+	)
+	if !found {
+		return nil, status.Error(codes.NotFound, "not found")
+	}
+
+	return &types.QueryGetSupplierResponse{Supplier: val}, nil
+}

--- a/x/supplier/keeper/query_supplier_test.go
+++ b/x/supplier/keeper/query_supplier_test.go
@@ -1,0 +1,127 @@
+package keeper_test
+
+import (
+	"strconv"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	keepertest "pocket/testutil/keeper"
+	"pocket/testutil/nullify"
+	"pocket/x/supplier/types"
+)
+
+// Prevent strconv unused error
+var _ = strconv.IntSize
+
+func TestSupplierQuerySingle(t *testing.T) {
+	keeper, ctx := keepertest.SupplierKeeper(t)
+	wctx := sdk.WrapSDKContext(ctx)
+	msgs := createNSupplier(keeper, ctx, 2)
+	tests := []struct {
+		desc     string
+		request  *types.QueryGetSupplierRequest
+		response *types.QueryGetSupplierResponse
+		err      error
+	}{
+		{
+			desc: "First",
+			request: &types.QueryGetSupplierRequest{
+				Address: msgs[0].Address,
+			},
+			response: &types.QueryGetSupplierResponse{Supplier: msgs[0]},
+		},
+		{
+			desc: "Second",
+			request: &types.QueryGetSupplierRequest{
+				Address: msgs[1].Address,
+			},
+			response: &types.QueryGetSupplierResponse{Supplier: msgs[1]},
+		},
+		{
+			desc: "KeyNotFound",
+			request: &types.QueryGetSupplierRequest{
+				Address: strconv.Itoa(100000),
+			},
+			err: status.Error(codes.NotFound, "not found"),
+		},
+		{
+			desc: "InvalidRequest",
+			err:  status.Error(codes.InvalidArgument, "invalid request"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			response, err := keeper.Supplier(wctx, tc.request)
+			if tc.err != nil {
+				require.ErrorIs(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t,
+					nullify.Fill(tc.response),
+					nullify.Fill(response),
+				)
+			}
+		})
+	}
+}
+
+func TestSupplierQueryPaginated(t *testing.T) {
+	keeper, ctx := keepertest.SupplierKeeper(t)
+	wctx := sdk.WrapSDKContext(ctx)
+	msgs := createNSupplier(keeper, ctx, 5)
+
+	request := func(next []byte, offset, limit uint64, total bool) *types.QueryAllSupplierRequest {
+		return &types.QueryAllSupplierRequest{
+			Pagination: &query.PageRequest{
+				Key:        next,
+				Offset:     offset,
+				Limit:      limit,
+				CountTotal: total,
+			},
+		}
+	}
+	t.Run("ByOffset", func(t *testing.T) {
+		step := 2
+		for i := 0; i < len(msgs); i += step {
+			resp, err := keeper.SupplierAll(wctx, request(nil, uint64(i), uint64(step), false))
+			require.NoError(t, err)
+			require.LessOrEqual(t, len(resp.Supplier), step)
+			require.Subset(t,
+				nullify.Fill(msgs),
+				nullify.Fill(resp.Supplier),
+			)
+		}
+	})
+	t.Run("ByKey", func(t *testing.T) {
+		step := 2
+		var next []byte
+		for i := 0; i < len(msgs); i += step {
+			resp, err := keeper.SupplierAll(wctx, request(next, 0, uint64(step), false))
+			require.NoError(t, err)
+			require.LessOrEqual(t, len(resp.Supplier), step)
+			require.Subset(t,
+				nullify.Fill(msgs),
+				nullify.Fill(resp.Supplier),
+			)
+			next = resp.Pagination.NextKey
+		}
+	})
+	t.Run("Total", func(t *testing.T) {
+		resp, err := keeper.SupplierAll(wctx, request(nil, 0, 0, true))
+		require.NoError(t, err)
+		require.Equal(t, len(msgs), int(resp.Pagination.Total))
+		require.ElementsMatch(t,
+			nullify.Fill(msgs),
+			nullify.Fill(resp.Supplier),
+		)
+	})
+	t.Run("InvalidRequest", func(t *testing.T) {
+		_, err := keeper.SupplierAll(wctx, nil)
+		require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "invalid request"))
+	})
+}

--- a/x/supplier/keeper/supplier.go
+++ b/x/supplier/keeper/supplier.go
@@ -1,0 +1,63 @@
+package keeper
+
+import (
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"pocket/x/supplier/types"
+)
+
+// SetSupplier set a specific supplier in the store from its index
+func (k Keeper) SetSupplier(ctx sdk.Context, supplier types.Supplier) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.SupplierKeyPrefix))
+	b := k.cdc.MustMarshal(&supplier)
+	store.Set(types.SupplierKey(
+		supplier.Address,
+	), b)
+}
+
+// GetSupplier returns a supplier from its index
+func (k Keeper) GetSupplier(
+	ctx sdk.Context,
+	address string,
+
+) (val types.Supplier, found bool) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.SupplierKeyPrefix))
+
+	b := store.Get(types.SupplierKey(
+		address,
+	))
+	if b == nil {
+		return val, false
+	}
+
+	k.cdc.MustUnmarshal(b, &val)
+	return val, true
+}
+
+// RemoveSupplier removes a supplier from the store
+func (k Keeper) RemoveSupplier(
+	ctx sdk.Context,
+	address string,
+
+) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.SupplierKeyPrefix))
+	store.Delete(types.SupplierKey(
+		address,
+	))
+}
+
+// GetAllSupplier returns all supplier
+func (k Keeper) GetAllSupplier(ctx sdk.Context) (list []types.Supplier) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.SupplierKeyPrefix))
+	iterator := sdk.KVStorePrefixIterator(store, []byte{})
+
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		var val types.Supplier
+		k.cdc.MustUnmarshal(iterator.Value(), &val)
+		list = append(list, val)
+	}
+
+	return
+}

--- a/x/supplier/keeper/supplier_test.go
+++ b/x/supplier/keeper/supplier_test.go
@@ -1,0 +1,63 @@
+package keeper_test
+
+import (
+	"strconv"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	keepertest "pocket/testutil/keeper"
+	"pocket/testutil/nullify"
+	"pocket/x/supplier/keeper"
+	"pocket/x/supplier/types"
+)
+
+// Prevent strconv unused error
+var _ = strconv.IntSize
+
+func createNSupplier(keeper *keeper.Keeper, ctx sdk.Context, n int) []types.Supplier {
+	items := make([]types.Supplier, n)
+	for i := range items {
+		items[i].Address = strconv.Itoa(i)
+
+		keeper.SetSupplier(ctx, items[i])
+	}
+	return items
+}
+
+func TestSupplierGet(t *testing.T) {
+	keeper, ctx := keepertest.SupplierKeeper(t)
+	items := createNSupplier(keeper, ctx, 10)
+	for _, item := range items {
+		rst, found := keeper.GetSupplier(ctx,
+			item.Address,
+		)
+		require.True(t, found)
+		require.Equal(t,
+			nullify.Fill(&item),
+			nullify.Fill(&rst),
+		)
+	}
+}
+func TestSupplierRemove(t *testing.T) {
+	keeper, ctx := keepertest.SupplierKeeper(t)
+	items := createNSupplier(keeper, ctx, 10)
+	for _, item := range items {
+		keeper.RemoveSupplier(ctx,
+			item.Address,
+		)
+		_, found := keeper.GetSupplier(ctx,
+			item.Address,
+		)
+		require.False(t, found)
+	}
+}
+
+func TestSupplierGetAll(t *testing.T) {
+	keeper, ctx := keepertest.SupplierKeeper(t)
+	items := createNSupplier(keeper, ctx, 10)
+	require.ElementsMatch(t,
+		nullify.Fill(items),
+		nullify.Fill(keeper.GetAllSupplier(ctx)),
+	)
+}

--- a/x/supplier/types/genesis.go
+++ b/x/supplier/types/genesis.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-// this line is used by starport scaffolding # genesis/types/import
+	"fmt"
 )
 
 // DefaultIndex is the default global index
@@ -10,6 +10,7 @@ const DefaultIndex uint64 = 1
 // DefaultGenesis returns the default genesis state
 func DefaultGenesis() *GenesisState {
 	return &GenesisState{
+		SupplierList: []Supplier{},
 		// this line is used by starport scaffolding # genesis/types/default
 		Params: DefaultParams(),
 	}
@@ -18,6 +19,16 @@ func DefaultGenesis() *GenesisState {
 // Validate performs basic genesis state validation returning an error upon any
 // failure.
 func (gs GenesisState) Validate() error {
+	// Check for duplicated index in supplier
+	supplierIndexMap := make(map[string]struct{})
+
+	for _, elem := range gs.SupplierList {
+		index := string(SupplierKey(elem.Address))
+		if _, ok := supplierIndexMap[index]; ok {
+			return fmt.Errorf("duplicated index for supplier")
+		}
+		supplierIndexMap[index] = struct{}{}
+	}
 	// this line is used by starport scaffolding # genesis/types/validate
 
 	return gs.Params.Validate()

--- a/x/supplier/types/genesis_test.go
+++ b/x/supplier/types/genesis_test.go
@@ -19,12 +19,34 @@ func TestGenesisState_Validate(t *testing.T) {
 			valid:    true,
 		},
 		{
-			desc:     "valid genesis state",
+			desc: "valid genesis state",
 			genState: &types.GenesisState{
 
+				SupplierList: []types.Supplier{
+					{
+						Address: "0",
+					},
+					{
+						Address: "1",
+					},
+				},
 				// this line is used by starport scaffolding # types/genesis/validField
 			},
 			valid: true,
+		},
+		{
+			desc: "duplicated supplier",
+			genState: &types.GenesisState{
+				SupplierList: []types.Supplier{
+					{
+						Address: "0",
+					},
+					{
+						Address: "0",
+					},
+				},
+			},
+			valid: false,
 		},
 		// this line is used by starport scaffolding # types/genesis/testcase
 	}

--- a/x/supplier/types/key_supplier.go
+++ b/x/supplier/types/key_supplier.go
@@ -1,0 +1,23 @@
+package types
+
+import "encoding/binary"
+
+var _ binary.ByteOrder
+
+const (
+	// SupplierKeyPrefix is the prefix to retrieve all Supplier
+	SupplierKeyPrefix = "Supplier/value/"
+)
+
+// SupplierKey returns the store key to retrieve a Supplier from the index fields
+func SupplierKey(
+	address string,
+) []byte {
+	var key []byte
+
+	addressBytes := []byte(address)
+	key = append(key, addressBytes...)
+	key = append(key, []byte("/")...)
+
+	return key
+}


### PR DESCRIPTION
## Summary

Simply ran the following command:

```
ignite scaffold map supplier --module supplier --signer address --no-message --index address --yes
```

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Oct 23 20:16 UTC
This pull request includes the following changes:

1. The file `x/supplier/keeper/supplier_test.go` is a new file with 63 lines of code, containing test suites for the `x/supplier/keeper` package and test functions for `GetSupplier`, `RemoveSupplier`, and `GetAllSupplier` functions.
2. The file `x/supplier/types/genesis_test.go` includes changes related to a valid genesis state with two suppliers in the `SupplierList` and a testcase for duplicated suppliers in the `SupplierList`.
3. The diff includes the addition of two new test files, `query_supplier_test.go` and `list_supplier_test.go`, which contain test cases for the `ShowSupplier` and `ListSupplier` functions.
4. A new file, "key_supplier.go", has been added under the `x/supplier/types` package, providing functionality for handling store keys for the `Supplier` type.
5. Changes in the file `genesis_test.go` are related to the `SupplierList` field in the `GenesisState` struct and testing the `Genesis` function in the `supplier` module.
6. Modifications in the file `query_supplier_test.go` in the `x/supplier/keeper` directory include importing packages, adding test functions for querying a single supplier address and paginated supplier querying.
7. The diff includes changes to the file `supplier.proto` with added import statements and new message definitions for querying suppliers.
8. The file `query_supplier.go` has been added, containing methods for querying and displaying suppliers.
9. The file `genesis.proto` has undergone changes related to import statements and the `GenesisState` message.
10. The file `genesis.go` has changes in the `InitGenesis` and `ExportGenesis` functions, updating the `SupplierList` from the `genState` and exporting the list to `genesis.SupplierList`.
11. Changes in the file `supplier.proto` include the addition of a new protobuf definition for `Supplier` and specifying the Go import path.
12. The file `query_supplier.go` has been added, with methods for retrieving all suppliers and a specific supplier by address.
13. The file `supplier.go` has been added, containing functions for setting, getting, removing, and retrieving all suppliers in the `x/supplier/keeper` package.
14. Changes in the file `types/genesis.go` include adding a new import, initializing the `SupplierList` with an empty slice, and adding validation for duplicated indexes.
15. The file diff includes changes related to adding new endpoints and definitions for the supplier-related functionalities in the Pocket API.
16. Two new commands, `CmdListSupplier()` and `CmdShowSupplier()`, have been added to the existing query command in the supplier client CLI application.

Let me know if you need more details or specific file diffs to review.
<!-- reviewpad:summarize:end -->

## Issue

Part of #7

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make test_all_unit`
- [x] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
