### PR TITLE
[Gateway] Add the Gateway type definition

### DIFF
--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -46634,6 +46634,167 @@ paths:
                   additionalProperties: {}
       tags:
         - Query
+  /pocket/gateway/gateway:
+    get:
+      operationId: PocketGatewayGatewayAll
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              gateway:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    address:
+                      type: string
+              pagination:
+                type: object
+                properties:
+                  next_key:
+                    type: string
+                    format: byte
+                    description: |-
+                      next_key is the key to be passed to PageRequest.key to
+                      query the next page most efficiently. It will be empty if
+                      there are no more results.
+                  total:
+                    type: string
+                    format: uint64
+                    title: >-
+                      total is total number of results available if
+                      PageRequest.count_total
+
+                      was set, its value is undefined otherwise
+                description: >-
+                  PageResponse is to be embedded in gRPC response messages where
+                  the
+
+                  corresponding request message has used PageRequest.
+
+                   message SomeResponse {
+                           repeated Bar results = 1;
+                           PageResponse page = 2;
+                   }
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    '@type':
+                      type: string
+                  additionalProperties: {}
+      parameters:
+        - name: pagination.key
+          description: |-
+            key is a value returned in PageResponse.next_key to begin
+            querying the next page most efficiently. Only one of offset or key
+            should be set.
+          in: query
+          required: false
+          type: string
+          format: byte
+        - name: pagination.offset
+          description: >-
+            offset is a numeric offset that can be used when key is unavailable.
+
+            It is less efficient than using key. Only one of offset or key
+            should
+
+            be set.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.limit
+          description: >-
+            limit is the total number of results to be returned in the result
+            page.
+
+            If left empty it will default to a value to be set by each app.
+          in: query
+          required: false
+          type: string
+          format: uint64
+        - name: pagination.count_total
+          description: >-
+            count_total is set to true  to indicate that the result set should
+            include
+
+            a count of the total number of items available for pagination in
+            UIs.
+
+            count_total is only respected when offset is used. It is ignored
+            when key
+
+            is set.
+          in: query
+          required: false
+          type: boolean
+        - name: pagination.reverse
+          description: >-
+            reverse is set to true if results are to be returned in the
+            descending order.
+
+
+            Since: cosmos-sdk 0.43
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - Query
+  /pocket/gateway/gateway/{address}:
+    get:
+      summary: Queries a list of Gateway items.
+      operationId: PocketGatewayGateway
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              gateway:
+                type: object
+                properties:
+                  address:
+                    type: string
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    '@type':
+                      type: string
+                  additionalProperties: {}
+      parameters:
+        - name: address
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
   /pocket/gateway/params:
     get:
       summary: Parameters queries the parameters of the module.
@@ -75777,9 +75938,58 @@ definitions:
         description: params holds all the parameters of this module.
         type: object
     description: QueryParamsResponse is response type for the Query/Params RPC method.
+  pocket.gateway.Gateway:
+    type: object
+    properties:
+      address:
+        type: string
   pocket.gateway.Params:
     type: object
     description: Params defines the parameters for the module.
+  pocket.gateway.QueryAllGatewayResponse:
+    type: object
+    properties:
+      gateway:
+        type: array
+        items:
+          type: object
+          properties:
+            address:
+              type: string
+      pagination:
+        type: object
+        properties:
+          next_key:
+            type: string
+            format: byte
+            description: |-
+              next_key is the key to be passed to PageRequest.key to
+              query the next page most efficiently. It will be empty if
+              there are no more results.
+          total:
+            type: string
+            format: uint64
+            title: >-
+              total is total number of results available if
+              PageRequest.count_total
+
+              was set, its value is undefined otherwise
+        description: |-
+          PageResponse is to be embedded in gRPC response messages where the
+          corresponding request message has used PageRequest.
+
+           message SomeResponse {
+                   repeated Bar results = 1;
+                   PageResponse page = 2;
+           }
+  pocket.gateway.QueryGetGatewayResponse:
+    type: object
+    properties:
+      gateway:
+        type: object
+        properties:
+          address:
+            type: string
   pocket.gateway.QueryParamsResponse:
     type: object
     properties:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cosmossdk.io/api v0.3.1
 	github.com/cometbft/cometbft v0.37.2
 	github.com/cometbft/cometbft-db v0.8.0
