### PR TITLE
[Miner] feat: add the map channel observable operator

### DIFF
--- a/pkg/observable/channel/map.go
+++ b/pkg/observable/channel/map.go
@@ -1,0 +1,30 @@
+package channel
+
+import (
+	"context"
+
+	"pocket/pkg/observable"
+)
+
+func Map[S, D any](
+	ctx context.Context,
+	srcObservable observable.Observable[S],
+	// TODO_CONSIDERATION: if this were variadic, it could simplify serial transformations.
+	transformFn func(src S) (dst D, skip bool),
+) observable.Observable[D] {
+	dstObservable, dstProducer := NewObservable[D]()
+	srcObserver := srcObservable.Subscribe(ctx)
+
+	go func() {
+		for srcNotification := range srcObserver.Ch() {
+			dstNotification, skip := transformFn(srcNotification)
+			if skip {
+				continue
+			}
+
+			dstProducer <- dstNotification
+		}
+	}()
+
+	return dstObservable
+}

--- a/pkg/observable/channel/map.go
+++ b/pkg/observable/channel/map.go
@@ -6,6 +6,10 @@ import (
 	"pocket/pkg/observable"
 )
 
+// Map transforms the given observable by applying the given transformFn to each
+// notification received from the observable. If the transformFn returns a skip
+// bool of true, the notification is skipped and not emitted to the resulting
+// observable.
 func Map[S, D any](
 	ctx context.Context,
 	srcObservable observable.Observable[S],

--- a/pkg/observable/channel/map_test.go
+++ b/pkg/observable/channel/map_test.go
@@ -11,7 +11,7 @@ import (
 	"pocket/pkg/observable/channel"
 )
 
-func TestMapWord_BzToPalindrome(t *testing.T) {
+func TestMap_Word_BytesToPalindrome(t *testing.T) {
 	tests := []struct {
 		name    string
 		wordBz  []byte
@@ -77,7 +77,9 @@ func TestMapWord_BzToPalindrome(t *testing.T) {
 	}
 }
 
-// palindrome is a word that is spelled the same forwards and backwards.
+// Palindrome is a word that is spelled the same forwards and backwards.
+// It's used as an example of a type that can be mapped from one observable
+// and has no real utility outside of this test.
 type palindrome struct {
 	forwards  string
 	backwards string

--- a/pkg/observable/channel/map_test.go
+++ b/pkg/observable/channel/map_test.go
@@ -2,7 +2,9 @@ package channel_test
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -29,20 +31,30 @@ func TestMapWord_BzToPalindrome(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			var (
+				wordCounter int32
+				ctx, cancel = context.WithCancel(context.Background())
+			)
 			t.Cleanup(cancel)
 
+			// set up source bytes observable
 			bzObservable, bzPublishCh := channel.NewObservable[[]byte]()
 			bytesToPalindrome := func(wordBz []byte) (palindrome, bool) {
-				return newPalindrome(string(wordBz)), true
+				return newPalindrome(string(wordBz)), false
 			}
+
+			// map bytes observable to palindrome observable
 			palindromeObservable := channel.Map(ctx, bzObservable, bytesToPalindrome)
 			palindromeObserver := palindromeObservable.Subscribe(ctx)
 
+			// publish a word in bytes
 			bzPublishCh <- tt.wordBz
 
+			// concurrently consume the palindrome observer's channel
 			go func() {
 				for word := range palindromeObserver.Ch() {
+					atomic.AddInt32(&wordCounter, 1)
+
 					// word.forwards should always match the original word
 					require.Equal(t, string(tt.wordBz), word.forwards)
 
@@ -55,6 +67,12 @@ func TestMapWord_BzToPalindrome(t *testing.T) {
 					}
 				}
 			}()
+
+			// wait a tick for the observer to receive the word
+			time.Sleep(time.Millisecond)
+
+			// ensure that the observer received the word
+			require.Equal(t, int32(1), atomic.LoadInt32(&wordCounter))
 		})
 	}
 }
@@ -72,10 +90,12 @@ func newPalindrome(word string) palindrome {
 	}
 }
 
