### PR TITLE
[Supplier] Scaffolded the UnstakeSupplier message and nothing else

### DIFF
--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -75350,6 +75350,8 @@ definitions:
         description: params holds all the parameters of this module.
         type: object
     description: QueryParamsResponse is response type for the Query/Params RPC method.
+  pocket.supplier.MsgUnstakeSupplierResponse:
+    type: object
   pocket.supplier.Params:
     type: object
     description: Params defines the parameters for the module.

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
-	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	google.golang.org/grpc v1.56.1
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -259,6 +258,7 @@ require (
 	gonum.org/v1/gonum v0.11.0 // indirect
 	google.golang.org/api v0.122.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/proto/pocket/supplier/tx.proto
+++ b/proto/pocket/supplier/tx.proto
@@ -1,7 +1,16 @@
 syntax = "proto3";
+
 package pocket.supplier;
 
 option go_package = "pocket/x/supplier/types";
 
 // Msg defines the Msg service.
-service Msg {}
+service Msg {
+  rpc UnstakeSupplier (MsgUnstakeSupplier) returns (MsgUnstakeSupplierResponse);
+}
+message MsgUnstakeSupplier {
+  string address = 1;
+}
+
+message MsgUnstakeSupplierResponse {}
+

--- a/x/supplier/client/cli/tx.go
+++ b/x/supplier/client/cli/tx.go
@@ -30,6 +30,7 @@ func GetTxCmd() *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
+	cmd.AddCommand(CmdUnstakeSupplier())
 	// this line is used by starport scaffolding # 1
 
 	return cmd

--- a/x/supplier/client/cli/tx_unstake_supplier.go
+++ b/x/supplier/client/cli/tx_unstake_supplier.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/spf13/cobra"
+	"pocket/x/supplier/types"
+)
+
+var _ = strconv.Itoa(0)
+
+func CmdUnstakeSupplier() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unstake-supplier",
+		Short: "Broadcast message unstake-supplier",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgUnstakeSupplier(
+				clientCtx.GetFromAddress().String(),
+			)
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/supplier/keeper/msg_server_unstake_supplier.go
+++ b/x/supplier/keeper/msg_server_unstake_supplier.go
@@ -1,0 +1,17 @@
+package keeper
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"pocket/x/supplier/types"
+)
+
+func (k msgServer) UnstakeSupplier(goCtx context.Context, msg *types.MsgUnstakeSupplier) (*types.MsgUnstakeSupplierResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	// TODO: Handling the message
+	_ = ctx
+
+	return &types.MsgUnstakeSupplierResponse{}, nil
+}

--- a/x/supplier/module_simulation.go
+++ b/x/supplier/module_simulation.go
@@ -95,8 +95,10 @@ func (am AppModule) ProposalMsgs(simState module.SimulationState) []simtypes.Wei
 			defaultWeightMsgStakeSupplier,
 			func(r *rand.Rand, ctx sdk.Context, accs []simtypes.Account) sdk.Msg {
 				suppliersimulation.SimulateMsgStakeSupplier(am.accountKeeper, am.bankKeeper, am.keeper)
+				return nil
 			},
-
+		),
+		simulation.NewWeightedProposalMsg(
 			opWeightMsgUnstakeSupplier,
 			defaultWeightMsgUnstakeSupplier,
 			func(r *rand.Rand, ctx sdk.Context, accs []simtypes.Account) sdk.Msg {

--- a/x/supplier/module_simulation.go
+++ b/x/supplier/module_simulation.go
@@ -23,7 +23,11 @@ var (
 )
 
 const (
-// this line is used by starport scaffolding # simapp/module/const
+	opWeightMsgUnstakeSupplier = "op_weight_msg_unstake_supplier"
+	// TODO: Determine the simulation weight value
+	defaultWeightMsgUnstakeSupplier int = 100
+
+	// this line is used by starport scaffolding # simapp/module/const
 )
 
 // GenerateGenesisState creates a randomized GenState of the module.
@@ -51,6 +55,17 @@ func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedP
 func (am AppModule) WeightedOperations(simState module.SimulationState) []simtypes.WeightedOperation {
 	operations := make([]simtypes.WeightedOperation, 0)
 
+	var weightMsgUnstakeSupplier int
+	simState.AppParams.GetOrGenerate(simState.Cdc, opWeightMsgUnstakeSupplier, &weightMsgUnstakeSupplier, nil,
+		func(_ *rand.Rand) {
+			weightMsgUnstakeSupplier = defaultWeightMsgUnstakeSupplier
+		},
+	)
+	operations = append(operations, simulation.NewWeightedOperation(
+		weightMsgUnstakeSupplier,
+		suppliersimulation.SimulateMsgUnstakeSupplier(am.accountKeeper, am.bankKeeper, am.keeper),
+	))
+
 	// this line is used by starport scaffolding # simapp/module/operation
 
 	return operations
@@ -59,6 +74,14 @@ func (am AppModule) WeightedOperations(simState module.SimulationState) []simtyp
 // ProposalMsgs returns msgs used for governance proposals for simulations.
 func (am AppModule) ProposalMsgs(simState module.SimulationState) []simtypes.WeightedProposalMsg {
 	return []simtypes.WeightedProposalMsg{
+		simulation.NewWeightedProposalMsg(
+			opWeightMsgUnstakeSupplier,
+			defaultWeightMsgUnstakeSupplier,
+			func(r *rand.Rand, ctx sdk.Context, accs []simtypes.Account) sdk.Msg {
+				suppliersimulation.SimulateMsgUnstakeSupplier(am.accountKeeper, am.bankKeeper, am.keeper)
+				return nil
+			},
+		),
 		// this line is used by starport scaffolding # simapp/module/OpMsg
 	}
 }

--- a/x/supplier/simulation/unstake_supplier.go
+++ b/x/supplier/simulation/unstake_supplier.go
@@ -1,0 +1,29 @@
+package simulation
+
+import (
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"pocket/x/supplier/keeper"
+	"pocket/x/supplier/types"
+)
+
+func SimulateMsgUnstakeSupplier(
+	ak types.AccountKeeper,
+	bk types.BankKeeper,
+	k keeper.Keeper,
+) simtypes.Operation {
+	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		simAccount, _ := simtypes.RandomAcc(r, accs)
+		msg := &types.MsgUnstakeSupplier{
+			Address: simAccount.Address.String(),
+		}
+
+		// TODO: Handling the UnstakeSupplier simulation
+
+		return simtypes.NoOpMsg(types.ModuleName, msg.Type(), "UnstakeSupplier simulation not implemented"), nil, nil
+	}
+}

--- a/x/supplier/types/codec.go
+++ b/x/supplier/types/codec.go
@@ -3,15 +3,19 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
-	// this line is used by starport scaffolding # 1
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
+	cdc.RegisterConcrete(&MsgUnstakeSupplier{}, "supplier/UnstakeSupplier", nil)
 	// this line is used by starport scaffolding # 2
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgUnstakeSupplier{},
+	)
 	// this line is used by starport scaffolding # 3
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)

