### PR TITLE
[Supplier] Scaffolded the StakeSupplier message and nothing else

### DIFF
--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -75320,6 +75320,8 @@ definitions:
     description: |-
       Version defines the versioning scheme used to negotiate the IBC verison in
       the connection handshake.
+  pocket.application.MsgStakeApplicationResponse:
+    type: object
   pocket.application.Params:
     type: object
     description: Params defines the parameters for the module.

--- a/proto/pocket/application/tx.proto
+++ b/proto/pocket/application/tx.proto
@@ -1,7 +1,16 @@
 syntax = "proto3";
+
 package pocket.application;
 
 option go_package = "pocket/x/application/types";
 
 // Msg defines the Msg service.
-service Msg {}
+service Msg {
+  rpc StakeApplication (MsgStakeApplication) returns (MsgStakeApplicationResponse);
+}
+message MsgStakeApplication {
+  string address = 1;
+}
+
+message MsgStakeApplicationResponse {}
+

--- a/x/application/client/cli/tx.go
+++ b/x/application/client/cli/tx.go
@@ -30,6 +30,7 @@ func GetTxCmd() *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
+	cmd.AddCommand(CmdStakeApplication())
 	// this line is used by starport scaffolding # 1
 
 	return cmd

--- a/x/application/client/cli/tx_stake_application.go
+++ b/x/application/client/cli/tx_stake_application.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/spf13/cobra"
+	"pocket/x/application/types"
+)
+
+var _ = strconv.Itoa(0)
+
+func CmdStakeApplication() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stake-application",
+		Short: "Broadcast message stake-application",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgStakeApplication(
+				clientCtx.GetFromAddress().String(),
+			)
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/application/keeper/msg_server_stake_application.go
+++ b/x/application/keeper/msg_server_stake_application.go
@@ -1,0 +1,17 @@
+package keeper
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"pocket/x/application/types"
+)
+
+func (k msgServer) StakeApplication(goCtx context.Context, msg *types.MsgStakeApplication) (*types.MsgStakeApplicationResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	// TODO: Handling the message
+	_ = ctx
+
+	return &types.MsgStakeApplicationResponse{}, nil
+}

--- a/x/application/module_simulation.go
+++ b/x/application/module_simulation.go
@@ -23,7 +23,11 @@ var (
 )
 
 const (
-// this line is used by starport scaffolding # simapp/module/const
+	opWeightMsgStakeApplication = "op_weight_msg_stake_application"
+	// TODO: Determine the simulation weight value
+	defaultWeightMsgStakeApplication int = 100
+
+	// this line is used by starport scaffolding # simapp/module/const
 )
 
 // GenerateGenesisState creates a randomized GenState of the module.
@@ -51,6 +55,17 @@ func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedP
 func (am AppModule) WeightedOperations(simState module.SimulationState) []simtypes.WeightedOperation {
 	operations := make([]simtypes.WeightedOperation, 0)
 
+	var weightMsgStakeApplication int
+	simState.AppParams.GetOrGenerate(simState.Cdc, opWeightMsgStakeApplication, &weightMsgStakeApplication, nil,
+		func(_ *rand.Rand) {
+			weightMsgStakeApplication = defaultWeightMsgStakeApplication
+		},
+	)
+	operations = append(operations, simulation.NewWeightedOperation(
+		weightMsgStakeApplication,
+		applicationsimulation.SimulateMsgStakeApplication(am.accountKeeper, am.bankKeeper, am.keeper),
+	))
+
 	// this line is used by starport scaffolding # simapp/module/operation
 
 	return operations
@@ -59,6 +74,14 @@ func (am AppModule) WeightedOperations(simState module.SimulationState) []simtyp
 // ProposalMsgs returns msgs used for governance proposals for simulations.
 func (am AppModule) ProposalMsgs(simState module.SimulationState) []simtypes.WeightedProposalMsg {
 	return []simtypes.WeightedProposalMsg{
+		simulation.NewWeightedProposalMsg(
+			opWeightMsgStakeApplication,
+			defaultWeightMsgStakeApplication,
+			func(r *rand.Rand, ctx sdk.Context, accs []simtypes.Account) sdk.Msg {
+				applicationsimulation.SimulateMsgStakeApplication(am.accountKeeper, am.bankKeeper, am.keeper)
+				return nil
+			},
+		),
 		// this line is used by starport scaffolding # simapp/module/OpMsg
 	}
 }

--- a/x/application/simulation/stake_application.go
+++ b/x/application/simulation/stake_application.go
@@ -1,0 +1,29 @@
+package simulation
+
+import (
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"pocket/x/application/keeper"
+	"pocket/x/application/types"
+)
+
+func SimulateMsgStakeApplication(
+	ak types.AccountKeeper,
+	bk types.BankKeeper,
+	k keeper.Keeper,
+) simtypes.Operation {
+	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		simAccount, _ := simtypes.RandomAcc(r, accs)
+		msg := &types.MsgStakeApplication{
+			Address: simAccount.Address.String(),
+		}
+
+		// TODO: Handling the StakeApplication simulation
+
+		return simtypes.NoOpMsg(types.ModuleName, msg.Type(), "StakeApplication simulation not implemented"), nil, nil
+	}
+}

