### PR TITLE
[WIP][Session] Adding the Relay type

### DIFF
--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -46437,6 +46437,167 @@ paths:
                         }
       tags:
         - Query
+  /pocket/application/application:
+    get:
+      operationId: PocketApplicationApplicationAll
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              application:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    address:
+                      type: string
+              pagination:
+                type: object
+                properties:
+                  next_key:
+                    type: string
+                    format: byte
+                    description: |-
+                      next_key is the key to be passed to PageRequest.key to
+                      query the next page most efficiently. It will be empty if
+                      there are no more results.
+                  total:
+                    type: string
+                    format: uint64
+                    title: >-
+                      total is total number of results available if
+                      PageRequest.count_total
+
+                      was set, its value is undefined otherwise
+                description: >-
+                  PageResponse is to be embedded in gRPC response messages where
+                  the
+
+                  corresponding request message has used PageRequest.
+
+                   message SomeResponse {
+                           repeated Bar results = 1;
+                           PageResponse page = 2;
+                   }
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    '@type':
+                      type: string
+                  additionalProperties: {}
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /pocket/application/application/{address}:
+    get:
+      summary: Queries a list of Application items.
+      operationId: PocketApplicationApplication
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              application:
+                type: object
+                properties:
+                  address:
+                    type: string
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    '@type':
+                      type: string
+                  additionalProperties: {}
+      parameters:
+        - name: address
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
   /pocket/application/params:
     get:
       summary: Parameters queries the parameters of the module.
@@ -46509,17 +46670,46 @@ paths:
                   additionalProperties: {}
       tags:
         - Query
-<<<<<<< HEAD
   /pocket/service/params:
     get:
       summary: Parameters queries the parameters of the module.
       operationId: PocketServiceParams
-=======
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              params:
+                description: params holds all the parameters of this module.
+                type: object
+            description: >-
+              QueryParamsResponse is response type for the Query/Params RPC
+              method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    '@type':
+                      type: string
+                  additionalProperties: {}
+      tags:
+        - Query
   /pocket/session/params:
     get:
       summary: Parameters queries the parameters of the module.
       operationId: PocketSessionParams
->>>>>>> main
       responses:
         '200':
           description: A successful response.
@@ -75488,12 +75678,62 @@ definitions:
     description: |-
       Version defines the versioning scheme used to negotiate the IBC verison in
       the connection handshake.
+  pocket.application.Application:
+    type: object
+    properties:
+      address:
+        type: string
   pocket.application.MsgStakeApplicationResponse:
+    type: object
   pocket.application.MsgUnstakeApplicationResponse:
     type: object
   pocket.application.Params:
     type: object
     description: Params defines the parameters for the module.
+  pocket.application.QueryAllApplicationResponse:
+    type: object
+    properties:
+      application:
+        type: array
+        items:
+          type: object
+          properties:
+            address:
+              type: string
+      pagination:
+        type: object
+        properties:
+          next_key:
+            type: string
+            format: byte
+            description: |-
+              next_key is the key to be passed to PageRequest.key to
+              query the next page most efficiently. It will be empty if
+              there are no more results.
+          total:
+            type: string
+            format: uint64
+            title: >-
+              total is total number of results available if
+              PageRequest.count_total
+
+              was set, its value is undefined otherwise
+        description: |-
+          PageResponse is to be embedded in gRPC response messages where the
+          corresponding request message has used PageRequest.
+
+           message SomeResponse {
+                   repeated Bar results = 1;
+                   PageResponse page = 2;
+           }
+  pocket.application.QueryGetApplicationResponse:
+    type: object
+    properties:
+      application:
+        type: object
+        properties:
+          address:
+            type: string
   pocket.application.QueryParamsResponse:
     type: object
     properties:
@@ -75511,6 +75751,16 @@ definitions:
         description: params holds all the parameters of this module.
         type: object
     description: QueryParamsResponse is response type for the Query/Params RPC method.
+  pocket.service.Params:
+    type: object
+    description: Params defines the parameters for the module.
+  pocket.service.QueryParamsResponse:
+    type: object
+    properties:
+      params:
+        description: params holds all the parameters of this module.
+        type: object
+    description: QueryParamsResponse is response type for the Query/Params RPC method.
   pocket.session.Params:
     type: object
     description: Params defines the parameters for the module.
@@ -75521,11 +75771,9 @@ definitions:
         description: params holds all the parameters of this module.
         type: object
     description: QueryParamsResponse is response type for the Query/Params RPC method.
-<<<<<<< HEAD
-  pocket.supplier.MsgUnstakeSupplierResponse:
-=======
   pocket.supplier.MsgStakeSupplierResponse:
