### PR TITLE
feat: add either.AsyncErr type & helpers

### DIFF
--- a/pkg/either/errors.go
+++ b/pkg/either/errors.go
@@ -1,0 +1,35 @@
+package either
+
+// SyncErr creates an AsyncError either from a synchronous error.
+// It wraps the Error into the left field (conventionally associated with  the
+// error value in the Either pattern) of the Either type. It casts the result
+// to the AsyncError type.
+func SyncErr(err error) AsyncError {
+	return AsyncError(Error[chan error](err))
+}
+
+// AsyncErr creates an AsyncError from an error channel.
+// It wraps the error channel into the right field (conventionally associated with
+// successful values in the Either pattern) of the Either type.
+func AsyncErr(errCh chan error) AsyncError {
+	return AsyncError(Success[chan error](errCh))
+}
+
+// SyncOrAsyncError decomposes the AsyncError into its components, returning
+// a synchronous error and an error channel. If the AsyncError represents a
+// synchronous error, the error channel will be nil and vice versa.
+func (soaErr AsyncError) SyncOrAsyncError() (error, chan error) {
+	errCh, err := Either[chan error](soaErr).ValueOrError()
+	return err, errCh
+}
+
+// IsSyncError checks if the AsyncError represents a synchronous error.
+func (soaErr AsyncError) IsSyncError() bool {
+	return Either[chan error](soaErr).IsError()
+}
+
+// IsAsyncError checks if the AsyncError represents an asynchronous error
+// (sent through a channel).
+func (soaErr AsyncError) IsAsyncError() bool {
+	return Either[chan error](soaErr).IsSuccess()
+}

--- a/pkg/either/errors.go
+++ b/pkg/either/errors.go
@@ -1,7 +1,7 @@
 package either
 
 // SyncErr creates an AsyncError either from a synchronous error.
-// It wraps the Error into the left field (conventionally associated with  the
+// It wraps the Error into the left field (conventionally associated with the
 // error value in the Either pattern) of the Either type. It casts the result
 // to the AsyncError type.
 func SyncErr(err error) AsyncError {

--- a/pkg/either/types.go
+++ b/pkg/either/types.go
@@ -1,0 +1,6 @@
+package either
+
+// AsyncError represents a value which could either be a synchronous error or
+// an asynchronous error (sent through a channel). It wraps the more generic
+// `Either` type specific for error channels.
+type AsyncError Either[chan error]


### PR DESCRIPTION
## Summary

### Human Summary

Adds the `either.AsyncError` type (i.e. `either.Either[chan error]) as well as helper methods, analogous to `either.Either`'s:
- `SyncErr(err  error) either.AsyncError`
- `AsyncErr(errCh chan error) AsyncError`
- `AsyncError#SyncOrAsyncError() (error, chan error)`
- `AsyncError#IsSyncError() bool`
- `AsyncError#IsAsyncError() bool`

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Oct 23 22:37 UTC
This pull request includes two patches. 

The first patch adds the `either.AsyncErr` type and helper functions to the package `either`. It introduces the `SyncErr` function, which creates an `AsyncError` from a synchronous error, and the `AsyncErr` function, which creates an `AsyncError` from an error channel. It also includes functions to decompose the `AsyncError` into its components and check if it represents a synchronous or asynchronous error.

The second patch fixes a comment typo in the `SyncErr` function in the `errors.go` file of the `either` package.

Overall, this pull request enhances the `either` package by adding a new type and helper functions and fixing a comment typo.
<!-- reviewpad:summarize:end -->

## Issue

Relates to:
- #13 
- #64 
- #94 

1. Adds API for convenience when working with either objects in context where both a synchronous and asynchronous error are in scope.
2. Improves readability in such places.

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_develop_and_test`
- [x] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