+// IsValid returns true if the word actually is a palindrome.
 func (p *palindrome) IsValid() bool {
 	return p.forwards == (p.backwards)
 }
 
+// reverseString reverses a string, character-by-character.
 func reverseString(s string) string {
 	runes := []rune(s)
 	// use i & j as cursors to iteratively swap values on symmetrical indexes

--- a/pkg/observable/channel/map_test.go
+++ b/pkg/observable/channel/map_test.go
@@ -1,0 +1,86 @@
+package channel_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"pocket/pkg/observable/channel"
+)
+
+func TestMapWord_BzToPalindrome(t *testing.T) {
+	tests := []struct {
+		name    string
+		wordBz  []byte
+		isValid bool
+	}{
+		{
+			name:    "valid palindrome",
+			wordBz:  []byte("rotator"),
+			isValid: true,
+		},
+		{
+			name:    "invalid palindrome",
+			wordBz:  []byte("spinner"),
+			isValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			bzObservable, bzPublishCh := channel.NewObservable[[]byte]()
+			bytesToPalindrome := func(wordBz []byte) (palindrome, bool) {
+				return newPalindrome(string(wordBz)), true
+			}
+			palindromeObservable := channel.Map(ctx, bzObservable, bytesToPalindrome)
+			palindromeObserver := palindromeObservable.Subscribe(ctx)
+
+			bzPublishCh <- tt.wordBz
+
+			go func() {
+				for word := range palindromeObserver.Ch() {
+					// word.forwards should always match the original word
+					require.Equal(t, string(tt.wordBz), word.forwards)
+
+					if tt.isValid {
+						require.Equal(t, string(tt.wordBz), word.backwards)
+						require.Truef(t, word.IsValid(), "palindrome should be valid")
+					} else {
+						require.NotEmptyf(t, string(tt.wordBz), word.backwards)
+						require.Falsef(t, word.IsValid(), "palindrome should be invalid")
+					}
+				}
+			}()
+		})
+	}
+}
+
+// palindrome is a word that is spelled the same forwards and backwards.
+type palindrome struct {
+	forwards  string
+	backwards string
+}
+
+func newPalindrome(word string) palindrome {
+	return palindrome{
+		forwards:  word,
+		backwards: reverseString(word),
+	}
+}
+
+func (p *palindrome) IsValid() bool {
+	return p.forwards == (p.backwards)
+}
+
+func reverseString(s string) string {
+	runes := []rune(s)
+	// use i & j as cursors to iteratively swap values on symmetrical indexes
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+	return string(runes)
+}


### PR DESCRIPTION

## Summary

<!-- DELETE THIS COMMENT BLOCK
      - Provide a quick summary of the changes yourself
      - Let reviewpad summarize your PR under AI summary
      - You can leave a `/reviewpad summarize` comment at any time to trigger it manually.
-->

### Human Summary

Adds `Map`, a function which transforms a "source" observable into a new, "destination", observable via the provided `transformFn`.

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 24 Oct 23 12:39 UTC
This pull request introduces the map channel observable operator. It includes the implementation of the `Map` function in the `pkg/observable/channel/map.go` file, as well as tests in the `pkg/observable/channel/map_test.go` file. The `Map` function takes an observable and applies a transform function to each notification received from the observable. If the transform function returns a `skip` boolean of true, the notification is skipped and not emitted to the resulting observable. The tests cover various scenarios of mapping bytes to palindromes and checking their validity. The patch also includes improvements to comments and test names for better readability and clarity.
<!-- reviewpad:summarize:end -->

## Issue

Relates to:
- #13 
- #64

`Map` enables transforming observables, including their generic types, which is a dependency of `EventsQueryClient` (#64).

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_test`
- [x] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updated documentation and left TODOs throughout the codebase
