### PR TITLE
[Supplier] Scaffolded the UnstakeSupplier message and nothing else

### DIFF
--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -75320,6 +75320,8 @@ definitions:
     description: |-
       Version defines the versioning scheme used to negotiate the IBC verison in
       the connection handshake.
+  pocket.application.MsgUnstakeApplicationResponse:
+    type: object
   pocket.application.Params:
     type: object
     description: Params defines the parameters for the module.

--- a/proto/pocket/application/tx.proto
+++ b/proto/pocket/application/tx.proto
@@ -1,7 +1,16 @@
 syntax = "proto3";
+
 package pocket.application;
 
 option go_package = "pocket/x/application/types";
 
 // Msg defines the Msg service.
-service Msg {}
+service Msg {
+  rpc UnstakeApplication (MsgUnstakeApplication) returns (MsgUnstakeApplicationResponse);
+}
+message MsgUnstakeApplication {
+  string address = 1;
+}
+
+message MsgUnstakeApplicationResponse {}
+

--- a/x/application/client/cli/tx.go
+++ b/x/application/client/cli/tx.go
@@ -30,6 +30,7 @@ func GetTxCmd() *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
+	cmd.AddCommand(CmdUnstakeApplication())
 	// this line is used by starport scaffolding # 1
 
 	return cmd

--- a/x/application/client/cli/tx_unstake_application.go
+++ b/x/application/client/cli/tx_unstake_application.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/spf13/cobra"
+	"pocket/x/application/types"
+)
+
+var _ = strconv.Itoa(0)
+
+func CmdUnstakeApplication() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unstake-application",
+		Short: "Broadcast message unstake-application",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgUnstakeApplication(
+				clientCtx.GetFromAddress().String(),
+			)
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/application/keeper/msg_server_unstake_application.go
+++ b/x/application/keeper/msg_server_unstake_application.go
@@ -1,0 +1,17 @@
+package keeper
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"pocket/x/application/types"
+)
+
+func (k msgServer) UnstakeApplication(goCtx context.Context, msg *types.MsgUnstakeApplication) (*types.MsgUnstakeApplicationResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	// TODO: Handling the message
+	_ = ctx
+
+	return &types.MsgUnstakeApplicationResponse{}, nil
+}