+	github.com/cosmos/cosmos-proto v1.0.0-beta.2
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/cosmos/gogoproto v1.4.10
 	github.com/cosmos/ibc-go/v7 v7.1.0
@@ -17,6 +18,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
+	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	google.golang.org/grpc v1.56.1
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -61,7 +63,6 @@ require (
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
-	github.com/cosmos/cosmos-proto v1.0.0-beta.2 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/iavl v0.20.0 // indirect
@@ -258,7 +259,6 @@ require (
 	gonum.org/v1/gonum v0.11.0 // indirect
 	google.golang.org/api v0.122.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	cosmossdk.io/api v0.3.1
 	github.com/cometbft/cometbft v0.37.2
 	github.com/cometbft/cometbft-db v0.8.0
-	github.com/cosmos/cosmos-proto v1.0.0-beta.2
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/cosmos/gogoproto v1.4.10
 	github.com/cosmos/ibc-go/v7 v7.1.0
@@ -18,7 +17,6 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
-	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	google.golang.org/grpc v1.56.1
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -63,6 +61,7 @@ require (
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
+	github.com/cosmos/cosmos-proto v1.0.0-beta.2 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/iavl v0.20.0 // indirect
@@ -259,6 +258,7 @@ require (
 	gonum.org/v1/gonum v0.11.0 // indirect
 	google.golang.org/api v0.122.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/proto/pocket/gateway/gateway.proto
+++ b/proto/pocket/gateway/gateway.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package pocket.gateway;
+
+option go_package = "pocket/x/gateway/types";
+
+message Gateway {
+  string address = 1; 
+  
+}
+

--- a/proto/pocket/gateway/gateway.proto
+++ b/proto/pocket/gateway/gateway.proto
@@ -3,11 +3,7 @@ package pocket.gateway;
 
 option go_package = "pocket/x/gateway/types";
 
-import "cosmos_proto/cosmos.proto";
-import "cosmos/base/v1beta1/coin.proto";
-
 message Gateway {
-  string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  cosmos.base.v1beta1.Coin stake = 2;
+  string address = 1;
 }
 

--- a/proto/pocket/gateway/gateway.proto
+++ b/proto/pocket/gateway/gateway.proto
@@ -3,8 +3,11 @@ package pocket.gateway;
 
 option go_package = "pocket/x/gateway/types";
 
+import "cosmos_proto/cosmos.proto";
+import "cosmos/base/v1beta1/coin.proto";
+
 message Gateway {
-  string address = 1; 
-  
+  string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  cosmos.base.v1beta1.Coin stake = 2;
 }
 

--- a/proto/pocket/gateway/genesis.proto
+++ b/proto/pocket/gateway/genesis.proto
@@ -1,12 +1,16 @@
 syntax = "proto3";
+
 package pocket.gateway;
 
 import "gogoproto/gogo.proto";
 import "pocket/gateway/params.proto";
+import "pocket/gateway/gateway.proto";
 
 option go_package = "pocket/x/gateway/types";
 
 // GenesisState defines the gateway module's genesis state.
 message GenesisState {
-  Params params = 1 [(gogoproto.nullable) = false];
+           Params  params      = 1 [(gogoproto.nullable) = false];
+  repeated Gateway gatewayList = 2 [(gogoproto.nullable) = false];
 }
+

--- a/proto/pocket/gateway/query.proto
+++ b/proto/pocket/gateway/query.proto
@@ -1,26 +1,58 @@
 syntax = "proto3";
+
 package pocket.gateway;
 
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 import "pocket/gateway/params.proto";
+import "pocket/gateway/gateway.proto";
 
 option go_package = "pocket/x/gateway/types";
 
 // Query defines the gRPC querier service.
 service Query {
+  
   // Parameters queries the parameters of the module.
-  rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
+  rpc Params (QueryParamsRequest) returns (QueryParamsResponse) {
     option (google.api.http).get = "/pocket/gateway/params";
+  
+  }
+  
+  // Queries a list of Gateway items.
+  rpc Gateway    (QueryGetGatewayRequest) returns (QueryGetGatewayResponse) {
+    option (google.api.http).get = "/pocket/gateway/gateway/{address}";
+  
+  }
+  rpc GatewayAll (QueryAllGatewayRequest) returns (QueryAllGatewayResponse) {
+    option (google.api.http).get = "/pocket/gateway/gateway";
+  
   }
 }
-
 // QueryParamsRequest is request type for the Query/Params RPC method.
 message QueryParamsRequest {}
 
 // QueryParamsResponse is response type for the Query/Params RPC method.
 message QueryParamsResponse {
+  
   // params holds all the parameters of this module.
   Params params = 1 [(gogoproto.nullable) = false];
 }
+
+message QueryGetGatewayRequest {
+  string address = 1;
+}
+
+message QueryGetGatewayResponse {
+  Gateway gateway = 1 [(gogoproto.nullable) = false];
+}
+
+message QueryAllGatewayRequest {
+  cosmos.base.query.v1beta1.PageRequest pagination = 1;
+}
+
+message QueryAllGatewayResponse {
+  repeated Gateway                                gateway    = 1 [(gogoproto.nullable) = false];
+           cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+

--- a/x/gateway/client/cli/query.go
+++ b/x/gateway/client/cli/query.go
@@ -25,6 +25,8 @@ func GetQueryCmd(queryRoute string) *cobra.Command {
 	}
 
 	cmd.AddCommand(CmdQueryParams())
+	cmd.AddCommand(CmdListGateway())
+	cmd.AddCommand(CmdShowGateway())
 	// this line is used by starport scaffolding # 1
 
 	return cmd

--- a/x/gateway/client/cli/query_gateway.go
+++ b/x/gateway/client/cli/query_gateway.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+
+	"pocket/x/gateway/types"
+)
+
+func CmdListGateway() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list-gateway",
+		Short: "list all gateway",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			params := &types.QueryAllGatewayRequest{
+				Pagination: pageReq,
+			}
+
+			res, err := queryClient.GatewayAll(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddPaginationFlagsToCmd(cmd, cmd.Use)
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func CmdShowGateway() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show-gateway [address]",
+		Short: "shows a gateway",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			argAddress := args[0]
+
+			params := &types.QueryGetGatewayRequest{
+				Address: argAddress,
+			}
+
+			res, err := queryClient.Gateway(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/gateway/client/cli/query_gateway.go
+++ b/x/gateway/client/cli/query_gateway.go
@@ -11,7 +11,7 @@ import (
 func CmdListGateway() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list-gateway",
-		Short: "list all gateway",
+		Short: "list all gateways",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {

--- a/x/gateway/client/cli/query_gateway_test.go
+++ b/x/gateway/client/cli/query_gateway_test.go
@@ -1,0 +1,160 @@
+package cli_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	tmcli "github.com/cometbft/cometbft/libs/cli"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"pocket/testutil/network"
+	"pocket/testutil/nullify"
+	"pocket/x/gateway/client/cli"
+	"pocket/x/gateway/types"
+)
+
+// Prevent strconv unused error
+var _ = strconv.IntSize
+
+func networkWithGatewayObjects(t *testing.T, n int) (*network.Network, []types.Gateway) {
+	t.Helper()
+	cfg := network.DefaultConfig()
+	state := types.GenesisState{}
+	for i := 0; i < n; i++ {
+		gateway := types.Gateway{
+			Address: strconv.Itoa(i),
+		}
+		nullify.Fill(&gateway)
+		state.GatewayList = append(state.GatewayList, gateway)
+	}
+	buf, err := cfg.Codec.MarshalJSON(&state)
+	require.NoError(t, err)
+	cfg.GenesisState[types.ModuleName] = buf
+	return network.New(t, cfg), state.GatewayList
+}
+
+func TestShowGateway(t *testing.T) {
+	net, objs := networkWithGatewayObjects(t, 2)
+
+	ctx := net.Validators[0].ClientCtx
+	common := []string{
+		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+	}
+	tests := []struct {
+		desc      string
+		idAddress string
+
+		args []string
+		err  error
+		obj  types.Gateway
+	}{
+		{
+			desc:      "found",
+			idAddress: objs[0].Address,
+
+			args: common,
+			obj:  objs[0],
+		},
+		{
+			desc:      "not found",
+			idAddress: strconv.Itoa(100000),
+
+			args: common,
+			err:  status.Error(codes.NotFound, "not found"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			args := []string{
+				tc.idAddress,
+			}
+			args = append(args, tc.args...)
+			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdShowGateway(), args)
+			if tc.err != nil {
+				stat, ok := status.FromError(tc.err)
+				require.True(t, ok)
+				require.ErrorIs(t, stat.Err(), tc.err)
+			} else {
+				require.NoError(t, err)
+				var resp types.QueryGetGatewayResponse
+				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+				require.NotNil(t, resp.Gateway)
+				require.Equal(t,
+					nullify.Fill(&tc.obj),
+					nullify.Fill(&resp.Gateway),
+				)
+			}
+		})
+	}
+}
+
+func TestListGateway(t *testing.T) {
+	net, objs := networkWithGatewayObjects(t, 5)
+
+	ctx := net.Validators[0].ClientCtx
+	request := func(next []byte, offset, limit uint64, total bool) []string {
+		args := []string{
+			fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+		}
+		if next == nil {
+			args = append(args, fmt.Sprintf("--%s=%d", flags.FlagOffset, offset))
+		} else {
+			args = append(args, fmt.Sprintf("--%s=%s", flags.FlagPageKey, next))
+		}
+		args = append(args, fmt.Sprintf("--%s=%d", flags.FlagLimit, limit))
+		if total {
+			args = append(args, fmt.Sprintf("--%s", flags.FlagCountTotal))
+		}
+		return args
+	}
+	t.Run("ByOffset", func(t *testing.T) {
+		step := 2
+		for i := 0; i < len(objs); i += step {
+			args := request(nil, uint64(i), uint64(step), false)
+			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListGateway(), args)
+			require.NoError(t, err)
+			var resp types.QueryAllGatewayResponse
+			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.LessOrEqual(t, len(resp.Gateway), step)
+			require.Subset(t,
+				nullify.Fill(objs),
+				nullify.Fill(resp.Gateway),
+			)
+		}
+	})
+	t.Run("ByKey", func(t *testing.T) {
+		step := 2
+		var next []byte
+		for i := 0; i < len(objs); i += step {
+			args := request(next, 0, uint64(step), false)
+			out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListGateway(), args)
+			require.NoError(t, err)
+			var resp types.QueryAllGatewayResponse
+			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+			require.LessOrEqual(t, len(resp.Gateway), step)
+			require.Subset(t,
+				nullify.Fill(objs),
+				nullify.Fill(resp.Gateway),
+			)
+			next = resp.Pagination.NextKey
+		}
+	})
+	t.Run("Total", func(t *testing.T) {
+		args := request(nil, 0, uint64(len(objs)), true)
+		out, err := clitestutil.ExecTestCLICmd(ctx, cli.CmdListGateway(), args)
+		require.NoError(t, err)
+		var resp types.QueryAllGatewayResponse
+		require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
+		require.NoError(t, err)
+		require.Equal(t, len(objs), int(resp.Pagination.Total))
+		require.ElementsMatch(t,
+			nullify.Fill(objs),
+			nullify.Fill(resp.Gateway),
+		)
+	})
+}

--- a/x/gateway/genesis.go
+++ b/x/gateway/genesis.go
@@ -8,6 +8,10 @@ import (
 
 // InitGenesis initializes the module's state from a provided genesis state.
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
+	// Set all the gateway
+	for _, elem := range genState.GatewayList {
+		k.SetGateway(ctx, elem)
+	}
 	// this line is used by starport scaffolding # genesis/module/init
 	k.SetParams(ctx, genState.Params)
 }
@@ -17,6 +21,7 @@ func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
 	genesis.Params = k.GetParams(ctx)
 
+	genesis.GatewayList = k.GetAllGateway(ctx)
 	// this line is used by starport scaffolding # genesis/module/export
 
 	return genesis

--- a/x/gateway/genesis_test.go
+++ b/x/gateway/genesis_test.go
@@ -14,6 +14,14 @@ func TestGenesis(t *testing.T) {
 	genesisState := types.GenesisState{
 		Params: types.DefaultParams(),
 
+		GatewayList: []types.Gateway{
+			{
+				Address: "0",
+			},
+			{
+				Address: "1",
+			},
+		},
 		// this line is used by starport scaffolding # genesis/test/state
 	}
 
@@ -25,5 +33,6 @@ func TestGenesis(t *testing.T) {
 	nullify.Fill(&genesisState)
 	nullify.Fill(got)
 
+	require.ElementsMatch(t, genesisState.GatewayList, got.GatewayList)
 	// this line is used by starport scaffolding # genesis/test/assert
 }

--- a/x/gateway/keeper/gateway.go
+++ b/x/gateway/keeper/gateway.go
@@ -1,0 +1,63 @@
+package keeper
+
+import (
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"pocket/x/gateway/types"
+)
+
+// SetGateway set a specific gateway in the store from its index
+func (k Keeper) SetGateway(ctx sdk.Context, gateway types.Gateway) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.GatewayKeyPrefix))
+	b := k.cdc.MustMarshal(&gateway)
+	store.Set(types.GatewayKey(
+		gateway.Address,
+	), b)
+}
+
+// GetGateway returns a gateway from its index
+func (k Keeper) GetGateway(
+	ctx sdk.Context,
+	address string,
+
+) (val types.Gateway, found bool) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.GatewayKeyPrefix))
+
+	b := store.Get(types.GatewayKey(
+		address,
+	))
+	if b == nil {
+		return val, false
+	}
+
+	k.cdc.MustUnmarshal(b, &val)
+	return val, true
+}
+
+// RemoveGateway removes a gateway from the store
+func (k Keeper) RemoveGateway(
+	ctx sdk.Context,
+	address string,
+
+) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.GatewayKeyPrefix))
+	store.Delete(types.GatewayKey(
+		address,
+	))
+}
+
+// GetAllGateway returns all gateway
+func (k Keeper) GetAllGateway(ctx sdk.Context) (list []types.Gateway) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.GatewayKeyPrefix))
+	iterator := sdk.KVStorePrefixIterator(store, []byte{})
+
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		var val types.Gateway
+		k.cdc.MustUnmarshal(iterator.Value(), &val)
+		list = append(list, val)
+	}
+
+	return
+}

