### PR TITLE
[Experiment] repro: comet query client

### DIFF
--- a/pkg/client/comet_query/client.go
+++ b/pkg/client/comet_query/client.go
@@ -1,0 +1,96 @@
+package comet_query
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"pocket/pkg/either"
+	"sync"
+
+	cometclient "github.com/cometbft/cometbft/rpc/client"
+	comethttp "github.com/cometbft/cometbft/rpc/client/http"
+	comettypes "github.com/cometbft/cometbft/rpc/core/types"
+
+	"pocket/pkg/client"
+	"pocket/pkg/observable/channel"
+)
+
+type cometQueryClient struct {
+	client        cometclient.Client
+	observablesMu sync.Mutex
+	observables   map[string]client.EventsBytesObservable
+}
+
+var _ client.EventsQueryClient = (*cometQueryClient)(nil)
+
+func NewCometQueryClient(remote, wsEndpoint string) (client.EventsQueryClient, error) {
+	cometHttpClient, err := comethttp.New(remote, wsEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	if err := cometHttpClient.Start(); err != nil {
+		return nil, err
+	}
+
+	return &cometQueryClient{
+		client:      cometHttpClient,
+		observables: make(map[string]client.EventsBytesObservable),
+	}, nil
+}
+
+func (cClient *cometQueryClient) EventsBytes(
+	ctx context.Context,
+	query string,
+) (client.EventsBytesObservable, error) {
+	cClient.observablesMu.Lock()
+	defer cClient.observablesMu.Unlock()
+
+	if eventsObservable, ok := cClient.observables[query]; ok {
+		return eventsObservable, nil
+	}
+
+	cometEventsCh, err := cClient.client.Subscribe(ctx, query, query)
+	if err != nil {
+		return nil, err
+	}
+
+	eventsObservable, eventsProducer := channel.NewObservable[either.Either[[]byte]]()
+	cClient.observables[query] = eventsObservable
+
+	go cClient.goProduceEvents(cometEventsCh, eventsProducer)
+
+	return eventsObservable, nil
+}
+
+func (cClient *cometQueryClient) goProduceEvents(
+	eventsCh <-chan comettypes.ResultEvent,
+	eventsProducer chan<- either.Either[[]byte],
+) {
+	for {
+		select {
+		case event, ok := <-eventsCh:
+			if !ok {
+				return
+			}
+
+			eventJson, err := json.MarshalIndent(event, "", "  ")
+			if err != nil {
+				eventsProducer <- either.Error[[]byte](err)
+			}
+
+			log.Printf("events channel received, producing: %s", event)
+			eventsProducer <- either.Success(eventJson)
+		}
+	}
+}
+
+func (cClient *cometQueryClient) Close() {
+	cClient.observablesMu.Lock()
+	defer cClient.observablesMu.Unlock()
+
+	for _, obsvbl := range cClient.observables {
+		obsvbl.UnsubscribeAll()
+	}
+
+	_ = cClient.client.Stop()
+}

--- a/pkg/client/comet_query/client_test.go
+++ b/pkg/client/comet_query/client_test.go
@@ -1,0 +1,50 @@
+//go:build integration
+
+package comet_query
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCometQueryClient_EventsObservable(t *testing.T) {
+	var (
+		newBlockQuery        = "tm.event='NewBlock'"
+		notifyTimeout        = 5 * time.Second
+		observedEventCounter = new(uint64)
+		ctx                  = context.Background()
+	)
+
+	cClient, err := NewCometQueryClient("tcp://localhost:36657", "/websocket")
+	require.NoError(t, err)
+	require.NotNil(t, cClient)
+
+	eventsObservable, err := cClient.EventsBytes(ctx, newBlockQuery)
+	require.NoError(t, err)
+
+	testCtx, testDone := context.WithCancel(context.Background())
+	eventsObserver := eventsObservable.Subscribe(ctx)
+	go func() {
+		for eitherEvent := range eventsObserver.Ch() {
+			event, err := eitherEvent.ValueOrError()
+			assert.NoError(t, err)
+
+			t.Log("received event:")
+			t.Logf("%s", event)
+			atomic.AddUint64(observedEventCounter, 1)
+			testDone()
+		}
+	}()
+
+	select {
+	case <-testCtx.Done():
+		require.ErrorIs(t, ctx.Err(), context.Canceled)
+	case <-time.After(notifyTimeout):
+		t.Fatal("timeout waiting for error channel to receive")
+	}
+}


### PR DESCRIPTION
## Summary

### Human Summary

This branch is an attempt to replace our "custom" comet RPC client for event subscriptions (using the gorilla websocket package). As noted above the `QueryClient` interface definition in pkg/client/interface.go, such a thing seems to exist in the cometbft repo; however, my attempts at getting it to work, for our use case at least have been unsuccessful. I think there's likely something basic that I'm misunderstanding or an assumption that I don't realize I'm making. :thinking: 

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 26 Oct 23 18:51 UTC
This pull request implements a new HTTP RPC client for the `comet_query` package. It introduces a new `cometQueryClient` struct that handles querying events from a remote CometBFT node. The client can subscribe to specific events and receive event data in the form of bytes. The implementation includes functions for starting the client, subscribing to events, and producing events. Additionally, a test is added to verify the functionality of the `EventsBytes` method.
<!-- reviewpad:summarize:end -->

## Issue

Relates to:
- #64 

Improve maintainability (owning less code).

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Other (specify): experiment / reproduction

## Testing

- [ ] **Run all unit tests**: `make go_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
