### PR TITLE
fix: RelayerProxy interface mismatch

### DIFF
--- a/pkg/relayer/proxy/interface.go
+++ b/pkg/relayer/proxy/interface.go
@@ -17,7 +17,7 @@ type RelayerProxy interface {
 	Start(ctx context.Context) error
 
 	// Stop stops all supported proxies and returns an error if any of them fail.
-	Stop() error
+	Stop(ctx context.Context) error
 
 	// ServedRelays returns an observable that notifies the miner about the relays that have been served.
 	// A served relay is one whose RelayRequest's signature and session have been verified,

--- a/pkg/relayer/proxy/proxy.go
+++ b/pkg/relayer/proxy/proxy.go
@@ -44,7 +44,7 @@ type relayerProxy struct {
 	// providedServices is a map of the services provided by the relayer proxy. Each provided service
 	// has the necessary information to start the server that listens for incoming relay requests and
 	// the client that proxies the request to the supported native service.
-	providedServices map[string][]ProvidedService
+	providedServices map[string][]*ProvidedService
 
 	// servedRelays is an observable that notifies the miner about the relays that have been served.
 	servedRelays observable.Observable[*types.Relay]
@@ -106,7 +106,7 @@ func (rp *relayerProxy) ServedRelays() observable.Observable[*types.Relay] {
 func buildProvidedServices(
 	ctx context.Context,
 	supplierQuerier suppliertypes.QueryClient,
-) map[string]ProvidedService {
+) map[string][]*ProvidedService {
 	panic("TODO: implement buildProvidedServices")
 }
 


### PR DESCRIPTION
## Summary

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 23 Oct 23 15:55 UTC
This pull request fixes an interface mismatch in the RelayerProxy package. The `Stop` method in the `RelayerProxy` interface now takes a `context.Context` parameter. Additionally, the `providedServices` field in the `relayerProxy` struct is now a map of string to a slice of `*ProvidedService` instead of a map of string to `[]ProvidedService`. The `buildProvidedServices` function has also been updated to return a map of string to a slice of `*ProvidedService`.
<!-- reviewpad:summarize:end -->

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