--- a/x/supplier/types/message_unstake_supplier.go
+++ b/x/supplier/types/message_unstake_supplier.go
@@ -1,0 +1,45 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+const TypeMsgUnstakeSupplier = "unstake_supplier"
+
+var _ sdk.Msg = &MsgUnstakeSupplier{}
+
+func NewMsgUnstakeSupplier(address string) *MsgUnstakeSupplier {
+	return &MsgUnstakeSupplier{
+		Address: address,
+	}
+}
+
+func (msg *MsgUnstakeSupplier) Route() string {
+	return RouterKey
+}
+
+func (msg *MsgUnstakeSupplier) Type() string {
+	return TypeMsgUnstakeSupplier
+}
+
+func (msg *MsgUnstakeSupplier) GetSigners() []sdk.AccAddress {
+	address, err := sdk.AccAddressFromBech32(msg.Address)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{address}
+}
+
+func (msg *MsgUnstakeSupplier) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+func (msg *MsgUnstakeSupplier) ValidateBasic() error {
+	_, err := sdk.AccAddressFromBech32(msg.Address)
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid address address (%s)", err)
+	}
+	return nil
+}

--- a/x/supplier/types/message_unstake_supplier_test.go
+++ b/x/supplier/types/message_unstake_supplier_test.go
@@ -1,0 +1,40 @@
+package types
+
+import (
+	"testing"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/stretchr/testify/require"
+	"pocket/testutil/sample"
+)
+
+func TestMsgUnstakeSupplier_ValidateBasic(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  MsgUnstakeSupplier
+		err  error
+	}{
+		{
+			name: "invalid address",
+			msg: MsgUnstakeSupplier{
+				Address: "invalid_address",
+			},
+			err: sdkerrors.ErrInvalidAddress,
+		}, {
+			name: "valid address",
+			msg: MsgUnstakeSupplier{
+				Address: sample.AccAddress(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Ran the following command:

```
ignite scaffold message unstake-supplier --module supplier --signer address --yes
```

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Oct 23 21:22 UTC
This pull request includes the following changes:

1. In `docs/static/openapi.yml`, there are changes related to the `pocket.supplier.MsgStakeSupplierResponse` and the addition of the `pocket.supplier.MsgUnstakeSupplierResponse` type.

2. The file `proto/pocket/supplier/tx.proto` has been modified to add the `MsgUnstakeSupplier` message and the corresponding response type.

3. In `x/supplier/client/cli/tx.go`, the `CmdUnstakeSupplier` command has been added.

4. The file `x/supplier/client/cli/tx_unstake_supplier.go` has been added to implement the `unstake-supplier` command.

5. The file `x/supplier/keeper/msg_server_unstake_supplier.go` has been added to handle the `MsgUnstakeSupplier` message.

6. In `x/supplier/module_simulation.go`, there are changes related to the simulation of the `MsgUnstakeSupplier` operation.

7. The file `x/supplier/simulation/unstake_supplier.go` has been added to implement the simulation of the `MsgUnstakeSupplier` operation.

8. Changes have been made in `x/supplier/types/codec.go` to register the `MsgUnstakeSupplier` message and response type.

9. The file `x/supplier/types/message_unstake_supplier.go` has been added to implement the `MsgUnstakeSupplier` message.

10. The file `x/supplier/types/message_unstake_supplier_test.go` has been added to test the validation of the `MsgUnstakeSupplier` message.

Please review the diff for more details.
<!-- reviewpad:summarize:end -->

## Issue

Part of #7

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make test_all_unit`
- [x] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
