### PR TITLE
[Supplier] Scaffolded the StakeSupplier message and nothing else

### DIFF
--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -75350,6 +75350,8 @@ definitions:
         description: params holds all the parameters of this module.
         type: object
     description: QueryParamsResponse is response type for the Query/Params RPC method.
+  pocket.supplier.MsgStakeSupplierResponse:
+    type: object
   pocket.supplier.Params:
     type: object
     description: Params defines the parameters for the module.

--- a/proto/pocket/supplier/tx.proto
+++ b/proto/pocket/supplier/tx.proto
@@ -1,7 +1,16 @@
 syntax = "proto3";
+
 package pocket.supplier;
 
 option go_package = "pocket/x/supplier/types";
 
 // Msg defines the Msg service.
-service Msg {}
+service Msg {
+  rpc StakeSupplier (MsgStakeSupplier) returns (MsgStakeSupplierResponse);
+}
+message MsgStakeSupplier {
+  string address = 1;
+}
+
+message MsgStakeSupplierResponse {}
+

--- a/x/supplier/client/cli/tx.go
+++ b/x/supplier/client/cli/tx.go
@@ -30,6 +30,7 @@ func GetTxCmd() *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
+	cmd.AddCommand(CmdStakeSupplier())
 	// this line is used by starport scaffolding # 1
 
 	return cmd

--- a/x/supplier/client/cli/tx_stake_supplier.go
+++ b/x/supplier/client/cli/tx_stake_supplier.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/spf13/cobra"
+	"pocket/x/supplier/types"
+)
+
+var _ = strconv.Itoa(0)
+
+func CmdStakeSupplier() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stake-supplier",
+		Short: "Broadcast message stake-supplier",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgStakeSupplier(
+				clientCtx.GetFromAddress().String(),
+			)
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/supplier/keeper/msg_server_stake_supplier.go
+++ b/x/supplier/keeper/msg_server_stake_supplier.go
@@ -1,0 +1,17 @@
+package keeper
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"pocket/x/supplier/types"
+)
+
+func (k msgServer) StakeSupplier(goCtx context.Context, msg *types.MsgStakeSupplier) (*types.MsgStakeSupplierResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	// TODO: Handling the message
+	_ = ctx
+
+	return &types.MsgStakeSupplierResponse{}, nil
+}

--- a/x/supplier/module_simulation.go
+++ b/x/supplier/module_simulation.go
@@ -23,7 +23,11 @@ var (
 )
 
 const (
-// this line is used by starport scaffolding # simapp/module/const
+	opWeightMsgStakeSupplier = "op_weight_msg_stake_supplier"
+	// TODO: Determine the simulation weight value
+	defaultWeightMsgStakeSupplier int = 100
+
+	// this line is used by starport scaffolding # simapp/module/const
 )
 
 // GenerateGenesisState creates a randomized GenState of the module.
@@ -51,6 +55,17 @@ func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedP
 func (am AppModule) WeightedOperations(simState module.SimulationState) []simtypes.WeightedOperation {
 	operations := make([]simtypes.WeightedOperation, 0)
 
+	var weightMsgStakeSupplier int
+	simState.AppParams.GetOrGenerate(simState.Cdc, opWeightMsgStakeSupplier, &weightMsgStakeSupplier, nil,
+		func(_ *rand.Rand) {
+			weightMsgStakeSupplier = defaultWeightMsgStakeSupplier
+		},
+	)
+	operations = append(operations, simulation.NewWeightedOperation(
+		weightMsgStakeSupplier,
+		suppliersimulation.SimulateMsgStakeSupplier(am.accountKeeper, am.bankKeeper, am.keeper),
+	))
+
 	// this line is used by starport scaffolding # simapp/module/operation
 
 	return operations
@@ -59,6 +74,14 @@ func (am AppModule) WeightedOperations(simState module.SimulationState) []simtyp
 // ProposalMsgs returns msgs used for governance proposals for simulations.
 func (am AppModule) ProposalMsgs(simState module.SimulationState) []simtypes.WeightedProposalMsg {
 	return []simtypes.WeightedProposalMsg{
+		simulation.NewWeightedProposalMsg(
+			opWeightMsgStakeSupplier,
+			defaultWeightMsgStakeSupplier,
+			func(r *rand.Rand, ctx sdk.Context, accs []simtypes.Account) sdk.Msg {
+				suppliersimulation.SimulateMsgStakeSupplier(am.accountKeeper, am.bankKeeper, am.keeper)
+				return nil
+			},
+		),
 		// this line is used by starport scaffolding # simapp/module/OpMsg
 	}
 }

--- a/x/supplier/simulation/stake_supplier.go
+++ b/x/supplier/simulation/stake_supplier.go
@@ -1,0 +1,29 @@
+package simulation
+
+import (
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"pocket/x/supplier/keeper"
+	"pocket/x/supplier/types"
+)
+
+func SimulateMsgStakeSupplier(
+	ak types.AccountKeeper,
+	bk types.BankKeeper,
+	k keeper.Keeper,
+) simtypes.Operation {
+	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		simAccount, _ := simtypes.RandomAcc(r, accs)
+		msg := &types.MsgStakeSupplier{
+			Address: simAccount.Address.String(),
+		}
+
+		// TODO: Handling the StakeSupplier simulation
+
+		return simtypes.NoOpMsg(types.ModuleName, msg.Type(), "StakeSupplier simulation not implemented"), nil, nil
+	}
+}

