### PR TITLE
feat: seperate tests from go_develop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,10 @@ go_mockgen: ## Use `mockgen` to generate mocks used for testing purposes of all 
 	go generate ./x/supplier/types/
 
 .PHONY: go_develop
-go_develop: proto_regen go_mockgen go_test ## Generate protos, mocks and run all tests
+go_develop: proto_regen go_mockgen ## Generate protos and mocks
+
+.PHONY: go_develop_and_test
+go_develop_and_test: go_develop go_test ## Generate protos, mocks and run all tests
 
 #############
 ### TODOS ###

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	cosmossdk.io/math v1.0.1
 	github.com/cometbft/cometbft v0.37.2
 	github.com/cometbft/cometbft-db v0.8.0
-	github.com/cosmos/cosmos-proto v1.0.0-beta.2
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/cosmos/gogoproto v1.4.10
 	github.com/cosmos/ibc-go/v7 v7.1.0
@@ -23,7 +22,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/sync v0.3.0
-	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	google.golang.org/grpc v1.56.1
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -68,6 +66,7 @@ require (
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
+	github.com/cosmos/cosmos-proto v1.0.0-beta.2 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/iavl v0.20.0 // indirect
@@ -266,6 +265,7 @@ require (
 	gonum.org/v1/gonum v0.11.0 // indirect
 	google.golang.org/api v0.122.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
## Summary

### Human Summary

Separate `make go_develop` into `make go_develop` and `make go_develop_and_test`

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 21 Oct 23 21:50 UTC
This pull request separates tests from go_develop by modifying the Makefile and go.mod files. It removes the go_test command from the go_develop target and adds a new target go_develop_and_test that generates protos, mocks, and runs all tests.
<!-- reviewpad:summarize:end -->

## Issue

N/A

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_test`
- [x] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updated documentation and left TODOs throughout the codebase