->>>>>>> main
+    type: object
+  pocket.supplier.MsgUnstakeSupplierResponse:
     type: object
   pocket.supplier.Params:
     type: object

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
-	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	google.golang.org/grpc v1.56.1
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -259,6 +258,7 @@ require (
 	gonum.org/v1/gonum v0.11.0 // indirect
 	google.golang.org/api v0.122.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/proto/pocket/service/relay.proto
+++ b/proto/pocket/service/relay.proto
@@ -3,93 +3,90 @@ package pocket.service;
 
 option go_package = "pocket/x/service/types";
 
-
 import "cosmos_proto/cosmos.proto";
 import "pocket/service/service.proto";
 import "pocket/application/application.proto";
 import "pocket/supplier/supplier.proto";
 
-// Relay is a protobuf containing both the RelayRequest, signed by the Application
-// and the RelayResponse, signed by the Supplier. Together, the serialized tuple is
-// what is inserted into the SMST leaves as values in the Claim/Proof lifecycle.
+// Relay contains both the RelayRequest (signed by the Application) and the RelayResponse (signed by the Supplier).
+// The serialized tuple is inserted into the SMST leaves as values in the Claim/Proof lifecycle.
 message Relay {
     RelayRequest req = 1;
     RelayResponse res = 2;
 }
 
-
-// RelayRequestMetadata is used to hold the metadata for a RelayRequest.
+// RelayRequestMetadata contains the metadata for a RelayRequest.
 message RelayRequestMetadata {
-    session.SessionHeader session_header = 1; // The session header for the relay
-    bytes application_signature = 2; // The signature of the application of the request
+    session.SessionHeader session_header = 1; // Session header associated with the relay.
+    bytes application_signature = 2; // Signature of the application on the request.
 }
 
-// RelayResponse is used to hold the response from a RelayRequest.
+// RelayRequest holds the request details for a relay.
 message RelayRequest {
     RelayRequestMetadata meta = 1;
-    // TODO: Add other relay types in the future such as the ones below:
     oneof payload {
         JSONRPCRequestPayload json_rpc_payload = 2;
         RESTRequestPayload rest_payload = 3;
+        // Future possible relay types:
         // WebSocketsRequestPayload websockets_payload = 4;
         // GRPCRequestPayload grpc_payload = 5;
         // GraphQLRequestPayload graphql_payload = 6;
     }
 }
 
-// JSONRPCRequestPayload is used to hold the payload for a JSON-RPC request.
-// See the JSONRPC spec in the following link for more details: https://www.jsonrpc.org/specification#request_object
+// JSONRPCRequestPayload contains the payload for a JSON-RPC request.
 message JSONRPCRequestPayload {
-    bytes id = 1; // JSONRPC version 2 expected a field named "id"
-    string jsonrpc = 2; // JSONRPC version 2 expects a field named "jsonrpc" with a value of "2.0"
-    string method = 3; // The method being invoked on the server
-    map<string, string> parameters = 4; // The parameters field can be empty, an array or a structure
-    bytes data = 5;
+    bytes id = 1; // Expected "id" field for JSON-RPC version 2.
+    string jsonrpc = 2; // Expected "jsonrpc" field with a value of "2.0" for JSON-RPC version 2.
+    string method = 3; // Method being invoked on the server.
+    map<string, string> parameters = 4; // Parameters for the method. Can be empty, an array, or a structure.
+    bytes data = 5; // Additional data if needed.
 }
 
-// RESTRequestType is used to hold the type of REST request being made.
+// RESTRequestType represents the type of REST request.
 enum RESTRequestType {
-    REST_REQUEST_TYPE_UNKNOWN = 0; // Default value, used for uninitialized fields
+    REST_REQUEST_TYPE_UNKNOWN = 0; // Default uninitialized value.
     REST_REQUEST_TYPE_GET = 1;
     REST_REQUEST_TYPE_PUT = 2;
     REST_REQUEST_TYPE_POST = 3;
     REST_REQUEST_TYPE_DELETE = 4;
 }
 
-// RESTPayload is used to hold the payload and request metadata for a REST request.
+// RESTRequestPayload contains the payload and metadata for a REST request.
 message RESTRequestPayload {
     RESTRequestType request_type = 1;
-    string http_path = 2;
-    string contents = 3;
-    map<string, string> headers = 4; // The headers of the request
-    // TODO_INCOMPLETE: Add REST relay payload fields
+    string http_path = 2; // Path for the REST endpoint.
+    string contents = 3; // Request contents.
+    map<string, string> headers = 4; // Request headers.
 }
 
-// RelayResponse is used to hold the response to a RelayRequest.
+// RelayResponse contains the response details for a RelayRequest.
 message RelayResponse {
     RelayResponseMetadata meta = 1;
-    // TODO: Add other relay types in the future such as the ones below:
     oneof payload {
         JSONRPCResponsePayload json_rpc_payload = 2;
         RESTResponsePayload rest_payload = 3;
+        // Future possible relay types:
         // WebSocketsResponsePayload websockets_payload = 4;
         // GRPCResponsePayload grpc_payload = 5;
         // GraphQLResponsePayload graphql_payload = 6;
     }
 }
 
-// RelayResponseMetadata is used to hold the metadata for a RelayResponse
+// RelayResponseMetadata contains the metadata for a RelayResponse.
 message RelayResponseMetadata {
-    session.SessionHeader session_header = 1; // The session header for the relay
-    bytes supplier_signature = 2; // The signature of the supplier on the response
+    session.SessionHeader session_header = 1; // Session header associated with the relay.
+    bytes supplier_signature = 2; // Signature of the supplier on the response.
 }
 
+// JSONRPCResponsePayload contains the response details for a JSON-RPC relay.
 message JSONRPCResponsePayload {
-    uint32 status_code = 1; // The status code of the response
-    string err = 2; // The error message of the response
+    uint32 status_code = 1; // Response status code.
+    string err = 2; // Error message, if any.
 }
 
+// RESTResponsePayload contains the response details for a REST relay.
 message RESTResponsePayload {
-    uint32 status_code = 1; // The status code of the response
-    string err = 2; // The error message of the response
+    uint32 status_code = 1; // Response status code.
+    string err = 2; // Error message, if any.
 }

--- a/proto/pocket/service/relay.proto
+++ b/proto/pocket/service/relay.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package pocket.service;
+
+option go_package = "pocket/x/service/types";
+
+message Relay {
+  
+}

--- a/proto/pocket/service/relay.proto
+++ b/proto/pocket/service/relay.proto
@@ -4,7 +4,8 @@ package pocket.service;
 option go_package = "pocket/x/service/types";
 
 import "cosmos_proto/cosmos.proto";
-import "pocket/service/service.proto";
+// TODO(@Olshansk): Uncomment the line below once the `service.proto` is added.
+// import "pocket/service/service.proto";
 import "pocket/application/application.proto";
 import "pocket/supplier/supplier.proto";
 
@@ -17,7 +18,8 @@ message Relay {
 
 // RelayRequestMetadata contains the metadata for a RelayRequest.
 message RelayRequestMetadata {
-    session.SessionHeader session_header = 1; // Session header associated with the relay.
+    // TODO(@Olshansk): Uncomment the line below once the `service.proto` is added.
+    // session.SessionHeader session_header = 1; // Session header associated with the relay.
     // TODO_COMMENT(@h5law): Add link or more details to how this is related to ring signatures once implemented.
     bytes signature = 2; // The request signature. This may be the application signature, or any gateway it delegated to.
 }
@@ -36,12 +38,12 @@ message RelayRequest {
 }
 
 // JSONRPCRequestPayload contains the payload for a JSON-RPC request.
+// See https://www.jsonrpc.org/specification#request_object for more details.
 message JSONRPCRequestPayload {
-    bytes id = 1; // Expected "id" field for JSON-RPC version 2.
-    string jsonrpc = 2; // Expected "jsonrpc" field with a value of "2.0" for JSON-RPC version 2.
+    bytes id = 1; // Identifier established by the Client to create context for the request.
+    string jsonrpc = 2; // Version of JSON-RPC. Must be exactly "2.0".
     string method = 3; // Method being invoked on the server.
-    map<string, string> parameters = 4; // Parameters for the method. Can be empty, an array, or a structure.
-    bytes data = 5; // Additional data if needed.
+    map<string, string> parameters = 4; // Parameters for the method. https://www.jsonrpc.org/specification#parameter_structures
 }
 
 // RESTRequestType represents the type of REST request.
@@ -76,15 +78,24 @@ message RelayResponse {
 
 // RelayResponseMetadata contains the metadata for a RelayResponse.
 message RelayResponseMetadata {
-    session.SessionHeader session_header = 1; // Session header associated with the relay.
+    // TODO(@Olshansk): Uncomment the line below once the `service.proto` is added.
+    // session.SessionHeader session_header = 1; // Session header associated with the relay.
     bytes supplier_signature = 2; // Signature of the supplier on the response.
 }
 
 // JSONRPCResponsePayload contains the response details for a JSON-RPC relay.
+// See www.jsonrpc.org/specification for more details.
 message JSONRPCResponsePayload {
-    uint32 status_code = 1; // Response status code.
-    string err = 2; // Error message, if any.
-    bytes payload = 3; // Response payload.
+    bytes id = 1; // Identifier established by the Client to link the response back to the request.
+    string jsonrpc = 2; // Version of JSON-RPC. Must be exactly "2.0".
+    bytes result = 3; // Response result payload.
+    JSONRPCResponseError error = 4; // Error message, if any. Can be nil.
+}
+
+message JSONRPCResponseError {
+    int32 code = 1; // Error code.
+    string message  = 2; // Error message.
+    bytes data = 3; // Error data.
 }
 
 // RESTResponsePayload contains the response details for a REST relay.

--- a/proto/pocket/service/relay.proto
+++ b/proto/pocket/service/relay.proto
@@ -83,10 +83,12 @@ message RelayResponseMetadata {
 message JSONRPCResponsePayload {
     uint32 status_code = 1; // Response status code.
     string err = 2; // Error message, if any.
+    bytes payload = 3; // Response payload.
 }
 
 // RESTResponsePayload contains the response details for a REST relay.
 message RESTResponsePayload {
     uint32 status_code = 1; // Response status code.
     string err = 2; // Error message, if any.
+    bytes payload = 3; // Response payload.
 }

--- a/proto/pocket/service/relay.proto
+++ b/proto/pocket/service/relay.proto
@@ -18,7 +18,8 @@ message Relay {
 // RelayRequestMetadata contains the metadata for a RelayRequest.
 message RelayRequestMetadata {
     session.SessionHeader session_header = 1; // Session header associated with the relay.
-    bytes application_signature = 2; // Signature of the application on the request.
+    // TODO_COMMENT(@h5law): Add link or more details to how this is related to ring signatures once implemented.
+    bytes signature = 2; // The request signature. This may be the application signature, or any gateway it delegated to.
 }
 
 // RelayRequest holds the request details for a relay.

--- a/proto/pocket/service/relay.proto
+++ b/proto/pocket/service/relay.proto
@@ -3,112 +3,98 @@ package pocket.service;
 
 option go_package = "pocket/x/service/types";
 
-message Relay {
 
-}
+import "cosmos_proto/cosmos.proto";
+import "pocket/service/service.proto";
+import "pocket/application/application.proto";
+import "pocket/supplier/supplier.proto";
 
-
-
-syntax = "proto3";
-
-package core;
-
-option go_package = "github.com/pokt-network/pocket/shared/core/types";
-
-message Relay {
-    RelayMeta meta = 1;
-    // Every different chain/service may have its own custom payload (e.g. HTTP, JSON, GRPC, non-chain services)
-    oneof relay_payload {
-        JSONRPCPayload json_rpc_payload = 2;
-        RESTPayload rest_payload = 3;
-        // DISCUSS: design and content of other relay types
-        // GRPCPayload grpc_payload = 3;
-        // GraphQLPayload graphql_payload = 4;
-        // WebSocketsPayload websockets_payload = 5;
-    }
-}
-
-// INCOMPLETE: add REST relay payload fields
-message RESTPayload {
-    string contents = 1;
-    string http_path = 2;
-    RESTRequestType request_type = 3;
-}
-
-enum RESTRequestType {
-	RESTRequestTypeGET = 0;
-	RESTRequestTypePUT = 1;
-	RESTRequestTypePOST = 2;
-	RESTRequestTypeDELETE = 3;
-}
-
-message JSONRPCPayload {
-    // JSONRPC version 2 expected a field named "id".
-    // See the JSONRPC spec in the following link for more details:
-    //   https://www.jsonrpc.org/specification#request_object
-    bytes id = 1;
-    // JSONRPC version 2 expects a field named "jsonrpc" with a value of "2.0".
-    // See the JSONRPC spec in the following link for more details:
-    //   https://www.jsonrpc.org/specification#request_object
-    string json_rpc = 2;
-    string method = 3;
-    // The parameters field can be empty, an array or a structure. It is on the server to decide which one
-    // has been sent to it and whether the supplied value is valid.
-    // See the JSONRPC spec in the following link for more details:
-    //   https://www.jsonrpc.org/specification#parameter_structures
-    bytes parameters = 4;
-    map<string, string> headers = 5;
-}
-
-message RelayMeta {
-    int64 block_height = 1;
-    string servicer_public_key = 2;
-    // TODO(M5): Consider renaming `relay_chain` to `rpc_service` or something similar
-    // TODO: Make Chain/Service identifier type consistent in Session and Meta: use Identifiable for Chain/Service in Session (or a string here to match the session)
-    Identifiable relay_chain = 3;
-    Identifiable geo_zone = 4;
-    string signature = 5;  // TECHDEBT: Consolidate with `Signature` proto used elsewhere in the future
-    string application_address = 6;
-}
-
-message RelayResponse {
-    string payload = 1;
-    string servicer_signature = 2;
-}
-
-message AAT {
-    string version = 1;
-    string application_public_key = 2;
-    string client_public_key = 3;
-    string application_signature = 4;
-}
-
-message Identifiable {
-    string id = 1;
-    string name = 2;
-}
-
-
-// RelayReqRes contains a relay request and its response, used for persistence of relay service evidence
-message RelayReqRes {
-    Relay relay = 1;
-    RelayResponse response = 2;
-}
-
-
-
-
-syntax = "proto3";
-
-package poktroll.servicer;
-
-option go_package = "poktroll/x/servicer/types";
-
-// TODO_REFACTOR: See the commened out structure at the bottom of this file for what we should use in prod.
+// Relay is a protobuf containing both the RelayRequest, signed by the Application
+// and the RelayResponse, signed by the Supplier. Together, the serialized tuple is
+// what is inserted into the SMST leaves as values in the Claim/Proof lifecycle.
 message Relay {
     RelayRequest req = 1;
     RelayResponse res = 2;
 }
+
+// RelayMeta is used to hold the metadata for a RelayRequest.
+message RelayRequestMetadata {
+    session.SessionHeader session_header = 1; // The session header for the relay
+    map<string, string> headers = 2; // The headers of the request
+    bytes application_signature = 3; // The signature of the application of the request
+}
+
+// RelayResponse is used to hold the response from a RelayRequest.
+message RelayRequest {
+    RelayRequestMetadata meta = 1;
+    // Every different chain/service may have its own custom payload (e.g. HTTP, JSON, GRPC, non-chain services)
+    oneof relay_payload {
+        JSONRPCPayload json_rpc_payload = 2;
+        RESTPayload rest_payload = 3;
+        // TODO: Add other relay types in the future such as the ones below:
+        // WebSocketsPayload websockets_payload = 4;
+        // GRPCPayload grpc_payload = 5;
+        // GraphQLPayload graphql_payload = 6;
+    }
+}
+
+
+message RelayResponseMetadata {
+    session.SessionHeader session_header = 1; // The session header for the relay
+    map<string, string> headers = 2; // The headers of the response
+    uint32 status_code = 3;
+    string err = 4;
+    bytes supplier_signature = 5; // The signature of the supplier on the response
+}
+
+message RelayResponse {
+    RelayResponseMetadata meta = 1;
+    // Every different chain/service may have its own custom payload (e.g. HTTP, JSON, GRPC, non-chain services)
+    oneof relay_payload {
+        JSONRPCPayload json_rpc_payload = 2;
+        RESTPayload rest_payload = 3;
+    }
+}
+
+
+//     map<string, string> headers = 1;
+//     uint32 status_code = 2;
+//     string err = 3;
+//     bytes payload = 4;
+//     string session_id = 5;
+//     string servicer_address = 6;
+//     bytes servicer_signature = 7;
+// }
+
+// JSONRPCPayload is used to hold the payload and request metadata for a JSON-RPC request.
+// See the JSONRPC spec in the following link for more details: https://www.jsonrpc.org/specification#request_object
+message JSONRPCPayload {
+    bytes id = 1; // JSONRPC version 2 expected a field named "id".
+    string jsonrpc = 2; // JSONRPC version 2 expects a field named "jsonrpc" with a value of "2.0".
+    string method = 3; // The method being invoked on the server.
+    bytes parameters = 4; // The parameters field can be empty, an array or a structure
+
+}
+
+// RESTRequestType is used to hold the type of REST request being made.
+enum RESTRequestType {
+    REST_REQUEST_TYPE_UNKNOWN = 0; // Default value, used for uninitialized fields
+    REST_REQUEST_TYPE_GET = 1;
+    REST_REQUEST_TYPE_PUT = 2;
+    REST_REQUEST_TYPE_POST = 3;
+    REST_REQUEST_TYPE_DELETE = 4;
+}
+
+// RESTPayload is used to hold the payload and request metadata for a REST request.
+message RESTPayload {
+    RESTRequestType request_type = 1;
+    string http_path = 2;
+    string contents = 3;
+    // TODO_INCOMPLETE: Add REST relay payload fields
+}
+
+
+// TODO_REFACTOR: See the commened out structure at the bottom of this file for what we should use in prod.
 
 // Representation of Go's http.Request (simplified naïve implementation)
 message RelayRequest {
@@ -120,17 +106,6 @@ message RelayRequest {
     string application_address = 6;
     bytes application_signature = 7;
 }
-
-message RelayResponse {
-    map<string, string> headers = 1;
-    int32 status_code = 2;
-    string err = 3;
-    bytes payload = 4;
-    string session_id = 5;
-    string servicer_address = 6;
-    bytes servicer_signature = 7;
-}
-
 
 
 message RelayProof {
@@ -156,64 +131,7 @@ message ChallengeProofInvalidData {
 message RelayResponse {
 	option (gogoproto.goproto_getters) = false;
 
-	string signature = 1 [(gogoproto.jsontag) = "signature"];
-	string response = 2 [(gogoproto.jsontag) = "payload"];
-	RelayProof proof = 3 [(gogoproto.jsontag) = "proof", (gogoproto.nullable) = false];
+
+	string response = 1 [(gogoproto.jsontag) = "payload"];
+	RelayProof proof = 2 [(gogoproto.jsontag) = "proof", (gogoproto.nullable) = false];
 }
-
-
-// message Relay {
-//     RelayMeta meta = 1;
-//     // Every different chain/service may have its own custom payload (e.g. HTTP, JSON, GRPC, non-chain services)
-//     oneof relay_payload {
-//         JSONRPCPayload json_rpc_payload = 2;
-//         RESTPayload rest_payload = 3;
-//         // DISCUSS: design and content of other relay types
-//         // GRPCPayload grpc_payload = 3;
-//         // GraphQLPayload graphql_payload = 4;
-//         // WebSocketsPayload websockets_payload = 5;
-//     }
-// }
-
-// // INCOMPLETE: add REST relay payload fields
-// message RESTPayload {
-//     string contents = 1;
-//     string http_path = 2;
-//     RESTRequestType request_type = 3;
-// }
-
-// enum RESTRequestType {
-// 	RESTRequestTypeGET = 0;
-// 	RESTRequestTypePUT = 1;
-// 	RESTRequestTypePOST = 2;
-// 	RESTRequestTypeDELETE = 3;
-// }
-
-// message JSONRPCPayload {
-//     // JSONRPC version 2 expected a field named "id".
-//     // See the JSONRPC spec in the following link for more details:
-//     //   https://www.jsonrpc.org/specification#request_object
-//     bytes id = 1;
-//     // JSONRPC version 2 expects a field named "jsonrpc" with a value of "2.0".
-//     // See the JSONRPC spec in the following link for more details:
-//     //   https://www.jsonrpc.org/specification#request_object
-//     string json_rpc = 2;
-//     string method = 3;
-//     // The parameters field can be empty, an array or a structure. It is on the server to decide which one
-//     // has been sent to it and whether the supplied value is valid.
-//     // See the JSONRPC spec in the following link for more details:
-//     //   https://www.jsonrpc.org/specification#parameter_structures
-//     bytes parameters = 4;
-//     map<string, string> headers = 5;
-// }
-
-// message RelayMeta {
-//     int64 block_height = 1;
-//     string servicer_public_key = 2;
-//     // TODO(M5): Consider renaming `relay_chain` to `rpc_service` or something similar
-//     // TODO: Make Chain/Service identifier type consistent in Session and Meta: use Identifiable for Chain/Service in Session (or a string here to match the session)
-//     Identifiable relay_chain = 3;
-//     Identifiable geo_zone = 4;
-//     string signature = 5;  // TECHDEBT: Consolidate with `Signature` proto used elsewhere in the future
-//     string application_address = 6;
-// }

--- a/proto/pocket/service/relay.proto
+++ b/proto/pocket/service/relay.proto
@@ -17,11 +17,11 @@ message Relay {
     RelayResponse res = 2;
 }
 
-// RelayMeta is used to hold the metadata for a RelayRequest.
+
+// RelayRequestMetadata is used to hold the metadata for a RelayRequest.
 message RelayRequestMetadata {
     session.SessionHeader session_header = 1; // The session header for the relay
-    map<string, string> headers = 2; // The headers of the request
-    bytes application_signature = 3; // The signature of the application of the request
+    bytes application_signature = 2; // The signature of the application of the request
 }
 
 // RelayResponse is used to hold the response from a RelayRequest.
@@ -29,42 +29,20 @@ message RelayRequest {
     RelayRequestMetadata meta = 1;
     // TODO: Add other relay types in the future such as the ones below:
     oneof payload {
-        JSONRPCPayload json_rpc_payload = 2;
-        RESTPayload rest_payload = 3;
-        // WebSocketsPayload websockets_payload = 4;
-        // GRPCPayload grpc_payload = 5;
-        // GraphQLPayload graphql_payload = 6;
+        JSONRPCRequestPayload json_rpc_payload = 2;
+        RESTRequestPayload rest_payload = 3;
+        // WebSocketsRequestPayload websockets_payload = 4;
+        // GRPCRequestPayload grpc_payload = 5;
+        // GraphQLRequestPayload graphql_payload = 6;
     }
 }
 
-// RelayResponseMetadata is used to hold the metadata for a RelayResponse
-message RelayResponseMetadata {
-    session.SessionHeader session_header = 1; // The session header for the relay
-    map<string, string> headers = 2; // The headers of the response
-    uint32 status_code = 3; // The status code of the response
-    string err = 4; // The error message of the response
-    bytes supplier_signature = 5; // The signature of the supplier on the response
-}
-
-// RelayResponse is used to hold the response to a RelayRequest.
-message RelayResponse {
-    RelayResponseMetadata meta = 1;
-    // TODO: Add other relay types in the future such as the ones below:
-    oneof payload {
-        JSONRPCPayload json_rpc_payload = 2;
-        RESTPayload rest_payload = 3;
-        // WebSocketsPayload websockets_payload = 4;
-        // GRPCPayload grpc_payload = 5;
-        // GraphQLPayload graphql_payload = 6;
-    }
-}
-
-// JSONRPCPayload is used to hold the payload and request metadata for a JSON-RPC request.
+// JSONRPCRequestPayload is used to hold the payload for a JSON-RPC request.
 // See the JSONRPC spec in the following link for more details: https://www.jsonrpc.org/specification#request_object
-message JSONRPCPayload {
-    bytes id = 1; // JSONRPC version 2 expected a field named "id".
-    string jsonrpc = 2; // JSONRPC version 2 expects a field named "jsonrpc" with a value of "2.0".
-    string method = 3; // The method being invoked on the server.
+message JSONRPCRequestPayload {
+    bytes id = 1; // JSONRPC version 2 expected a field named "id"
+    string jsonrpc = 2; // JSONRPC version 2 expects a field named "jsonrpc" with a value of "2.0"
+    string method = 3; // The method being invoked on the server
     map<string, string> parameters = 4; // The parameters field can be empty, an array or a structure
     bytes data = 5;
 }
@@ -79,9 +57,39 @@ enum RESTRequestType {
 }
 
 // RESTPayload is used to hold the payload and request metadata for a REST request.
-message RESTPayload {
+message RESTRequestPayload {
     RESTRequestType request_type = 1;
     string http_path = 2;
     string contents = 3;
+    map<string, string> headers = 4; // The headers of the request
     // TODO_INCOMPLETE: Add REST relay payload fields
+}
+
+// RelayResponse is used to hold the response to a RelayRequest.
+message RelayResponse {
+    RelayResponseMetadata meta = 1;
+    // TODO: Add other relay types in the future such as the ones below:
+    oneof payload {
+        JSONRPCResponsePayload json_rpc_payload = 2;
+        RESTResponsePayload rest_payload = 3;
+        // WebSocketsResponsePayload websockets_payload = 4;
+        // GRPCResponsePayload grpc_payload = 5;
+        // GraphQLResponsePayload graphql_payload = 6;
+    }
+}
+
+// RelayResponseMetadata is used to hold the metadata for a RelayResponse
+message RelayResponseMetadata {
+    session.SessionHeader session_header = 1; // The session header for the relay
+    bytes supplier_signature = 2; // The signature of the supplier on the response
+}
+
+message JSONRPCResponsePayload {
+    uint32 status_code = 1; // The status code of the response
+    string err = 2; // The error message of the response
+}
+
+message RESTResponsePayload {
+    uint32 status_code = 1; // The status code of the response
+    string err = 2; // The error message of the response
 }

--- a/proto/pocket/service/relay.proto
+++ b/proto/pocket/service/relay.proto
@@ -27,44 +27,37 @@ message RelayRequestMetadata {
 // RelayResponse is used to hold the response from a RelayRequest.
 message RelayRequest {
     RelayRequestMetadata meta = 1;
-    // Every different chain/service may have its own custom payload (e.g. HTTP, JSON, GRPC, non-chain services)
-    oneof relay_payload {
+    // TODO: Add other relay types in the future such as the ones below:
+    oneof payload {
         JSONRPCPayload json_rpc_payload = 2;
         RESTPayload rest_payload = 3;
-        // TODO: Add other relay types in the future such as the ones below:
         // WebSocketsPayload websockets_payload = 4;
         // GRPCPayload grpc_payload = 5;
         // GraphQLPayload graphql_payload = 6;
     }
 }
 
-
+// RelayResponseMetadata is used to hold the metadata for a RelayResponse
 message RelayResponseMetadata {
     session.SessionHeader session_header = 1; // The session header for the relay
     map<string, string> headers = 2; // The headers of the response
-    uint32 status_code = 3;
-    string err = 4;
+    uint32 status_code = 3; // The status code of the response
+    string err = 4; // The error message of the response
     bytes supplier_signature = 5; // The signature of the supplier on the response
 }
 
+// RelayResponse is used to hold the response to a RelayRequest.
 message RelayResponse {
     RelayResponseMetadata meta = 1;
-    // Every different chain/service may have its own custom payload (e.g. HTTP, JSON, GRPC, non-chain services)
-    oneof relay_payload {
+    // TODO: Add other relay types in the future such as the ones below:
+    oneof payload {
         JSONRPCPayload json_rpc_payload = 2;
         RESTPayload rest_payload = 3;
+        // WebSocketsPayload websockets_payload = 4;
+        // GRPCPayload grpc_payload = 5;
+        // GraphQLPayload graphql_payload = 6;
     }
 }
-
-
-//     map<string, string> headers = 1;
-//     uint32 status_code = 2;
-//     string err = 3;
-//     bytes payload = 4;
-//     string session_id = 5;
-//     string servicer_address = 6;
-//     bytes servicer_signature = 7;
-// }
 
 // JSONRPCPayload is used to hold the payload and request metadata for a JSON-RPC request.
 // See the JSONRPC spec in the following link for more details: https://www.jsonrpc.org/specification#request_object
@@ -72,8 +65,8 @@ message JSONRPCPayload {
     bytes id = 1; // JSONRPC version 2 expected a field named "id".
     string jsonrpc = 2; // JSONRPC version 2 expects a field named "jsonrpc" with a value of "2.0".
     string method = 3; // The method being invoked on the server.
-    bytes parameters = 4; // The parameters field can be empty, an array or a structure
-
+    map<string, string> parameters = 4; // The parameters field can be empty, an array or a structure
+    bytes data = 5;
 }
 
 // RESTRequestType is used to hold the type of REST request being made.
@@ -91,47 +84,4 @@ message RESTPayload {
     string http_path = 2;
     string contents = 3;
     // TODO_INCOMPLETE: Add REST relay payload fields
-}
-
-
-// TODO_REFACTOR: See the commened out structure at the bottom of this file for what we should use in prod.
-
-// Representation of Go's http.Request (simplified naïve implementation)
-message RelayRequest {
-    map<string, string> headers = 1;
-    string method = 2;
-    string url = 3;
-    bytes payload = 4;
-    string session_id = 5;
-    string application_address = 6;
-    bytes application_signature = 7;
-}
-
-
-message RelayProof {
-	option (gogoproto.goproto_getters) = false;
-
-	string requestHash = 1 [(gogoproto.jsontag) = "request_hash"];
-	int64 entropy = 2 [(gogoproto.jsontag) = "entropy"];
-	int64 sessionBlockHeight = 3 [(gogoproto.jsontag) = "session_block_height"];
-	string servicerPubKey = 4 [(gogoproto.jsontag) = "servicer_pub_key"];
-	string blockchain = 5 [(gogoproto.jsontag) = "blockchain"];
-	AAT token = 6 [(gogoproto.jsontag) = "aat", (gogoproto.nullable) = false];
-	string signature = 7 [(gogoproto.jsontag) = "signature"];
-}
-
-message ChallengeProofInvalidData {
-	option (gogoproto.goproto_getters) = false;
-
-	repeated RelayResponse majorityResponses = 1 [(gogoproto.jsontag) = "majority_responses", (gogoproto.nullable) = false];
-	RelayResponse minorityResponse = 2 [(gogoproto.jsontag) = "minority_response", (gogoproto.nullable) = false];
-	bytes reporterAddress = 3 [(gogoproto.jsontag) = "reporters_address", (gogoproto.casttype) = "github.com/pokt-network/pocket-core/types.Address"];
-}
-
-message RelayResponse {
-	option (gogoproto.goproto_getters) = false;
-
-
-	string response = 1 [(gogoproto.jsontag) = "payload"];
-	RelayProof proof = 2 [(gogoproto.jsontag) = "proof", (gogoproto.nullable) = false];
 }

--- a/proto/pocket/service/relay.proto
+++ b/proto/pocket/service/relay.proto
@@ -4,5 +4,216 @@ package pocket.service;
 option go_package = "pocket/x/service/types";
 
 message Relay {
-  
+
 }
+
+
+
+syntax = "proto3";
+
+package core;
+
+option go_package = "github.com/pokt-network/pocket/shared/core/types";
+
+message Relay {
+    RelayMeta meta = 1;
+    // Every different chain/service may have its own custom payload (e.g. HTTP, JSON, GRPC, non-chain services)
+    oneof relay_payload {
+        JSONRPCPayload json_rpc_payload = 2;
+        RESTPayload rest_payload = 3;
+        // DISCUSS: design and content of other relay types
+        // GRPCPayload grpc_payload = 3;
+        // GraphQLPayload graphql_payload = 4;
+        // WebSocketsPayload websockets_payload = 5;
+    }
+}
+
+// INCOMPLETE: add REST relay payload fields
+message RESTPayload {
+    string contents = 1;
+    string http_path = 2;
+    RESTRequestType request_type = 3;
+}
+
+enum RESTRequestType {
+	RESTRequestTypeGET = 0;
+	RESTRequestTypePUT = 1;
+	RESTRequestTypePOST = 2;
+	RESTRequestTypeDELETE = 3;
+}
+
+message JSONRPCPayload {
+    // JSONRPC version 2 expected a field named "id".
+    // See the JSONRPC spec in the following link for more details:
+    //   https://www.jsonrpc.org/specification#request_object
+    bytes id = 1;
+    // JSONRPC version 2 expects a field named "jsonrpc" with a value of "2.0".
+    // See the JSONRPC spec in the following link for more details:
+    //   https://www.jsonrpc.org/specification#request_object
+    string json_rpc = 2;
+    string method = 3;
+    // The parameters field can be empty, an array or a structure. It is on the server to decide which one
+    // has been sent to it and whether the supplied value is valid.
+    // See the JSONRPC spec in the following link for more details:
+    //   https://www.jsonrpc.org/specification#parameter_structures
+    bytes parameters = 4;
+    map<string, string> headers = 5;
+}
+
+message RelayMeta {
+    int64 block_height = 1;
+    string servicer_public_key = 2;
+    // TODO(M5): Consider renaming `relay_chain` to `rpc_service` or something similar
+    // TODO: Make Chain/Service identifier type consistent in Session and Meta: use Identifiable for Chain/Service in Session (or a string here to match the session)
+    Identifiable relay_chain = 3;
+    Identifiable geo_zone = 4;
+    string signature = 5;  // TECHDEBT: Consolidate with `Signature` proto used elsewhere in the future
+    string application_address = 6;
+}
+
+message RelayResponse {
+    string payload = 1;
+    string servicer_signature = 2;
+}
+
+message AAT {
+    string version = 1;
+    string application_public_key = 2;
+    string client_public_key = 3;
+    string application_signature = 4;
+}
+
+message Identifiable {
+    string id = 1;
+    string name = 2;
+}
+
+
+// RelayReqRes contains a relay request and its response, used for persistence of relay service evidence
+message RelayReqRes {
+    Relay relay = 1;
+    RelayResponse response = 2;
+}
+
+
+
+
+syntax = "proto3";
+
+package poktroll.servicer;
+
+option go_package = "poktroll/x/servicer/types";
+
+// TODO_REFACTOR: See the commened out structure at the bottom of this file for what we should use in prod.
+message Relay {
+    RelayRequest req = 1;
+    RelayResponse res = 2;
+}
+
+// Representation of Go's http.Request (simplified naïve implementation)
+message RelayRequest {
+    map<string, string> headers = 1;
+    string method = 2;
+    string url = 3;
+    bytes payload = 4;
+    string session_id = 5;
+    string application_address = 6;
+    bytes application_signature = 7;
+}
+
+message RelayResponse {
+    map<string, string> headers = 1;
+    int32 status_code = 2;
+    string err = 3;
+    bytes payload = 4;
+    string session_id = 5;
+    string servicer_address = 6;
+    bytes servicer_signature = 7;
+}
+
+
+
+message RelayProof {
+	option (gogoproto.goproto_getters) = false;
+
+	string requestHash = 1 [(gogoproto.jsontag) = "request_hash"];
+	int64 entropy = 2 [(gogoproto.jsontag) = "entropy"];
+	int64 sessionBlockHeight = 3 [(gogoproto.jsontag) = "session_block_height"];
+	string servicerPubKey = 4 [(gogoproto.jsontag) = "servicer_pub_key"];
+	string blockchain = 5 [(gogoproto.jsontag) = "blockchain"];
+	AAT token = 6 [(gogoproto.jsontag) = "aat", (gogoproto.nullable) = false];
+	string signature = 7 [(gogoproto.jsontag) = "signature"];
+}
+
+message ChallengeProofInvalidData {
+	option (gogoproto.goproto_getters) = false;
+
+	repeated RelayResponse majorityResponses = 1 [(gogoproto.jsontag) = "majority_responses", (gogoproto.nullable) = false];
+	RelayResponse minorityResponse = 2 [(gogoproto.jsontag) = "minority_response", (gogoproto.nullable) = false];
+	bytes reporterAddress = 3 [(gogoproto.jsontag) = "reporters_address", (gogoproto.casttype) = "github.com/pokt-network/pocket-core/types.Address"];
+}
+
+message RelayResponse {
+	option (gogoproto.goproto_getters) = false;
+
+	string signature = 1 [(gogoproto.jsontag) = "signature"];
+	string response = 2 [(gogoproto.jsontag) = "payload"];
+	RelayProof proof = 3 [(gogoproto.jsontag) = "proof", (gogoproto.nullable) = false];
+}
+
+
+// message Relay {
+//     RelayMeta meta = 1;
+//     // Every different chain/service may have its own custom payload (e.g. HTTP, JSON, GRPC, non-chain services)
+//     oneof relay_payload {
+//         JSONRPCPayload json_rpc_payload = 2;
+//         RESTPayload rest_payload = 3;
+//         // DISCUSS: design and content of other relay types
+//         // GRPCPayload grpc_payload = 3;
+//         // GraphQLPayload graphql_payload = 4;
+//         // WebSocketsPayload websockets_payload = 5;
+//     }
+// }
+
+// // INCOMPLETE: add REST relay payload fields
+// message RESTPayload {
+//     string contents = 1;
+//     string http_path = 2;
+//     RESTRequestType request_type = 3;
+// }
+
+// enum RESTRequestType {
+// 	RESTRequestTypeGET = 0;
+// 	RESTRequestTypePUT = 1;
+// 	RESTRequestTypePOST = 2;
+// 	RESTRequestTypeDELETE = 3;
+// }
+
+// message JSONRPCPayload {
+//     // JSONRPC version 2 expected a field named "id".
+//     // See the JSONRPC spec in the following link for more details:
+//     //   https://www.jsonrpc.org/specification#request_object
+//     bytes id = 1;
+//     // JSONRPC version 2 expects a field named "jsonrpc" with a value of "2.0".
+//     // See the JSONRPC spec in the following link for more details:
+//     //   https://www.jsonrpc.org/specification#request_object
+//     string json_rpc = 2;
+//     string method = 3;
+//     // The parameters field can be empty, an array or a structure. It is on the server to decide which one
+//     // has been sent to it and whether the supplied value is valid.
+//     // See the JSONRPC spec in the following link for more details:
+//     //   https://www.jsonrpc.org/specification#parameter_structures
+//     bytes parameters = 4;
+//     map<string, string> headers = 5;
+// }
+
+// message RelayMeta {
+//     int64 block_height = 1;
+//     string servicer_public_key = 2;
+//     // TODO(M5): Consider renaming `relay_chain` to `rpc_service` or something similar
+//     // TODO: Make Chain/Service identifier type consistent in Session and Meta: use Identifiable for Chain/Service in Session (or a string here to match the session)
+//     Identifiable relay_chain = 3;
+//     Identifiable geo_zone = 4;
+//     string signature = 5;  // TECHDEBT: Consolidate with `Signature` proto used elsewhere in the future
+//     string application_address = 6;
+// }


### PR DESCRIPTION
## Summary

Scaffolding & adding the `Relay` type

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Oct 23 18:07 UTC
This pull request includes the following changes:

1. In the go.mod file, the dependency `google.golang.org/genproto` has been removed from the require section.
2. In the go.mod file, the dependency `google.golang.org/genproto` has been added to the require section.
3. A new file named `relay.proto` has been added in the `proto/pocket/service` directory. This file contains protobuf message definitions related to relaying requests and responses.
4. The `relay.proto` file imports other protobuf files and defines message structures for relay requests, relay responses, and their metadata. It also includes definitions for JSON-RPC request and response payloads, REST request payloads, and REST response payloads.

Please review these changes and provide any necessary feedback.
<!-- reviewpad:summarize:end -->

## Issue

Part of #10

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make test_all_unit`
- [x] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updated documentation and left TODOs throughout the codebase