--- a/x/gateway/keeper/gateway.go
+++ b/x/gateway/keeper/gateway.go
@@ -46,7 +46,7 @@ func (k Keeper) RemoveGateway(
 	))
 }
 
-// GetAllGateway returns all gateway
+// GetAllGateway returns all gateways
 func (k Keeper) GetAllGateway(ctx sdk.Context) (list []types.Gateway) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.GatewayKeyPrefix))
 	iterator := sdk.KVStorePrefixIterator(store, []byte{})

--- a/x/gateway/keeper/gateway_test.go
+++ b/x/gateway/keeper/gateway_test.go
@@ -1,0 +1,63 @@
+package keeper_test
+
+import (
+	"strconv"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	keepertest "pocket/testutil/keeper"
+	"pocket/testutil/nullify"
+	"pocket/x/gateway/keeper"
+	"pocket/x/gateway/types"
+)
+
+// Prevent strconv unused error
+var _ = strconv.IntSize
+
+func createNGateway(keeper *keeper.Keeper, ctx sdk.Context, n int) []types.Gateway {
+	items := make([]types.Gateway, n)
+	for i := range items {
+		items[i].Address = strconv.Itoa(i)
+
+		keeper.SetGateway(ctx, items[i])
+	}
+	return items
+}
+
+func TestGatewayGet(t *testing.T) {
+	keeper, ctx := keepertest.GatewayKeeper(t)
+	items := createNGateway(keeper, ctx, 10)
+	for _, item := range items {
+		rst, found := keeper.GetGateway(ctx,
+			item.Address,
+		)
+		require.True(t, found)
+		require.Equal(t,
+			nullify.Fill(&item),
+			nullify.Fill(&rst),
+		)
+	}
+}
+func TestGatewayRemove(t *testing.T) {
+	keeper, ctx := keepertest.GatewayKeeper(t)
+	items := createNGateway(keeper, ctx, 10)
+	for _, item := range items {
+		keeper.RemoveGateway(ctx,
+			item.Address,
+		)
+		_, found := keeper.GetGateway(ctx,
+			item.Address,
+		)
+		require.False(t, found)
+	}
+}
+
+func TestGatewayGetAll(t *testing.T) {
+	keeper, ctx := keepertest.GatewayKeeper(t)
+	items := createNGateway(keeper, ctx, 10)
+	require.ElementsMatch(t,
+		nullify.Fill(items),
+		nullify.Fill(keeper.GetAllGateway(ctx)),
+	)
+}