--- a/x/application/types/codec.go
+++ b/x/application/types/codec.go
@@ -3,15 +3,19 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
-	// this line is used by starport scaffolding # 1
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
+	cdc.RegisterConcrete(&MsgStakeApplication{}, "application/StakeApplication", nil)
 	// this line is used by starport scaffolding # 2
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgStakeApplication{},
+	)
 	// this line is used by starport scaffolding # 3
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)

--- a/x/application/types/message_stake_application.go
+++ b/x/application/types/message_stake_application.go
@@ -1,0 +1,45 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+const TypeMsgStakeApplication = "stake_application"
+
+var _ sdk.Msg = &MsgStakeApplication{}
+
+func NewMsgStakeApplication(address string) *MsgStakeApplication {
+	return &MsgStakeApplication{
+		Address: address,
+	}
+}
+
+func (msg *MsgStakeApplication) Route() string {
+	return RouterKey
+}
+
+func (msg *MsgStakeApplication) Type() string {
+	return TypeMsgStakeApplication
+}
+
+func (msg *MsgStakeApplication) GetSigners() []sdk.AccAddress {
+	address, err := sdk.AccAddressFromBech32(msg.Address)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{address}
+}
+
+func (msg *MsgStakeApplication) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+func (msg *MsgStakeApplication) ValidateBasic() error {
+	_, err := sdk.AccAddressFromBech32(msg.Address)
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid address address (%s)", err)
+	}
+	return nil
+}

--- a/x/application/types/message_stake_application_test.go
+++ b/x/application/types/message_stake_application_test.go
@@ -1,0 +1,40 @@
+package types
+
+import (
+	"testing"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/stretchr/testify/require"
+	"pocket/testutil/sample"
+)
+
+func TestMsgStakeApplication_ValidateBasic(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  MsgStakeApplication
+		err  error
+	}{
+		{
+			name: "invalid address",
+			msg: MsgStakeApplication{
+				Address: "invalid_address",
+			},
+			err: sdkerrors.ErrInvalidAddress,
+		}, {
+			name: "valid address",
+			msg: MsgStakeApplication{
+				Address: sample.AccAddress(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Ran the following command

```bash
ignite scaffold message stake-application --module application --signer address --yes
```

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Oct 23 20:42 UTC
This pull request includes the following changes:

- In the `docs/static/openapi.yml` file, a new object type `pocket.application.MsgStakeApplicationResponse` is added.
- In the `proto/pocket/application/tx.proto` file, a new service RPC `StakeApplication` and message types `MsgStakeApplication` and `MsgStakeApplicationResponse` are added.
- In the `x/application/client/cli/tx.go` file, a new command `stake-application` and its corresponding implementation are added.
- In the `x/application/client/cli/tx_stake_application.go` file, a new file with the implementation of the `stake-application` command is added.
- In the `x/application/keeper/msg_server_stake_application.go` file, the implementation of the `StakeApplication` method is added.
- In the `x/application/module_simulation.go` file, simulation-related configurations and operations are added for the `MsgStakeApplication` message type.
- In the `x/application/simulation/stake_application.go` file, the simulation implementation for the `MsgStakeApplication` message type is added.
- In the `x/application/types/codec.go` file, the `MsgStakeApplication` message type is registered for encoding and decoding.
- In the `x/application/types/message_stake_application.go` file, the implementation of the `MsgStakeApplication` message type is added.
- In the `x/application/types/message_stake_application_test.go` file, the tests for the `MsgStakeApplication` message type are added.
<!-- reviewpad:summarize:end -->

## Issue

Part of #8

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make test_all_unit`
- [x] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
