### PR TITLE
[Either] refactor: add `either.Bytes` alias

### DIFF
--- a/pkg/client/events_query/client.go
+++ b/pkg/client/events_query/client.go
@@ -48,9 +48,9 @@ type eventsQueryClient struct {
 // corresponding connection which produces its inputs.
 type eventsBytesAndConn struct {
 	// eventsBytes is an observable which is notified about chain event messages
-	// matching the given query. It receives an either.Either[[]byte] which is
+	// matching the given query. It receives an either.Bytes which is
 	// either an error or the event message bytes.
-	eventsBytes observable.Observable[either.Either[[]byte]]
+	eventsBytes observable.Observable[either.Bytes]
 	conn        client.Connection
 	isClosed    bool
 }
@@ -81,7 +81,7 @@ func NewEventsQueryClient(cometWebsocketURL string, opts ...client.EventsQueryCl
 }
 
 // EventsBytes returns an eventsBytes observable which is notified about chain
-// event messages matching the given query. It receives an either.Either[[]byte]
+// event messages matching the given query. It receives an either.Bytes
 // which is either an error or the event message bytes.
 // (see: https://pkg.go.dev/github.com/cometbft/cometbft/types#pkg-constants)
 // (see: https://docs.cosmos.network/v0.47/core/events#subscribing-to-events)
@@ -151,7 +151,7 @@ func (eqc *eventsQueryClient) newEventsBytesAndConn(
 	}
 
 	// Construct an eventsBytes for the given query.
-	eventsBzObservable, eventsBzPublishCh := channel.NewObservable[either.Either[[]byte]]()
+	eventsBzObservable, eventsBzPublishCh := channel.NewObservable[either.Bytes]()
 
 	// Publish either events bytes or an error received from the connection to
 	// the eventsBz observable.
@@ -198,7 +198,7 @@ func (eqc *eventsQueryClient) openEventsBytesAndConn(
 func (eqc *eventsQueryClient) goPublishEventsBz(
 	ctx context.Context,
 	conn client.Connection,
-	eventsBzPublishCh chan<- either.Either[[]byte],
+	eventsBzPublishCh chan<- either.Bytes,
 ) {
 	// Read and handle messages from the websocket. This loop will exit when the
 	// websocket connection is isClosed and/or returns an error.

--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -22,8 +22,8 @@ import (
 // value which contains either an error or the event message bytes.
 // TODO_HACK: The purpose of this type is to work around gomock's lack of
 // support for generic types. For the same reason, this type cannot be an
-// alias (i.e. EventsBytesObservable = observable.Observable[either.Either[[]byte]]).
-type EventsBytesObservable observable.Observable[either.Either[[]byte]]
+// alias (i.e. EventsBytesObservable = observable.Observable[either.Bytes]).
+type EventsBytesObservable observable.Observable[either.Bytes]
 
 // EventsQueryClient is used to subscribe to chain event messages matching the given query,
 type EventsQueryClient interface {

--- a/pkg/either/types.go
+++ b/pkg/either/types.go
@@ -3,4 +3,7 @@ package either
 // AsyncError represents a value which could either be a synchronous error or
 // an asynchronous error (sent through a channel). It wraps the more generic
 // `Either` type specific for error channels.
-type AsyncError Either[chan error]
+type (
+	AsyncError Either[chan error]
+	Bytes      = Either[[]byte]
+)


### PR DESCRIPTION

## Summary

### Human Summary

Quick refactoring of `either.Either[[]byte]` to `either.Bytes` for improved readability & convenience.

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 30 Oct 23 23:05 UTC
This pull request refactors the code by adding an alias `either.Bytes`. The changes are made in the `pkg/client/events_query/client.go`, `pkg/client/interface.go`, and `pkg/either/types.go` files. The `eventsBytes` field in the `eventsBytesAndConn` struct now receives an `either.Bytes` type instead of `either.Either[[]byte]`. Similarly, the `eventsBzObservable` and `eventsBzPublishCh` variables in the `newEventsBytesAndConn` function are changed to `observable.Observable[either.Bytes]` and `channel.NewObservable[either.Bytes]()` respectively. The `eventsBzPublishCh` parameter in the `goPublishEventsBz` function is also changed to `chan<- either.Bytes`. Furthermore, in the `pkg/client/interface.go` file, the `EventsBytesObservable` type alias is now defined as `observable.Observable[either.Bytes]`. Finally, in the `pkg/either/types.go` file, the `Bytes` type alias is created as a shorthand for `Either[[]byte]`.
<!-- reviewpad:summarize:end -->

## Issue

Relates to:
- #13 
- #94 

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_develop_and_test`
- [x] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
