### PR TITLE
[Proxy] feat: add general proxy logic and server builder

### DIFF
--- a/pkg/relayer/proxy/errors.go
+++ b/pkg/relayer/proxy/errors.go
@@ -1,8 +1,8 @@
 package proxy
 
-import errorsmod "cosmossdk.io/errors"
+import sdkerrors "cosmossdk.io/errors"
 
 var (
-	ErrUnsupportedRPCType = errorsmod.Register(codespace, 1, "unsupported rpc type")
 	codespace             = "relayer/proxy"
+	ErrUnsupportedRPCType = sdkerrors.Register(codespace, 1, "unsupported rpc type")
 )

--- a/pkg/relayer/proxy/errors.go
+++ b/pkg/relayer/proxy/errors.go
@@ -1,0 +1,8 @@
+package proxy
+
+import errorsmod "cosmossdk.io/errors"
+
+var (
+	ErrUnsupportedRPCType = errorsmod.Register(codespace, 1, "unsupported rpc type")
+	codespace             = "relayer/proxy"
+)

--- a/pkg/relayer/proxy/interface.go
+++ b/pkg/relayer/proxy/interface.go
@@ -24,3 +24,15 @@ type RelayerProxy interface {
 	// and its RelayResponse has been signed and successfully sent to the client.
 	ServedRelays() observable.Observable[*types.Relay]
 }
+
+// RelayServer is the interface of the proxy servers provided by the RelayerProxy.
+type RelayServer interface {
+	// Start starts the service server and returns an error if it fails.
+	Start(ctx context.Context) error
+
+	// Stop terminates the service server and returns an error if it fails.
+	Stop(ctx context.Context) error
+
+	// Name returns the name of the service.
+	Name() string
+}

--- a/pkg/relayer/proxy/interface.go
+++ b/pkg/relayer/proxy/interface.go
@@ -8,15 +8,15 @@ import (
 )
 
 // RelayerProxy is the interface for the proxy that serves relays to the application.