--- a/x/supplier/types/codec.go
+++ b/x/supplier/types/codec.go
@@ -3,15 +3,19 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
-	// this line is used by starport scaffolding # 1
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
+	cdc.RegisterConcrete(&MsgStakeSupplier{}, "supplier/StakeSupplier", nil)
 	// this line is used by starport scaffolding # 2
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgStakeSupplier{},
+	)
 	// this line is used by starport scaffolding # 3
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)

--- a/x/supplier/types/message_stake_supplier.go
+++ b/x/supplier/types/message_stake_supplier.go
@@ -1,0 +1,45 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+const TypeMsgStakeSupplier = "stake_supplier"
+
+var _ sdk.Msg = &MsgStakeSupplier{}
+
+func NewMsgStakeSupplier(address string) *MsgStakeSupplier {
+	return &MsgStakeSupplier{
+		Address: address,
+	}
+}
+
+func (msg *MsgStakeSupplier) Route() string {
+	return RouterKey
+}
+
+func (msg *MsgStakeSupplier) Type() string {
+	return TypeMsgStakeSupplier
+}
+
+func (msg *MsgStakeSupplier) GetSigners() []sdk.AccAddress {
+	address, err := sdk.AccAddressFromBech32(msg.Address)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{address}
+}
+
+func (msg *MsgStakeSupplier) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+func (msg *MsgStakeSupplier) ValidateBasic() error {
+	_, err := sdk.AccAddressFromBech32(msg.Address)
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid address address (%s)", err)
+	}
+	return nil
+}

--- a/x/supplier/types/message_stake_supplier_test.go
+++ b/x/supplier/types/message_stake_supplier_test.go
@@ -1,0 +1,40 @@
+package types
+
+import (
+	"testing"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/stretchr/testify/require"
+	"pocket/testutil/sample"
+)
+
+func TestMsgStakeSupplier_ValidateBasic(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  MsgStakeSupplier
+		err  error
+	}{
+		{
+			name: "invalid address",
+			msg: MsgStakeSupplier{
+				Address: "invalid_address",
+			},
+			err: sdkerrors.ErrInvalidAddress,
+		}, {
+			name: "valid address",
+			msg: MsgStakeSupplier{
+				Address: sample.AccAddress(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Ran the following command:

```
ignite scaffold message stake-supplier --module supplier --signer address --yes
```

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Oct 23 20:24 UTC
This pull request includes the following changes:

- Added a new definition for `pocket.supplier.MsgStakeSupplierResponse` in `openapi.yml`.
- Added a new service method `StakeSupplier` and `MsgStakeSupplier` message in `tx.proto`.
- Added a new command `CmdStakeSupplier` in `tx.go`.
- Added a new file `tx_stake_supplier.go` in `cli` package.
- Added a new file `msg_server_stake_supplier.go` in `keeper` package.
- Added a new file `stake_supplier.go` in `simulation` package.
- Updated the `RegisterCodec` and `RegisterInterfaces` functions in `codec.go`.
- Added a new file `message_stake_supplier.go` in `types` package.
- Added a new file `message_stake_supplier_test.go` in `types` package.

Please review these changes.
<!-- reviewpad:summarize:end -->

## Issue

Part of #7

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make test_all_unit`
- [x] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