--- a/x/application/module_simulation.go
+++ b/x/application/module_simulation.go
@@ -91,17 +91,18 @@ func (am AppModule) WeightedOperations(simState module.SimulationState) []simtyp
 func (am AppModule) ProposalMsgs(simState module.SimulationState) []simtypes.WeightedProposalMsg {
 	return []simtypes.WeightedProposalMsg{
 		simulation.NewWeightedProposalMsg(
-
-			opWeightMsgUnstakeApplication,
-			defaultWeightMsgUnstakeApplication,
-			func(r *rand.Rand, ctx sdk.Context, accs []simtypes.Account) sdk.Msg {
-				applicationsimulation.SimulateMsgUnstakeApplication(am.accountKeeper, am.bankKeeper, am.keeper)
-			},
-
 			opWeightMsgStakeApplication,
 			defaultWeightMsgStakeApplication,
 			func(r *rand.Rand, ctx sdk.Context, accs []simtypes.Account) sdk.Msg {
 				applicationsimulation.SimulateMsgStakeApplication(am.accountKeeper, am.bankKeeper, am.keeper)
+				return nil
+			},
+		),
+		simulation.NewWeightedProposalMsg(
+			opWeightMsgUnstakeApplication,
+			defaultWeightMsgUnstakeApplication,
+			func(r *rand.Rand, ctx sdk.Context, accs []simtypes.Account) sdk.Msg {
+				applicationsimulation.SimulateMsgUnstakeApplication(am.accountKeeper, am.bankKeeper, am.keeper)
 				return nil
 			},
 		),

--- a/x/application/module_simulation.go
+++ b/x/application/module_simulation.go
@@ -23,7 +23,11 @@ var (
 )
 
 const (
-// this line is used by starport scaffolding # simapp/module/const
+	opWeightMsgUnstakeApplication = "op_weight_msg_unstake_application"
+	// TODO: Determine the simulation weight value
+	defaultWeightMsgUnstakeApplication int = 100
+
+	// this line is used by starport scaffolding # simapp/module/const
 )
 
 // GenerateGenesisState creates a randomized GenState of the module.
@@ -51,6 +55,17 @@ func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedP
 func (am AppModule) WeightedOperations(simState module.SimulationState) []simtypes.WeightedOperation {
 	operations := make([]simtypes.WeightedOperation, 0)
 
+	var weightMsgUnstakeApplication int
+	simState.AppParams.GetOrGenerate(simState.Cdc, opWeightMsgUnstakeApplication, &weightMsgUnstakeApplication, nil,
+		func(_ *rand.Rand) {
+			weightMsgUnstakeApplication = defaultWeightMsgUnstakeApplication
+		},
+	)
+	operations = append(operations, simulation.NewWeightedOperation(
+		weightMsgUnstakeApplication,
+		applicationsimulation.SimulateMsgUnstakeApplication(am.accountKeeper, am.bankKeeper, am.keeper),
+	))
+
 	// this line is used by starport scaffolding # simapp/module/operation
 
 	return operations
@@ -59,6 +74,14 @@ func (am AppModule) WeightedOperations(simState module.SimulationState) []simtyp
 // ProposalMsgs returns msgs used for governance proposals for simulations.
 func (am AppModule) ProposalMsgs(simState module.SimulationState) []simtypes.WeightedProposalMsg {
 	return []simtypes.WeightedProposalMsg{
+		simulation.NewWeightedProposalMsg(
+			opWeightMsgUnstakeApplication,
+			defaultWeightMsgUnstakeApplication,
+			func(r *rand.Rand, ctx sdk.Context, accs []simtypes.Account) sdk.Msg {
+				applicationsimulation.SimulateMsgUnstakeApplication(am.accountKeeper, am.bankKeeper, am.keeper)
+				return nil
+			},
+		),
 		// this line is used by starport scaffolding # simapp/module/OpMsg
 	}
 }

--- a/x/application/simulation/unstake_application.go
+++ b/x/application/simulation/unstake_application.go
@@ -1,0 +1,29 @@
+package simulation
+
+import (
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	"pocket/x/application/keeper"
+	"pocket/x/application/types"
+)
+
+func SimulateMsgUnstakeApplication(
+	ak types.AccountKeeper,
+	bk types.BankKeeper,
+	k keeper.Keeper,
+) simtypes.Operation {
+	return func(r *rand.Rand, app *baseapp.BaseApp, ctx sdk.Context, accs []simtypes.Account, chainID string,
+	) (simtypes.OperationMsg, []simtypes.FutureOperation, error) {
+		simAccount, _ := simtypes.RandomAcc(r, accs)
+		msg := &types.MsgUnstakeApplication{
+			Address: simAccount.Address.String(),
+		}
+
+		// TODO: Handling the UnstakeApplication simulation
+
+		return simtypes.NoOpMsg(types.ModuleName, msg.Type(), "UnstakeApplication simulation not implemented"), nil, nil
+	}
+}

--- a/x/application/types/codec.go
+++ b/x/application/types/codec.go
@@ -3,15 +3,19 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
-	// this line is used by starport scaffolding # 1
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
+	cdc.RegisterConcrete(&MsgUnstakeApplication{}, "application/UnstakeApplication", nil)
 	// this line is used by starport scaffolding # 2
 }
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgUnstakeApplication{},
+	)
 	// this line is used by starport scaffolding # 3
 
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)

--- a/x/application/types/message_unstake_application.go
+++ b/x/application/types/message_unstake_application.go
@@ -1,0 +1,45 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+const TypeMsgUnstakeApplication = "unstake_application"
+
+var _ sdk.Msg = &MsgUnstakeApplication{}
+
+func NewMsgUnstakeApplication(address string) *MsgUnstakeApplication {
+	return &MsgUnstakeApplication{
+		Address: address,
+	}
+}
+
+func (msg *MsgUnstakeApplication) Route() string {
+	return RouterKey
+}
+
+func (msg *MsgUnstakeApplication) Type() string {
+	return TypeMsgUnstakeApplication
+}
+
+func (msg *MsgUnstakeApplication) GetSigners() []sdk.AccAddress {
+	address, err := sdk.AccAddressFromBech32(msg.Address)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{address}
+}
+
+func (msg *MsgUnstakeApplication) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(msg)
+	return sdk.MustSortJSON(bz)
+}
+
+func (msg *MsgUnstakeApplication) ValidateBasic() error {
+	_, err := sdk.AccAddressFromBech32(msg.Address)
+	if err != nil {
+		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid address address (%s)", err)
+	}
+	return nil
+}