-// It is responsible for starting and stopping all supported proxies.
+// It is responsible for starting and stopping all supported RelayServers.
 // While handling requests and responding in a closed loop, it also notifies
 // the miner about the relays that have been served.
 type RelayerProxy interface {
 
-	// Start starts all supported proxies and returns an error if any of them fail to start.
+	// Start starts all advertised relay servers and returns an error if any of them fail to start.
 	Start(ctx context.Context) error
 
-	// Stop stops all supported proxies and returns an error if any of them fail.
+	// Stop stops all advertised relay servers and returns an error if any of them fail.
 	Stop(ctx context.Context) error
 
 	// ServedRelays returns an observable that notifies the miner about the relays that have been served.
@@ -25,7 +25,7 @@ type RelayerProxy interface {
 	ServedRelays() observable.Observable[*types.Relay]
 }
 
-// RelayServer is the interface of the proxy servers provided by the RelayerProxy.
+// RelayServer is the interface of the advertised relay servers provided by the RelayerProxy.
 type RelayServer interface {
 	// Start starts the service server and returns an error if it fails.
 	Start(ctx context.Context) error
@@ -33,6 +33,6 @@ type RelayServer interface {
 	// Stop terminates the service server and returns an error if it fails.
 	Stop(ctx context.Context) error
 
-	// Name returns the name of the service.
-	Name() string
+	// ServiceId returns the serviceId of the service.
+	ServiceId() string
 }

--- a/pkg/relayer/proxy/interface.go
+++ b/pkg/relayer/proxy/interface.go
@@ -5,6 +5,7 @@ import (
 
 	"pocket/pkg/observable"
 	"pocket/x/service/types"
+	sharedtypes "pocket/x/shared/types"
 )
 
 // RelayerProxy is the interface for the proxy that serves relays to the application.
@@ -41,5 +42,5 @@ type RelayServer interface {
 	Stop(ctx context.Context) error
 
 	// ServiceId returns the serviceId of the service.
-	ServiceId() string
+	ServiceId() *sharedtypes.ServiceId
 }

--- a/pkg/relayer/proxy/interface.go
+++ b/pkg/relayer/proxy/interface.go
@@ -23,6 +23,13 @@ type RelayerProxy interface {
 	// A served relay is one whose RelayRequest's signature and session have been verified,
 	// and its RelayResponse has been signed and successfully sent to the client.
 	ServedRelays() observable.Observable[*types.Relay]
+
+	// VerifyRelayRequest is a shared method used by RelayServers to check the
+	// relay request signature and session validity.
+	VerifyRelayRequest(relayRequest *types.RelayRequest) (isValid bool, err error)
+
+	// SignRelayResponse is a shared method used by RelayServers to sign the relay response.
+	SignRelayResponse(relayResponse *types.RelayResponse) ([]byte, error)
 }
 
 // RelayServer is the interface of the advertised relay servers provided by the RelayerProxy.

--- a/pkg/relayer/proxy/jsonrpc.go
+++ b/pkg/relayer/proxy/jsonrpc.go
@@ -3,21 +3,24 @@ package proxy
 import (
 	"context"
 	"net/http"
+	"net/url"
 
 	"pocket/x/service/types"
+	sharedtypes "pocket/x/shared/types"
 )
 
 var _ RelayServer = (*jsonRPCServer)(nil)
 
 type jsonRPCServer struct {
 	// serviceId is the id of the service that the server is responsible for.
-	serviceId string
+	serviceId *sharedtypes.ServiceId
 
-	// endpointUrl is the url that the server listens to for incoming relay requests.
-	endpointUrl string
+	// serverEndpoint is the advertised endpoint configuration that the server uses to
+	// listen for incoming relay requests.
+	serverEndpoint *sharedtypes.SupplierEndpoint
 
-	// nativeServiceListenAddress is the address of the native service that the server relays requests to.
-	nativeServiceListenAddress string
+	// proxiedServiceEndpoint is the address of the proxied service that the server relays requests to.
+	proxiedServiceEndpoint url.URL
 
 	// server is the http server that listens for incoming relay requests.
 	server *http.Server
@@ -31,28 +34,28 @@ type jsonRPCServer struct {
 }
 
 // NewJSONRPCServer creates a new HTTP server that listens for incoming relay requests
-// and proxies them to the supported native service.
+// and forwards them to the supported proxied service endpoint.
 // It takes the serviceId, endpointUrl, and the main RelayerProxy as arguments and returns
 // a RelayServer that listens to incoming RelayRequests
 func NewJSONRPCServer(
-	serviceId string,
-	endpointUrl string,
-	nativeServiceListenAddress string,
+	serviceId *sharedtypes.ServiceId,
+	supplierEndpoint *sharedtypes.SupplierEndpoint,
+	proxiedServiceEndpoint url.URL,
 	servedRelaysProducer chan<- *types.Relay,
 	proxy RelayerProxy,
 ) RelayServer {
 	return &jsonRPCServer{
-		serviceId:                  serviceId,
-		endpointUrl:                endpointUrl,
-		server:                     &http.Server{Addr: endpointUrl},
-		relayerProxy:               proxy,
-		nativeServiceListenAddress: nativeServiceListenAddress,
-		servedRelaysProducer:       servedRelaysProducer,
+		serviceId:              serviceId,
+		serverEndpoint:         supplierEndpoint,
+		server:                 &http.Server{Addr: supplierEndpoint.Url},
+		relayerProxy:           proxy,
+		proxiedServiceEndpoint: proxiedServiceEndpoint,
+		servedRelaysProducer:   servedRelaysProducer,
 	}
 }
 
 // Start starts the service server and returns an error if it fails.
-// It also waits for the passed in context to be done to shut down.
+// It also waits for the passed in context to end before shutting down.
 // This method is blocking and should be called in a goroutine.
 func (j *jsonRPCServer) Start(ctx context.Context) error {
 	go func() {
@@ -68,8 +71,8 @@ func (j *jsonRPCServer) Stop(ctx context.Context) error {
 	return j.server.Shutdown(ctx)
 }
 
-// ServiceId returns the serviceId of the service.
-func (j *jsonRPCServer) ServiceId() string {
+// ServiceId returns the serviceId of the JSON-RPC service.
+func (j *jsonRPCServer) ServiceId() *sharedtypes.ServiceId {
 	return j.serviceId
 }
 
@@ -78,4 +81,5 @@ func (j *jsonRPCServer) ServiceId() string {
 // when jsonRPCServer is used as an http.Handler with an http.Server.
 // (see https://pkg.go.dev/net/http#Handler)
 func (j *jsonRPCServer) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	panic("TODO: implement jsonRPCServer.ServeHTTP")
 }

--- a/pkg/relayer/proxy/jsonrpc.go
+++ b/pkg/relayer/proxy/jsonrpc.go
@@ -7,7 +7,7 @@ import (
 	"pocket/x/service/types"
 )
 
-var _ RelayServer = &jsonRPCServer{}
+var _ RelayServer = (*jsonRPCServer)(nil)
 
 type jsonRPCServer struct {
 	// serviceId is the id of the service that the server is responsible for.

--- a/pkg/relayer/proxy/jsonrpc.go
+++ b/pkg/relayer/proxy/jsonrpc.go
@@ -21,7 +21,7 @@ type jsonRPCServer struct {
 	relayerProxy RelayerProxy
 }
 
-// NewHTTPServer creates a new HTTP server that listens for incoming relay requests
+// NewJSONRPCServer creates a new HTTP server that listens for incoming relay requests
 // and proxies them to the supported native service.
 // It takes the serviceId, endpointUrl, and the main RelayerProxy as arguments and returns
 // a RelayServer that listens to incoming RelayRequests
@@ -51,12 +51,14 @@ func (j *jsonRPCServer) Stop(ctx context.Context) error {
 	return j.server.Shutdown(ctx)
 }
 
-// Name returns the name of the service.
-func (j *jsonRPCServer) Name() string {
+// ServiceId returns the serviceId of the service.
+func (j *jsonRPCServer) ServiceId() string {
 	return j.serviceId
 }
 
-// ServeHTTP is the http handler that listens for incoming relay requests.
-func (j *jsonRPCServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	panic("TODO: implement httpServer.ServeHTTP")
+// ServeHTTP listens for incoming relay requests. It implements the respective
+// method of the http.Handler interface. It is called by http.ListenAndServe()
+// when jsonRPCServer is used as an http.Handler with an http.Server.
+// (see https://pkg.go.dev/net/http#Handler)
+func (j *jsonRPCServer) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 }

--- a/pkg/relayer/proxy/jsonrpc.go
+++ b/pkg/relayer/proxy/jsonrpc.go
@@ -1,0 +1,62 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+)
+
+var _ RelayServer = &jsonRPCServer{}
+
+type jsonRPCServer struct {
+	// serviceId is the id of the service that the server is responsible for.
+	serviceId string
+
+	// endpointUrl is the url that the server listens to for incoming relay requests.
+	endpointUrl string
+
+	// server is the http server that listens for incoming relay requests.
+	server *http.Server
+
+	// relayerProxy is the main relayer proxy that the server uses to perform its operations.
+	relayerProxy RelayerProxy
+}
+
+// NewHTTPServer creates a new HTTP server that listens for incoming relay requests
+// and proxies them to the supported native service.
+// It takes the serviceId, endpointUrl, and the main RelayerProxy as arguments and returns
+// a RelayServer that listens to incoming RelayRequests
+func NewJSONRPCServer(serviceId string, endpointUrl string, proxy RelayerProxy) RelayServer {
+	return &jsonRPCServer{
+		serviceId:    serviceId,
+		endpointUrl:  endpointUrl,
+		server:       &http.Server{Addr: endpointUrl},
+		relayerProxy: proxy,
+	}
+}
+
+// Start starts the service server and returns an error if it fails.
+// It also waits for the passed in context to be done to shut down.
+// This method is blocking and should be called in a goroutine.
+func (j *jsonRPCServer) Start(ctx context.Context) error {
+	go func() {
+		<-ctx.Done()
+		j.server.Shutdown(ctx)
+	}()
+
+	return j.server.ListenAndServe()
+}
+
+// Stop terminates the service server and returns an error if it fails.
+func (j *jsonRPCServer) Stop(ctx context.Context) error {
+	return j.server.Shutdown(ctx)
+}
+
+// Name returns the name of the service.
+func (j *jsonRPCServer) Name() string {
+	return j.serviceId
+}
+
+// ServeHTTP is the http handler that listens for incoming relay requests.
+func (j *jsonRPCServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	panic("TODO: implement httpServer.ServeHTTP")
+}

--- a/pkg/relayer/proxy/proxy.go
+++ b/pkg/relayer/proxy/proxy.go
@@ -52,6 +52,9 @@ type relayerProxy struct {
 	// the client that relays the request to the supported native service.
 	advertisedRelayServers RelayServersMap
 
+	// nativeServiceListenAddresses is a map of the native services server's listen addresses
+	// that are supported by the relayer proxy.
+	nativeServicesListenAddress map[serviceId]string
 
 	// servedRelays is an observable that notifies the miner about the relays that have been served.
 	servedRelays observable.Observable[*types.Relay]
@@ -66,7 +69,7 @@ func NewRelayerProxy(
 	clientCtx sdkclient.Context,
 	keyName string,
 	keyring keyring.Keyring,
-
+	nativeServicesListenAddress map[serviceId]string,
 	// TODO_INCOMPLETE(@red-0ne): Uncomment once the BlockClient interface is available.
 	// blockClient blocktypes.BlockClient,
 ) RelayerProxy {
@@ -78,13 +81,14 @@ func NewRelayerProxy(
 	return &relayerProxy{
 		// TODO_INCOMPLETE(@red-0ne): Uncomment once the BlockClient interface is available.
 		// blockClient:       blockClient,
-		keyName:              keyName,
-		keyring:              keyring,
-		accountsQuerier:      accountQuerier,
-		supplierQuerier:      supplierQuerier,
-		sessionQuerier:       sessionQuerier,
-		servedRelays:         servedRelays,
-		servedRelaysProducer: servedRelaysProducer,
+		keyName:                     keyName,
+		keyring:                     keyring,
+		accountsQuerier:             accountQuerier,
+		supplierQuerier:             supplierQuerier,
+		sessionQuerier:              sessionQuerier,
+		nativeServicesListenAddress: nativeServicesListenAddress,
+		servedRelays:                servedRelays,
+		servedRelaysProducer:        servedRelaysProducer,
 	}
 }
 
@@ -130,4 +134,14 @@ func (rp *relayerProxy) Stop(ctx context.Context) error {
 // and its RelayResponse has been signed and successfully sent to the client.
 func (rp *relayerProxy) ServedRelays() observable.Observable[*types.Relay] {
 	return rp.servedRelays
+}
+
+// VerifyRelayRequest is a shared method used by RelayServers to check the relay request signature and session validity.
+func (rp *relayerProxy) VerifyRelayRequest(relayRequest *types.RelayRequest) (isValid bool, err error) {
+	panic("TODO: implement relayerProxy.VerifyRelayRequest")
+}
+
+// SignRelayResponse is a shared method used by RelayServers to sign the relay response.
+func (rp *relayerProxy) SignRelayResponse(relayResponse *types.RelayResponse) ([]byte, error) {
+	panic("TODO: implement relayerProxy.SignRelayResponse")
 }

--- a/pkg/relayer/proxy/proxy.go
+++ b/pkg/relayer/proxy/proxy.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"net/url"
 
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -20,8 +21,9 @@ import (
 var _ RelayerProxy = (*relayerProxy)(nil)
 
 type (
-	serviceId       = string
-	RelayServersMap = map[serviceId][]RelayServer
+	serviceId            = string
+	relayServersMap      = map[serviceId][]RelayServer
+	servicesEndpointsMap = map[serviceId]url.URL
 )
 
 type relayerProxy struct {
@@ -49,12 +51,11 @@ type relayerProxy struct {
 
 	// advertisedRelayServers is a map of the services provided by the relayer proxy. Each provided service
 	// has the necessary information to start the server that listens for incoming relay requests and
-	// the client that relays the request to the supported native service.
-	advertisedRelayServers RelayServersMap
+	// the client that relays the request to the supported proxied service.
+	advertisedRelayServers relayServersMap
 
-	// nativeServiceListenAddresses is a map of the native services server's listen addresses
-	// that are supported by the relayer proxy.
-	nativeServicesListenAddress map[serviceId]string
+	// proxiedServicesEndpoints is a map of the proxied services endpoints that the relayer proxy supports.
+	proxiedServicesEndpoints servicesEndpointsMap
 
 	// servedRelays is an observable that notifies the miner about the relays that have been served.
 	servedRelays observable.Observable[*types.Relay]
@@ -69,7 +70,7 @@ func NewRelayerProxy(
 	clientCtx sdkclient.Context,
 	keyName string,
 	keyring keyring.Keyring,
-	nativeServicesListenAddress map[serviceId]string,
+	proxiedServicesEndpoints servicesEndpointsMap,
 	// TODO_INCOMPLETE(@red-0ne): Uncomment once the BlockClient interface is available.
 	// blockClient blocktypes.BlockClient,
 ) RelayerProxy {
@@ -81,34 +82,34 @@ func NewRelayerProxy(
 	return &relayerProxy{
 		// TODO_INCOMPLETE(@red-0ne): Uncomment once the BlockClient interface is available.
 		// blockClient:       blockClient,
-		keyName:                     keyName,
-		keyring:                     keyring,
-		accountsQuerier:             accountQuerier,
-		supplierQuerier:             supplierQuerier,
-		sessionQuerier:              sessionQuerier,
-		nativeServicesListenAddress: nativeServicesListenAddress,
-		servedRelays:                servedRelays,
-		servedRelaysProducer:        servedRelaysProducer,
+		keyName:                  keyName,
+		keyring:                  keyring,
+		accountsQuerier:          accountQuerier,
+		supplierQuerier:          supplierQuerier,
+		sessionQuerier:           sessionQuerier,
+		proxiedServicesEndpoints: proxiedServicesEndpoints,
+		servedRelays:             servedRelays,
+		servedRelaysProducer:     servedRelaysProducer,
 	}
 }
 
 // Start concurrently starts all advertised relay servers and returns an error if any of them fails to start.
+// This method is blocking until all RelayServers are started.
 func (rp *relayerProxy) Start(ctx context.Context) error {
 	// The provided services map is built from the supplier's on-chain advertised information,
 	// which is a runtime parameter that can be changed by the supplier.
-	// Build the provided services map at Start instead of NewRelayerProxy to avoid having to
+	// NOTE: We build the provided services map at Start instead of NewRelayerProxy to avoid having to
 	// return an error from the constructor.
-	err := rp.BuildProvidedServices(ctx)
-	if err != nil {
+	if err := rp.BuildProvidedServices(ctx); err != nil {
 		return err
 	}
 
-	startGroup, gctx := errgroup.WithContext(ctx)
+	startGroup, ctx := errgroup.WithContext(ctx)
 
 	for _, relayServer := range rp.advertisedRelayServers {
 		for _, svr := range relayServer {
 			server := svr // create a new variable scoped to the anonymous function
-			startGroup.Go(func() error { return server.Start(gctx) })
+			startGroup.Go(func() error { return server.Start(ctx) })
 		}
 	}
 
@@ -116,13 +117,14 @@ func (rp *relayerProxy) Start(ctx context.Context) error {
 }
 
 // Stop concurrently stops all advertised relay servers and returns an error if any of them fails.
+// This method is blocking until all RelayServers are stopped.
 func (rp *relayerProxy) Stop(ctx context.Context) error {
-	stopGroup, gctx := errgroup.WithContext(ctx)
+	stopGroup, ctx := errgroup.WithContext(ctx)
 
 	for _, providedService := range rp.advertisedRelayServers {
 		for _, svr := range providedService {
 			server := svr // create a new variable scoped to the anonymous function
-			stopGroup.Go(func() error { return server.Stop(gctx) })
+			stopGroup.Go(func() error { return server.Stop(ctx) })
 		}
 	}
 

--- a/pkg/relayer/proxy/server_builder.go
+++ b/pkg/relayer/proxy/server_builder.go
@@ -1,0 +1,57 @@
+package proxy
+
+import (
+	"context"
+
+	sharedtypes "pocket/x/shared/types"
+	suppliertypes "pocket/x/supplier/types"
+)
+
+type RelayServersMap map[string][]RelayServer
+
+// BuildProvidedServices builds the provided services from the supplier's on-chain advertised services.
+// It populates the relayerProxy's `providedServices` map of servers for each service, where each server
+// is responsible for listening for incoming relay requests and poxying them to the supported native service.
+func (rp *relayerProxy) BuildProvidedServices(ctx context.Context) error {
+	// Get the supplier address from the keyring
+	supplierAddress, err := rp.keyring.Key(rp.keyName)
+	if err != nil {
+		return err
+	}
+
+	// Get the supplier's advertised information from the blockchain
+	supplierQuery := &suppliertypes.QueryGetSupplierRequest{Address: supplierAddress.String()}
+	supplierQueryResponse, err := rp.supplierQuerier.Supplier(ctx, supplierQuery)
+	if err != nil {
+		return err
+	}
+
+	services := supplierQueryResponse.Supplier.Services
+
+	// Build the provided services map. For each service's endpoint, create the appropriate server.
+	providedServices := make(RelayServersMap)
+	for _, serviceConfig := range services {
+		serviceId := serviceConfig.Id.Id
+		serviceEndpoints := make([]RelayServer, len(serviceConfig.Endpoints))
+
+		for _, endpoint := range serviceConfig.Endpoints {
+			var server RelayServer
+
+			// Switch to the RPC type to create the appropriate server
+			switch endpoint.RpcType {
+			case sharedtypes.RPCType_JSON_RPC:
+				server = NewJSONRPCServer(serviceId, endpoint.Url, rp)
+			default:
+				return ErrUnsupportedRPCType
+			}
+
+			serviceEndpoints = append(serviceEndpoints, server)
+		}
+
+		providedServices[serviceId] = serviceEndpoints
+	}
+
+	rp.providedServices = providedServices
+
+	return nil
+}

--- a/pkg/relayer/proxy/server_builder.go
+++ b/pkg/relayer/proxy/server_builder.go
@@ -29,7 +29,7 @@ func (rp *relayerProxy) BuildProvidedServices(ctx context.Context) error {
 	// Build the advertised relay servers map. For each service's endpoint, create the appropriate RelayServer.
 	providedServices := make(relayServersMap)
 	for _, serviceConfig := range services {
-		serviceId := serviceConfig.Id
+		serviceId := serviceConfig.ServiceId
 		proxiedServicesEndpoints := rp.proxiedServicesEndpoints[serviceId.Id]
 		serviceEndpoints := make([]RelayServer, len(serviceConfig.Endpoints))
 

--- a/pkg/relayer/proxy/server_builder.go
+++ b/pkg/relayer/proxy/server_builder.go
@@ -7,11 +7,9 @@ import (
 	suppliertypes "pocket/x/supplier/types"
 )
 
-type RelayServersMap map[string][]RelayServer
-
-// BuildProvidedServices builds the provided services from the supplier's on-chain advertised services.
-// It populates the relayerProxy's `providedServices` map of servers for each service, where each server
-// is responsible for listening for incoming relay requests and poxying them to the supported native service.
+// BuildProvidedServices builds the advertised relay servers from the supplier's on-chain advertised services.
+// It populates the relayerProxy's `advertisedRelayServers` map of servers for each service, where each server
+// is responsible for listening for incoming relay requests and relaying them to the supported native service.
 func (rp *relayerProxy) BuildProvidedServices(ctx context.Context) error {
 	// Get the supplier address from the keyring
 	supplierAddress, err := rp.keyring.Key(rp.keyName)
@@ -28,7 +26,7 @@ func (rp *relayerProxy) BuildProvidedServices(ctx context.Context) error {
 
 	services := supplierQueryResponse.Supplier.Services
 
-	// Build the provided services map. For each service's endpoint, create the appropriate server.
+	// Build the advertised relay servers map. For each service's endpoint, create the appropriate RelayServer.
 	providedServices := make(RelayServersMap)
 	for _, serviceConfig := range services {
 		serviceId := serviceConfig.Id.Id
@@ -37,7 +35,7 @@ func (rp *relayerProxy) BuildProvidedServices(ctx context.Context) error {
 		for _, endpoint := range serviceConfig.Endpoints {
 			var server RelayServer
 
-			// Switch to the RPC type to create the appropriate server
+			// Switch to the RPC type to create the appropriate RelayServer
 			switch endpoint.RpcType {
 			case sharedtypes.RPCType_JSON_RPC:
 				server = NewJSONRPCServer(serviceId, endpoint.Url, rp)
@@ -51,7 +49,7 @@ func (rp *relayerProxy) BuildProvidedServices(ctx context.Context) error {
 		providedServices[serviceId] = serviceEndpoints
 	}
 
-	rp.providedServices = providedServices
+	rp.advertisedRelayServers = providedServices
 
 	return nil
 }

--- a/pkg/relayer/proxy/server_builder.go
+++ b/pkg/relayer/proxy/server_builder.go
@@ -30,6 +30,7 @@ func (rp *relayerProxy) BuildProvidedServices(ctx context.Context) error {
 	providedServices := make(RelayServersMap)
 	for _, serviceConfig := range services {
 		serviceId := serviceConfig.Id.Id
+		nativeServiceListenAddress := rp.nativeServicesListenAddress[serviceId]
 		serviceEndpoints := make([]RelayServer, len(serviceConfig.Endpoints))
 
 		for _, endpoint := range serviceConfig.Endpoints {
@@ -38,7 +39,13 @@ func (rp *relayerProxy) BuildProvidedServices(ctx context.Context) error {
 			// Switch to the RPC type to create the appropriate RelayServer
 			switch endpoint.RpcType {
 			case sharedtypes.RPCType_JSON_RPC:
-				server = NewJSONRPCServer(serviceId, endpoint.Url, rp)
+				server = NewJSONRPCServer(
+					serviceId,
+					endpoint.Url,
+					nativeServiceListenAddress,
+					rp.servedRelaysProducer,
+					rp,
+				)
 			default:
 				return ErrUnsupportedRPCType
 			}

--- a/proto/pocket/shared/supplier.proto
+++ b/proto/pocket/shared/supplier.proto
@@ -14,5 +14,6 @@ import "pocket/shared/service.proto";
 message Supplier {
   string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"]; // The Bech32 address of the supplier using cosmos' ScalarDescriptor to ensure deterministic deterministic encoding using cosmos' ScalarDescriptor to ensure deterministic deterministic encoding
   cosmos.base.v1beta1.Coin stake = 2; // The total amount of uPOKT the supplier has staked
+  // TODO(@olshansk): This is uncommented for integration purposes but business logic is not yet implemented.
   repeated SupplierServiceConfig services = 3; // The service configs this supplier can support
 }

--- a/proto/pocket/shared/supplier.proto
+++ b/proto/pocket/shared/supplier.proto
@@ -8,12 +8,11 @@ option go_package = "pocket/x/shared/types";
 
 import "cosmos_proto/cosmos.proto";
 import "cosmos/base/v1beta1/coin.proto";
+import "pocket/shared/service.proto";
 
 // Supplier is the type defining the actor in Pocket Network that provides RPC services.
 message Supplier {
   string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"]; // The Bech32 address of the supplier using cosmos' ScalarDescriptor to ensure deterministic deterministic encoding using cosmos' ScalarDescriptor to ensure deterministic deterministic encoding
   cosmos.base.v1beta1.Coin stake = 2; // The total amount of uPOKT the supplier has staked
-  // TODO(@Olshansk): Uncomment the line below once the `ServiceId` proto is defined
-  // repeated service.SupplierServiceConfig services = 3; // The service configs this supplier can support
+  repeated SupplierServiceConfig services = 3; // The service configs this supplier can support
 }
-


### PR DESCRIPTION
## Summary

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 28 Oct 23 01:29 UTC
This pull request includes the following changes:
- The file `supplier.proto` had a deletion of an empty line at the end of the file.
- The file `errors.go` was added to the `pkg/relayer/proxy` directory. It defines a package `proxy` and imports `cosmossdk.io/errors` as `sdkerrors`. It declares a variable `codespace` as "relayer/proxy" and an error `ErrUnsupportedRPCType` with the code 1 and message "unsupported rpc type".
- The file contains interface definitions for the RelayerProxy and RelayServer. The RelayerProxy interface is responsible for starting and stopping all advertised relay servers and notifying the miner about the served relays. It also includes methods for verifying relay request signatures and sessions, as well as signing relay responses. The RelayServer interface represents the advertised relay servers provided by the RelayerProxy and includes methods for starting and stopping the service server, as well as getting the service ID.
- The file diff also shows the addition of a new file called "jsonrpc.go" in the "pkg/relayer/proxy" directory. This file contains the implementation of a JSON-RPC server that listens for incoming relay requests and forwards them to a proxied service endpoint. It includes methods to start, stop, and serve HTTP requests. The implementation is currently incomplete.
- The file `server_builder.go` includes several changes, such as adding imports for `pocket/x/shared/types` and `pocket/x/supplier/types`, implementing a function `BuildProvidedServices` to build advertised relay servers based on on-chain advertised services, retrieving the supplier address and advertised information from the blockchain, creating relay servers for each service, switching to the appropriate RPC type to create the RelayServer, and updating the `advertisedRelayServers` map.

Overall, this pull request introduces changes related to the supplier, error handling, interface definitions, JSON-RPC server implementation, and building advertised relay servers based on on-chain data.
<!-- reviewpad:summarize:end -->

## Issue

- #14 

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updated documentation and left TODOs throughout the codebase
