### PR TITLE
fix: flaky block client test

### DIFF
--- a/internal/testclient/testeventsquery/client.go
+++ b/internal/testclient/testeventsquery/client.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/require"
 
 	"github.com/pokt-network/poktroll/internal/mocks/mockclient"
 	"github.com/pokt-network/poktroll/internal/testclient"
@@ -39,11 +38,9 @@ func NewAnyTimesEventsBytesEventsQueryClient(
 	eventsQueryClient := mockclient.NewMockEventsQueryClient(ctrl)
 	eventsQueryClient.EXPECT().Close().Times(1)
 	eventsQueryClient.EXPECT().
-		EventsBytes(gomock.AssignableToTypeOf(ctx), gomock.AssignableToTypeOf("")).
+		EventsBytes(gomock.AssignableToTypeOf(ctx), gomock.Eq(expectedQuery)).
 		DoAndReturn(
 			func(ctx context.Context, query string) (client.EventsBytesObservable, error) {
-				require.Equal(t, expectedQuery, query)
-
 				bytesObsvbl, bytesPublishCh := channel.NewReplayObservable[either.Bytes](ctx, 1)
 
 				// Now that the observable is set up, publish the expected event bytes.

--- a/internal/testclient/testeventsquery/client.go
+++ b/internal/testclient/testeventsquery/client.go
@@ -1,11 +1,19 @@
 package testeventsquery
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/poktroll/internal/mocks/mockclient"
 	"github.com/pokt-network/poktroll/internal/testclient"
 	"github.com/pokt-network/poktroll/pkg/client"
 	eventsquery "github.com/pokt-network/poktroll/pkg/client/events_query"
+	"github.com/pokt-network/poktroll/pkg/either"
+	"github.com/pokt-network/poktroll/pkg/observable/channel"
 )
 
 // NewLocalnetClient returns a new events query client which is configured to
@@ -14,4 +22,39 @@ func NewLocalnetClient(t *testing.T, opts ...client.EventsQueryClientOption) cli
 	t.Helper()
 
 	return eventsquery.NewEventsQueryClient(testclient.CometLocalWebsocketURL, opts...)
+}
+
+func NewAnyTimesEventsBytesEventsQueryClient(
+	ctx context.Context,
+	t *testing.T,
+	expectedQuery string,
+	expectedEventBytes []byte,
+) client.EventsQueryClient {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	eventsQueryClient := mockclient.NewMockEventsQueryClient(ctrl)
+	eventsQueryClient.EXPECT().Close().Times(1)
+	eventsQueryClient.EXPECT().
+		EventsBytes(gomock.AssignableToTypeOf(ctx), gomock.AssignableToTypeOf("")).
+		DoAndReturn(
+			func(ctx context.Context, query string) (client.EventsBytesObservable, error) {
+				require.Equal(t, expectedQuery, query)
+
+				bytesObsvbl, bytesPublishCh := channel.NewReplayObservable[either.Bytes](ctx, 1)
+
+				// Now that the observable is set up, publish the expected event bytes.
+				// Only need to send once because it's a ReplayObservable.
+				bytesPublishCh <- either.Success(expectedEventBytes)
+
+				// Wait a tick for the observables to be set up. This isn't strictly
+				// necessary but is done to mitigate test flakiness.
+				time.Sleep(10 * time.Millisecond)
+
+				return bytesObsvbl, nil
+			},
+		).
+		AnyTimes()
+
+	return eventsQueryClient
 }

--- a/internal/testclient/testeventsquery/client.go
+++ b/internal/testclient/testeventsquery/client.go
@@ -24,6 +24,9 @@ func NewLocalnetClient(t *testing.T, opts ...client.EventsQueryClientOption) cli
 	return eventsquery.NewEventsQueryClient(testclient.CometLocalWebsocketURL, opts...)
 }
 
+// NewAnyTimesEventsBytesEventsQueryClient returns a new events query client which
+// is configured to return the expected event bytes when queried with the expected
+// query, any number of times. The returned client also expects to be closed once.
 func NewAnyTimesEventsBytesEventsQueryClient(
 	ctx context.Context,
 	t *testing.T,

--- a/pkg/client/block/client.go
+++ b/pkg/client/block/client.go
@@ -155,7 +155,7 @@ func (bClient *blockClient) retryPublishBlocksFactory(ctx context.Context) func(
 		}
 
 		// NB: must cast back to generic observable type to use with Map.
-		// client.BlocksObservable is only used to workaround gomock's lack of
+		// client.BlocksObservable cannot be an alias due to gomock's lack of
 		// support for generic types.
 		eventsBz := observable.Observable[either.Either[[]byte]](eventsBzObsvbl)
 		blockEventFromEventBz := newEventsBytesToBlockMapFn(errCh)


### PR DESCRIPTION
## Summary

### Human Summary

Refactors a flaky block client test to eliminate flakiness (as far as measured, 0:10000) and improve readability.

## Issue

![image](https://github.com/pokt-network/poktroll/assets/600733/97a7e305-82a0-492a-bec8-05bb95cc8ce8)

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_develop_and_test`
- [x] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updated documentation and left TODOs throughout the codebase