--- a/x/gateway/keeper/query_gateway.go
+++ b/x/gateway/keeper/query_gateway.go
@@ -1,0 +1,57 @@
+package keeper
+
+import (
+	"context"
+
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"pocket/x/gateway/types"
+)
+
+func (k Keeper) GatewayAll(goCtx context.Context, req *types.QueryAllGatewayRequest) (*types.QueryAllGatewayResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+
+	var gateways []types.Gateway
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	store := ctx.KVStore(k.storeKey)
+	gatewayStore := prefix.NewStore(store, types.KeyPrefix(types.GatewayKeyPrefix))
+
+	pageRes, err := query.Paginate(gatewayStore, req.Pagination, func(key []byte, value []byte) error {
+		var gateway types.Gateway
+		if err := k.cdc.Unmarshal(value, &gateway); err != nil {
+			return err
+		}
+
+		gateways = append(gateways, gateway)
+		return nil
+	})
+
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	return &types.QueryAllGatewayResponse{Gateway: gateways, Pagination: pageRes}, nil
+}
+
+func (k Keeper) Gateway(goCtx context.Context, req *types.QueryGetGatewayRequest) (*types.QueryGetGatewayResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	val, found := k.GetGateway(
+		ctx,
+		req.Address,
+	)
+	if !found {
+		return nil, status.Error(codes.NotFound, "not found")
+	}
+
+	return &types.QueryGetGatewayResponse{Gateway: val}, nil
+}

