### PR TITLE
[Test] Enforce `msg.ValidateBasic` in all the `keepers` and `msgServers` for redundancy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	cosmossdk.io/math v1.0.1
 	github.com/cometbft/cometbft v0.37.2
 	github.com/cometbft/cometbft-db v0.8.0
-	github.com/cosmos/cosmos-proto v1.0.0-beta.2
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/cosmos/gogoproto v1.4.10
 	github.com/cosmos/ibc-go/v7 v7.1.0
@@ -23,7 +22,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/sync v0.3.0
-	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	google.golang.org/grpc v1.56.1
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -68,6 +66,7 @@ require (
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
+	github.com/cosmos/cosmos-proto v1.0.0-beta.2 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/iavl v0.20.0 // indirect
@@ -266,6 +265,7 @@ require (
 	gonum.org/v1/gonum v0.11.0 // indirect
 	google.golang.org/api v0.122.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/x/application/keeper/msg_server_delegate_to_gateway.go
+++ b/x/application/keeper/msg_server_delegate_to_gateway.go
@@ -4,11 +4,16 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"pocket/x/application/types"
 )
 
 func (k msgServer) DelegateToGateway(goCtx context.Context, msg *types.MsgDelegateToGateway) (*types.MsgDelegateToGatewayResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
 
 	// TODO: Handling the message
 	_ = ctx

--- a/x/application/keeper/msg_server_stake_application.go
+++ b/x/application/keeper/msg_server_stake_application.go
@@ -18,6 +18,10 @@ func (k msgServer) StakeApplication(
 	logger := k.Logger(ctx).With("method", "StakeApplication")
 	logger.Info("About to stake application with msg: %v", msg)
 
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
 	// Check if the application already exists or not
 	var err error
 	var coinsToDelegate sdk.Coin

--- a/x/application/keeper/msg_server_undelegate_from_gateway.go
+++ b/x/application/keeper/msg_server_undelegate_from_gateway.go
@@ -4,11 +4,16 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"pocket/x/application/types"
 )
 
 func (k msgServer) UndelegateFromGateway(goCtx context.Context, msg *types.MsgUndelegateFromGateway) (*types.MsgUndelegateFromGatewayResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
 
 	// TODO: Handling the message
 	_ = ctx

--- a/x/application/keeper/query_application.go
+++ b/x/application/keeper/query_application.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
 	"pocket/x/application/types"
 )
 

--- a/x/gateway/keeper/msg_server_stake_gateway.go
+++ b/x/gateway/keeper/msg_server_stake_gateway.go
@@ -18,6 +18,10 @@ func (k msgServer) StakeGateway(
 	logger := k.Logger(ctx).With("method", "StakeGateway")
 	logger.Info("About to stake gateway with msg: %v", msg)
 
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
 	// Check if the gateway already exists or not
 	var err error
 	var coinsToDelegate sdk.Coin

--- a/x/gateway/keeper/msg_server_unstake_gateway.go
+++ b/x/gateway/keeper/msg_server_unstake_gateway.go
@@ -19,6 +19,10 @@ func (k msgServer) UnstakeGateway(
 	logger := k.Logger(ctx).With("method", "UnstakeGateway")
 	logger.Info("About to unstake gateway with msg: %v", msg)
 
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
 	// Check if the gateway already exists or not
 	var err error
 	gateway, isGatewayFound := k.GetGateway(ctx, msg.Address)

--- a/x/supplier/keeper/msg_server_create_claim.go
+++ b/x/supplier/keeper/msg_server_create_claim.go
@@ -4,11 +4,16 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"pocket/x/supplier/types"
 )
 
 func (k msgServer) CreateClaim(goCtx context.Context, msg *types.MsgCreateClaim) (*types.MsgCreateClaimResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
 
 	/*
 		INCOMPLETE: Handling the message

--- a/x/supplier/keeper/msg_server_stake_supplier.go
+++ b/x/supplier/keeper/msg_server_stake_supplier.go
@@ -19,6 +19,10 @@ func (k msgServer) StakeSupplier(
 	logger := k.Logger(ctx).With("method", "StakeSupplier")
 	logger.Info("About to stake supplier with msg: %v", msg)
 
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
 	// Check if the supplier already exists or not
 	var err error
 	var coinsToDelegate sdk.Coin

--- a/x/supplier/keeper/msg_server_submit_proof.go
+++ b/x/supplier/keeper/msg_server_submit_proof.go
@@ -4,11 +4,16 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"pocket/x/supplier/types"
 )
 
 func (k msgServer) SubmitProof(goCtx context.Context, msg *types.MsgSubmitProof) (*types.MsgSubmitProofResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
 
 	/*
 		INCOMPLETE: Handling the message

--- a/x/supplier/keeper/msg_server_unstake_supplier.go
+++ b/x/supplier/keeper/msg_server_unstake_supplier.go
@@ -18,8 +18,11 @@ func (k msgServer) UnstakeSupplier(
 	logger := k.Logger(ctx).With("method", "UnstakeSupplier")
 	logger.Info("About to unstake supplier with msg: %v", msg)
 
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
 	// Check if the supplier already exists or not
-	var err error
 	supplier, isSupplierFound := k.GetSupplier(ctx, msg.Address)
 	if !isSupplierFound {
 		logger.Info("Supplier not found. Cannot unstake address %s", msg.Address)


### PR DESCRIPTION
## Summary

### Human Summary

Call `ValidateBasic` on messages & txs before on-chain actors execute the business logic.

The `ValidateBasic` function is often called on the client side, but it is just as important to validate it again (for redundancy) before it is used to execute a state transition.

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 25 Oct 23 22:20 UTC
This pull request adds an extra layer of message validation to several files in the codebase. The patch modifies the `go.mod` file and adds validation checks to message handling functions in various modules including application, gateway, and supplier. Overall, the changes aim to improve the validation and error handling in the code.
<!-- reviewpad:summarize:end -->

## Issue

No issue. Just a small change added for redundancy

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