--- a/x/application/types/message_unstake_application_test.go
+++ b/x/application/types/message_unstake_application_test.go
@@ -1,0 +1,40 @@
+package types
+
+import (
+	"testing"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/stretchr/testify/require"
+	"pocket/testutil/sample"
+)
+
+func TestMsgUnstakeApplication_ValidateBasic(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  MsgUnstakeApplication
+		err  error
+	}{
+		{
+			name: "invalid address",
+			msg: MsgUnstakeApplication{
+				Address: "invalid_address",
+			},
+			err: sdkerrors.ErrInvalidAddress,
+		}, {
+			name: "valid address",
+			msg: MsgUnstakeApplication{
+				Address: sample.AccAddress(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.err != nil {
+				require.ErrorIs(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Ran the following command

```bash
ignite scaffold message unstake-application --module application --signer address --yes
```

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Oct 23 21:10 UTC
This pull request introduces several changes related to unstaking applications:

1. A new Go file named `unstake_application.go` is added to the repository. It contains a command `CmdUnstakeApplication()` that is used to broadcast a message to unstake an application. The command validates the message and generates or broadcasts a transaction.

2. The file `codec.go` is modified by adding a new message type `MsgUnstakeApplication` to the `RegisterCodec` and `RegisterInterfaces` functions. These changes indicate the registration of the new message type for unstaking an application.

3. A new test file named `message_unstake_application_test.go` is added to the `x/application/types` package. The test file contains a test function named `TestMsgUnstakeApplication_ValidateBasic` that tests the `ValidateBasic` function of the `MsgUnstakeApplication` type. The test function includes test cases for both invalid and valid addresses and uses the `require` package for assertions.

4. The file `tx.proto` is modified by adding an RPC function `UnstakeApplication` to the `Msg` service. Additionally, new message types `MsgUnstakeApplication` and `MsgUnstakeApplicationResponse` are defined.

5. Another new file named `message_unstake_application.go` is added to the `types` package. This file exports a constant named `TypeMsgUnstakeApplication` and defines a struct called `MsgUnstakeApplication` that implements the `sdk.Msg` interface. The struct has various methods for message creation, route and type retrieval, signer retrieval, sign bytes retrieval, and message validation. The `MsgUnstakeApplication` struct includes an `Address` field, and its `ValidateBasic` method ensures that the address is a valid Bech32 encoded address.

6. The file `tx.go` is modified by adding the command `CmdUnstakeApplication()` to the existing command list.

7. The file `openapi.yml` is modified by adding `pocket.application.MsgUnstakeApplicationResponse` to the `definitions` and removing `pocket.service.Params` and `pocket.service.QueryParamsResponse` from the `definitions`. Additionally, `pocket.session.Params` and `pocket.session.QueryParamsResponse` are added to the `definitions`.

8. Another new file named `unstake_application.go` is added to the `simulation` package. This file includes imports for various packages and defines a function named `SimulateMsgUnstakeApplication` that generates a random account and creates a `types.MsgUnstakeApplication` object. The function returns a `simtypes.NoOpMsg`, indicating that the simulation for `UnstakeApplication` is not implemented yet.

9. The file `module_simulation.go` is modified by adding import statements, constants, and functions related to simulating the `MsgUnstakeApplication` message.

10. Finally, the file `msg_server_unstake_application.go` is added to the `x/application/keeper` package. This file includes a package import, a function named `UnstakeApplication` in the `msgServer` struct, and some code commenting indicating that the handling of the message is a TODO.

Please review these changes.
<!-- reviewpad:summarize:end -->

## Issue

Part of #8

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make test_all_unit`
- [x] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