--- a/x/gateway/keeper/query_gateway_test.go
+++ b/x/gateway/keeper/query_gateway_test.go
@@ -1,0 +1,127 @@
+package keeper_test
+
+import (
+	"strconv"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	keepertest "pocket/testutil/keeper"
+	"pocket/testutil/nullify"
+	"pocket/x/gateway/types"
+)
+
+// Prevent strconv unused error
+var _ = strconv.IntSize
+
+func TestGatewayQuerySingle(t *testing.T) {
+	keeper, ctx := keepertest.GatewayKeeper(t)
+	wctx := sdk.WrapSDKContext(ctx)
+	msgs := createNGateway(keeper, ctx, 2)
+	tests := []struct {
+		desc     string
+		request  *types.QueryGetGatewayRequest
+		response *types.QueryGetGatewayResponse
+		err      error
+	}{
+		{
+			desc: "First",
+			request: &types.QueryGetGatewayRequest{
+				Address: msgs[0].Address,
+			},
+			response: &types.QueryGetGatewayResponse{Gateway: msgs[0]},
+		},
+		{
+			desc: "Second",
+			request: &types.QueryGetGatewayRequest{
+				Address: msgs[1].Address,
+			},
+			response: &types.QueryGetGatewayResponse{Gateway: msgs[1]},
+		},
+		{
+			desc: "KeyNotFound",
+			request: &types.QueryGetGatewayRequest{
+				Address: strconv.Itoa(100000),
+			},
+			err: status.Error(codes.NotFound, "not found"),
+		},
+		{
+			desc: "InvalidRequest",
+			err:  status.Error(codes.InvalidArgument, "invalid request"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			response, err := keeper.Gateway(wctx, tc.request)
+			if tc.err != nil {
+				require.ErrorIs(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t,
+					nullify.Fill(tc.response),
+					nullify.Fill(response),
+				)
+			}
+		})
+	}
+}
+
+func TestGatewayQueryPaginated(t *testing.T) {
+	keeper, ctx := keepertest.GatewayKeeper(t)
+	wctx := sdk.WrapSDKContext(ctx)
+	msgs := createNGateway(keeper, ctx, 5)
+
+	request := func(next []byte, offset, limit uint64, total bool) *types.QueryAllGatewayRequest {
+		return &types.QueryAllGatewayRequest{
+			Pagination: &query.PageRequest{
+				Key:        next,
+				Offset:     offset,
+				Limit:      limit,
+				CountTotal: total,
+			},
+		}
+	}
+	t.Run("ByOffset", func(t *testing.T) {
+		step := 2
+		for i := 0; i < len(msgs); i += step {
+			resp, err := keeper.GatewayAll(wctx, request(nil, uint64(i), uint64(step), false))
+			require.NoError(t, err)
+			require.LessOrEqual(t, len(resp.Gateway), step)
+			require.Subset(t,
+				nullify.Fill(msgs),
+				nullify.Fill(resp.Gateway),
+			)
+		}
+	})
+	t.Run("ByKey", func(t *testing.T) {
+		step := 2
+		var next []byte
+		for i := 0; i < len(msgs); i += step {
+			resp, err := keeper.GatewayAll(wctx, request(next, 0, uint64(step), false))
+			require.NoError(t, err)
+			require.LessOrEqual(t, len(resp.Gateway), step)
+			require.Subset(t,
+				nullify.Fill(msgs),
+				nullify.Fill(resp.Gateway),
+			)
+			next = resp.Pagination.NextKey
+		}
+	})
+	t.Run("Total", func(t *testing.T) {
+		resp, err := keeper.GatewayAll(wctx, request(nil, 0, 0, true))
+		require.NoError(t, err)
+		require.Equal(t, len(msgs), int(resp.Pagination.Total))
+		require.ElementsMatch(t,
+			nullify.Fill(msgs),
+			nullify.Fill(resp.Gateway),
+		)
+	})
+	t.Run("InvalidRequest", func(t *testing.T) {
+		_, err := keeper.GatewayAll(wctx, nil)
+		require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "invalid request"))
+	})
+}

--- a/x/gateway/types/genesis.go
+++ b/x/gateway/types/genesis.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-// this line is used by starport scaffolding # genesis/types/import
+	"fmt"
 )
 
 // DefaultIndex is the default global index
@@ -10,6 +10,7 @@ const DefaultIndex uint64 = 1
 // DefaultGenesis returns the default genesis state
 func DefaultGenesis() *GenesisState {
 	return &GenesisState{
+		GatewayList: []Gateway{},
 		// this line is used by starport scaffolding # genesis/types/default
 		Params: DefaultParams(),
 	}
@@ -18,6 +19,16 @@ func DefaultGenesis() *GenesisState {
 // Validate performs basic genesis state validation returning an error upon any
 // failure.
 func (gs GenesisState) Validate() error {
+	// Check for duplicated index in gateway
+	gatewayIndexMap := make(map[string]struct{})
+
+	for _, elem := range gs.GatewayList {
+		index := string(GatewayKey(elem.Address))
+		if _, ok := gatewayIndexMap[index]; ok {
+			return fmt.Errorf("duplicated index for gateway")
+		}
+		gatewayIndexMap[index] = struct{}{}
+	}
 	// this line is used by starport scaffolding # genesis/types/validate
 
 	return gs.Params.Validate()

--- a/x/gateway/types/genesis_test.go
+++ b/x/gateway/types/genesis_test.go
@@ -19,12 +19,34 @@ func TestGenesisState_Validate(t *testing.T) {
 			valid:    true,
 		},
 		{
-			desc:     "valid genesis state",
+			desc: "valid genesis state",
 			genState: &types.GenesisState{
 
+				GatewayList: []types.Gateway{
+					{
+						Address: "0",
+					},
+					{
+						Address: "1",
+					},
+				},
 				// this line is used by starport scaffolding # types/genesis/validField
 			},
 			valid: true,
+		},
+		{
+			desc: "duplicated gateway",
+			genState: &types.GenesisState{
+				GatewayList: []types.Gateway{
+					{
+						Address: "0",
+					},
+					{
+						Address: "0",
+					},
+				},
+			},
+			valid: false,
 		},
 		// this line is used by starport scaffolding # types/genesis/testcase
 	}

--- a/x/gateway/types/key_gateway.go
+++ b/x/gateway/types/key_gateway.go
@@ -1,0 +1,23 @@
+package types
+
+import "encoding/binary"
+
+var _ binary.ByteOrder
+
+const (
+	// GatewayKeyPrefix is the prefix to retrieve all Gateway
+	GatewayKeyPrefix = "Gateway/value/"
+)
+
+// GatewayKey returns the store key to retrieve a Gateway from the index fields
+func GatewayKey(
+	address string,
+) []byte {
+	var key []byte
+
+	addressBytes := []byte(address)
+	key = append(key, addressBytes...)
+	key = append(key, []byte("/")...)
+
+	return key
+}

--- a/x/gateway/types/key_gateway.go
+++ b/x/gateway/types/key_gateway.go
@@ -5,7 +5,7 @@ import "encoding/binary"
 var _ binary.ByteOrder
 
 const (
-	// GatewayKeyPrefix is the prefix to retrieve all Gateway
+	// GatewayKeyPrefix is the prefix to retrieve all Gateways
 	GatewayKeyPrefix = "Gateway/value/"
 )
 


### PR DESCRIPTION
## Summary

Ran `ignite scaffold map gateway --module gateway --signer address --no-message --index address --yes`

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 12 Oct 23 12:28 UTC
This pull request includes various changes to multiple files. Here is a summary of the diff:

- Changes to the file `x/gateway/gateway_test.go`:
  - Added test cases to validate the `GatewayList` field in the `GenesisState` struct.
  - Assertion added to verify the consistency of the `GatewayList` in the `genesisState` and `got.GatewayList`.

- Changes to the file `genesis_test.go`:
  - Added new test cases to validate the genesis state for the gateway module.
  - Added gateway addresses in the test cases to ensure proper validation.

- Changes to the file `query_gateway_test.go`:
  - Added two new test functions to test gateway queries (single and paginated).
  - The functions test various scenarios such as valid requests, key not found, and invalid requests.
  
- Changes to the file `query_gateway.go`:
  - Added a new file to the `keeper` package with two functions: `GatewayAll` and `Gateway`.
  - The functions retrieve gateway information based on the provided address and return the response.
  - They handle invalid requests and return appropriate error messages.
  - Dependencies include packages from `cosmos-sdk` and the `query` package.

- Changes to the file `gateway.go`:
  - Added functions for managing gateways in the store (set, get, remove, get all).
  - Included necessary imports and the definition of the `Gateway` struct.

- Changes to the file `gateway.proto`:
  - Added a new file defining a protocol buffer message named `Gateway` with an `address` field of type string.
  - Located in the `proto/pocket/gateway` directory and belongs to the `pocket.gateway` package.
  - Specifies the Go package as `pocket/x/gateway/types`.
  
- Changes to the file `genesis.go`:
  - Added a loop in the `InitGenesis` function to set gateway elements from the provided genesis state.
  - Modified the `ExportGenesis` function to set the `gatewayList` field by calling `k.GetAllGateway(ctx)`.
  
- Changes to the file `gateway_test.go`:
  - Added test functions to test the `Gateway` struct's operations.
  - Includes tests for getting, removing, and getting all gateway items.
  
- Changes to the file `types/key_gateway.go`:
  - Added a new file defining the key prefix and key generation function for gateways.
  
- Changes to the `openapi.yml` file:
  - Added new API endpoints for retrieving gateway information and querying specific gateways.
  - Added request parameters and response schemas for the new endpoints.
  
- Changes to the `x/gateway/types/genesis.go` file:
  - Added import statements and made changes to the `GatewayList` field initialization.
  
- Changes to the file `x/gateway/client/cli/query_gateway_test.go`:
  - Added unit test functions for the CLI query commands related to the gateway module.
  
- Changes to the file `x/gateway/types/genesis.go`:
  - Added import statements and made changes to the genesis state initialization.
  
- Changes to the file `query.go`:
  - Added new commands for listing and showing gateway information.
  
These changes aim to enhance various aspects of the gateway module's functionality, including testing, querying, and validation.
<!-- reviewpad:summarize:end -->

## Issue

Fixes (in part) [19](https://github.com/pokt-network/poktroll/issues/19)

> [ ] A single PR that defines & updates the Gateway type with required (MVP) fields to support business logic in future work

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make test_all_unit`
- [x] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updated documentation and left TODOs throughout the codebase
