### PR TITLE
[Service] Rename the `ServiceId` proto to `Service`

### DIFF
--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -46477,7 +46477,7 @@ paths:
                       items:
                         type: object
                         properties:
-                          service_id:
+                          service:
                             title: Unique and semantic identifier for the service
                             type: object
                             properties:
@@ -46504,7 +46504,9 @@ paths:
                         title: >-
                           ApplicationServiceConfig holds the service
                           configuration the application stakes for
-                      title: The ID of the service this session is servicing
+                      title: >-
+                        The list of services this appliccation is configured to
+                        request service for
                     delegatee_gateway_addresses:
                       type: array
                       items:
@@ -46659,7 +46661,7 @@ paths:
                     items:
                       type: object
                       properties:
-                        service_id:
+                        service:
                           title: Unique and semantic identifier for the service
                           type: object
                           properties:
@@ -46686,7 +46688,9 @@ paths:
                       title: >-
                         ApplicationServiceConfig holds the service configuration
                         the application stakes for
-                    title: The ID of the service this session is servicing
+                    title: >-
+                      The list of services this appliccation is configured to
+                      request service for
                   delegatee_gateway_addresses:
                     type: array
                     items:
@@ -47090,8 +47094,8 @@ paths:
                         title: >-
                           The Bech32 address of the application using cosmos'
                           ScalarDescriptor to ensure deterministic encoding
-                      service_id:
-                        title: The ID of the service this session is servicing
+                      service:
+                        title: The service this session is for
                         type: object
                         properties:
                           id:
@@ -47173,7 +47177,7 @@ paths:
                         items:
                           type: object
                           properties:
-                            service_id:
+                            service:
                               title: Unique and semantic identifier for the service
                               type: object
                               properties:
@@ -47200,7 +47204,9 @@ paths:
                           title: >-
                             ApplicationServiceConfig holds the service
                             configuration the application stakes for
-                        title: The ID of the service this session is servicing
+                        title: >-
+                          The list of services this appliccation is configured
+                          to request service for
                       delegatee_gateway_addresses:
                         type: array
                         items:
@@ -47240,7 +47246,7 @@ paths:
                           items:
                             type: object
                             properties:
-                              service_id:
+                              service:
                                 title: Unique and semantic identifier for the service
                                 type: object
                                 properties:
@@ -47363,7 +47369,7 @@ paths:
           in: query
           required: false
           type: string
-        - name: service_id.id
+        - name: service.id
           description: >-
             NOTE: `ServiceId.Id` may seem redundant but was desigtned created to
             enable more complex service identification
@@ -47376,7 +47382,7 @@ paths:
           in: query
           required: false
           type: string
-        - name: service_id.name
+        - name: service.name
           description: >-
             TODO_TECHDEBT: Name is currently unused but acts as a reminder than
             an optional onchain representation of the service is necessary
@@ -76616,7 +76622,7 @@ definitions:
         items:
           type: object
           properties:
-            service_id:
+            service:
               title: Unique and semantic identifier for the service
               type: object
               properties:
@@ -76640,7 +76646,9 @@ definitions:
           title: >-
             ApplicationServiceConfig holds the service configuration the
             application stakes for
-        title: The ID of the service this session is servicing
+        title: >-
+          The list of services this appliccation is configured to request
+          service for
       delegatee_gateway_addresses:
         type: array
         items:
@@ -76701,7 +76709,7 @@ definitions:
               items:
                 type: object
                 properties:
-                  service_id:
+                  service:
                     title: Unique and semantic identifier for the service
                     type: object
                     properties:
@@ -76728,7 +76736,9 @@ definitions:
                 title: >-
                   ApplicationServiceConfig holds the service configuration the
                   application stakes for
-              title: The ID of the service this session is servicing
+              title: >-
+                The list of services this appliccation is configured to request
+                service for
             delegatee_gateway_addresses:
               type: array
               items:
@@ -76797,7 +76807,7 @@ definitions:
             items:
               type: object
               properties:
-                service_id:
+                service:
                   title: Unique and semantic identifier for the service
                   type: object
                   properties:
@@ -76822,7 +76832,9 @@ definitions:
               title: >-
                 ApplicationServiceConfig holds the service configuration the
                 application stakes for
-            title: The ID of the service this session is servicing
+            title: >-
+              The list of services this appliccation is configured to request
+              service for
           delegatee_gateway_addresses:
             type: array
             items:
@@ -76850,7 +76862,7 @@ definitions:
   pocket.shared.ApplicationServiceConfig:
     type: object
     properties:
-      service_id:
+      service:
         title: Unique and semantic identifier for the service
         type: object
         properties:
@@ -76873,7 +76885,7 @@ definitions:
     title: >-
       ApplicationServiceConfig holds the service configuration the application
       stakes for
-  pocket.shared.ServiceId:
+  pocket.shared.Service:
     type: object
     properties:
       id:
@@ -76892,7 +76904,7 @@ definitions:
           TODO_TECHDEBT: Name is currently unused but acts as a reminder than an
           optional onchain representation of the service is necessary
     title: >-
-      ServiceId message to encapsulate unique and semantic identifiers for a
+      Service message to encapsulate unique and semantic identifiers for a
       service on the network
   pocket.gateway.Gateway:
     type: object
@@ -77043,8 +77055,8 @@ definitions:
                 title: >-
                   The Bech32 address of the application using cosmos'
                   ScalarDescriptor to ensure deterministic encoding
-              service_id:
-                title: The ID of the service this session is servicing
+              service:
+                title: The service this session is for
                 type: object
                 properties:
                   id:
@@ -77121,7 +77133,7 @@ definitions:
                 items:
                   type: object
                   properties:
-                    service_id:
+                    service:
                       title: Unique and semantic identifier for the service
                       type: object
                       properties:
@@ -77148,7 +77160,9 @@ definitions:
                   title: >-
                     ApplicationServiceConfig holds the service configuration the
                     application stakes for
-                title: The ID of the service this session is servicing
+                title: >-
+                  The list of services this appliccation is configured to
+                  request service for
               delegatee_gateway_addresses:
                 type: array
                 items:
@@ -77187,7 +77201,7 @@ definitions:
                   items:
                     type: object
                     properties:
-                      service_id:
+                      service:
                         title: Unique and semantic identifier for the service
                         type: object
                         properties:
@@ -77300,8 +77314,8 @@ definitions:
             title: >-
               The Bech32 address of the application using cosmos'
               ScalarDescriptor to ensure deterministic encoding
-          service_id:
-            title: The ID of the service this session is servicing
+          service:
+            title: The service this session is for
             type: object
             properties:
               id:
@@ -77378,7 +77392,7 @@ definitions:
             items:
               type: object
               properties:
-                service_id:
+                service:
                   title: Unique and semantic identifier for the service
                   type: object
                   properties:
@@ -77403,7 +77417,9 @@ definitions:
               title: >-
                 ApplicationServiceConfig holds the service configuration the
                 application stakes for
-            title: The ID of the service this session is servicing
+            title: >-
+              The list of services this appliccation is configured to request
+              service for
           delegatee_gateway_addresses:
             type: array
             items:
@@ -77442,7 +77458,7 @@ definitions:
               items:
                 type: object
                 properties:
-                  service_id:
+                  service:
                     title: Unique and semantic identifier for the service
                     type: object
                     properties:
@@ -77542,8 +77558,8 @@ definitions:
         title: >-
           The Bech32 address of the application using cosmos' ScalarDescriptor
           to ensure deterministic encoding
-      service_id:
-        title: The ID of the service this session is servicing
+      service:
+        title: The service this session is for
         type: object
         properties:
           id:
@@ -77572,6 +77588,26 @@ definitions:
         title: >-
           NOTE: session_id can be derived from the above values using on-chain
           but is included in the header for convenience
+      service_id:
+        title: The ID of the service this session is servicing
+        type: object
+        properties:
+          id:
+            type: string
+            description: Unique identifier for the service
+            title: >-
+              NOTE: `ServiceId.Id` may seem redundant but was desigtned created
+              to enable more complex service identification
+
+              For example, what if we want to request a session for a certain
+              service but with some additional configs that identify it?
+          name:
+            type: string
+            description: (Optional) Semantic human readable name for the service
+            title: >-
+              TODO_TECHDEBT: Name is currently unused but acts as a reminder
+              than an optional onchain representation of the service is
+              necessary
     description: >-
       SessionHeader is a lightweight header for a session that can be passed
       around.
@@ -77657,7 +77693,7 @@ definitions:
         items:
           type: object
           properties:
-            service_id:
+            service:
               title: Unique and semantic identifier for the service
               type: object
               properties:
@@ -77730,6 +77766,27 @@ definitions:
                     title: Additional configuration options for the endpoint
                 title: SupplierEndpoint message to hold service configuration details
               title: List of endpoints for the service
+            service_id:
+              title: Unique and semantic identifier for the service
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: Unique identifier for the service
+                  title: >-
+                    NOTE: `ServiceId.Id` may seem redundant but was desigtned
+                    created to enable more complex service identification
+
+                    For example, what if we want to request a session for a
+                    certain service but with some additional configs that
+                    identify it?
+                name:
+                  type: string
+                  description: (Optional) Semantic human readable name for the service
+                  title: >-
+                    TODO_TECHDEBT: Name is currently unused but acts as a
+                    reminder than an optional onchain representation of the
+                    service is necessary
           title: >-
             SupplierServiceConfig holds the service configuration the supplier
             stakes for
@@ -77789,7 +77846,7 @@ definitions:
   pocket.shared.SupplierServiceConfig:
     type: object
     properties:
-      service_id:
+      service:
         title: Unique and semantic identifier for the service
         type: object
         properties:
@@ -77861,9 +77918,50 @@ definitions:
               title: Additional configuration options for the endpoint
           title: SupplierEndpoint message to hold service configuration details
         title: List of endpoints for the service
+      service_id:
+        title: Unique and semantic identifier for the service
+        type: object
+        properties:
+          id:
+            type: string
+            description: Unique identifier for the service
+            title: >-
+              NOTE: `ServiceId.Id` may seem redundant but was desigtned created
+              to enable more complex service identification
+
+              For example, what if we want to request a session for a certain
+              service but with some additional configs that identify it?
+          name:
+            type: string
+            description: (Optional) Semantic human readable name for the service
+            title: >-
+              TODO_TECHDEBT: Name is currently unused but acts as a reminder
+              than an optional onchain representation of the service is
+              necessary
     title: >-
       SupplierServiceConfig holds the service configuration the supplier stakes
       for
+  pocket.shared.ServiceId:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Unique identifier for the service
+        title: >-
+          NOTE: `ServiceId.Id` may seem redundant but was desigtned created to
+          enable more complex service identification
+
+          For example, what if we want to request a session for a certain
+          service but with some additional configs that identify it?
+      name:
+        type: string
+        description: (Optional) Semantic human readable name for the service
+        title: >-
+          TODO_TECHDEBT: Name is currently unused but acts as a reminder than an
+          optional onchain representation of the service is necessary
+    title: >-
+      ServiceId message to encapsulate unique and semantic identifiers for a
+      service on the network
   pocket.supplier.MsgCreateClaimResponse:
     type: object
   pocket.supplier.MsgStakeSupplierResponse:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	cosmossdk.io/math v1.0.1
 	github.com/cometbft/cometbft v0.37.2
 	github.com/cometbft/cometbft-db v0.8.0
-	github.com/cosmos/cosmos-proto v1.0.0-beta.2
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/cosmos/gogoproto v1.4.10
 	github.com/cosmos/ibc-go/v7 v7.1.0
@@ -27,7 +26,6 @@ require (
 	go.uber.org/multierr v1.11.0
 	golang.org/x/crypto v0.12.0
 	golang.org/x/sync v0.3.0
-	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	google.golang.org/grpc v1.56.1
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -71,6 +69,7 @@ require (
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
+	github.com/cosmos/cosmos-proto v1.0.0-beta.2 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/iavl v0.20.0 // indirect
@@ -266,6 +265,7 @@ require (
 	gonum.org/v1/gonum v0.11.0 // indirect
 	google.golang.org/api v0.122.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	cosmossdk.io/math v1.0.1
 	github.com/cometbft/cometbft v0.37.2
 	github.com/cometbft/cometbft-db v0.8.0
+	github.com/cosmos/cosmos-proto v1.0.0-beta.2
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/cosmos/gogoproto v1.4.10
 	github.com/cosmos/ibc-go/v7 v7.1.0
@@ -26,6 +27,7 @@ require (
 	go.uber.org/multierr v1.11.0
 	golang.org/x/crypto v0.12.0
 	golang.org/x/sync v0.3.0
+	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	google.golang.org/grpc v1.56.1
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -69,7 +71,6 @@ require (
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
-	github.com/cosmos/cosmos-proto v1.0.0-beta.2 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/iavl v0.20.0 // indirect
@@ -265,7 +266,6 @@ require (
 	gonum.org/v1/gonum v0.11.0 // indirect
 	google.golang.org/api v0.122.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/pkg/relayer/proxy/interface.go
+++ b/pkg/relayer/proxy/interface.go
@@ -42,5 +42,5 @@ type RelayServer interface {
 	Stop(ctx context.Context) error
 
 	// ServiceId returns the serviceId of the service.
-	ServiceId() *sharedtypes.ServiceId
+	Service() *sharedtypes.Service
 }

--- a/pkg/relayer/proxy/interface.go
+++ b/pkg/relayer/proxy/interface.go
@@ -41,6 +41,6 @@ type RelayServer interface {
 	// Stop terminates the service server and returns an error if it fails.
 	Stop(ctx context.Context) error
 
-	// ServiceId returns the serviceId of the service.
+	// Service returns the serviceId of the service.
 	Service() *sharedtypes.Service
 }

--- a/pkg/relayer/proxy/jsonrpc.go
+++ b/pkg/relayer/proxy/jsonrpc.go
@@ -12,8 +12,8 @@ import (
 var _ RelayServer = (*jsonRPCServer)(nil)
 
 type jsonRPCServer struct {
-	// serviceId is the id of the service that the server is responsible for.
-	serviceId *sharedtypes.ServiceId
+	// service is the id of the service that the server is responsible for.
+	service *sharedtypes.Service
 
 	// serverEndpoint is the advertised endpoint configuration that the server uses to
 	// listen for incoming relay requests.
@@ -38,14 +38,14 @@ type jsonRPCServer struct {
 // It takes the serviceId, endpointUrl, and the main RelayerProxy as arguments and returns
 // a RelayServer that listens to incoming RelayRequests
 func NewJSONRPCServer(
-	serviceId *sharedtypes.ServiceId,
+	service *sharedtypes.Service,
 	supplierEndpoint *sharedtypes.SupplierEndpoint,
 	proxiedServiceEndpoint url.URL,
 	servedRelaysProducer chan<- *types.Relay,
 	proxy RelayerProxy,
 ) RelayServer {
 	return &jsonRPCServer{
-		serviceId:              serviceId,
+		service:                service,
 		serverEndpoint:         supplierEndpoint,
 		server:                 &http.Server{Addr: supplierEndpoint.Url},
 		relayerProxy:           proxy,
@@ -71,9 +71,9 @@ func (j *jsonRPCServer) Stop(ctx context.Context) error {
 	return j.server.Shutdown(ctx)
 }
 
-// ServiceId returns the serviceId of the JSON-RPC service.
-func (j *jsonRPCServer) ServiceId() *sharedtypes.ServiceId {
-	return j.serviceId
+// Service returns the serviceId of the JSON-RPC service.
+func (j *jsonRPCServer) Service() *sharedtypes.Service {
+	return j.service
 }
 
 // ServeHTTP listens for incoming relay requests. It implements the respective

--- a/pkg/relayer/proxy/server_builder.go
+++ b/pkg/relayer/proxy/server_builder.go
@@ -29,8 +29,8 @@ func (rp *relayerProxy) BuildProvidedServices(ctx context.Context) error {
 	// Build the advertised relay servers map. For each service's endpoint, create the appropriate RelayServer.
 	providedServices := make(relayServersMap)
 	for _, serviceConfig := range services {
-		serviceId := serviceConfig.ServiceId
-		proxiedServicesEndpoints := rp.proxiedServicesEndpoints[serviceId.Id]
+		service := serviceConfig.Service
+		proxiedServicesEndpoints := rp.proxiedServicesEndpoints[service.Id]
 		serviceEndpoints := make([]RelayServer, len(serviceConfig.Endpoints))
 
 		for _, endpoint := range serviceConfig.Endpoints {
@@ -40,7 +40,7 @@ func (rp *relayerProxy) BuildProvidedServices(ctx context.Context) error {
 			switch endpoint.RpcType {
 			case sharedtypes.RPCType_JSON_RPC:
 				server = NewJSONRPCServer(
-					serviceId,
+					service,
 					endpoint,
 					proxiedServicesEndpoints,
 					rp.servedRelaysProducer,
@@ -53,7 +53,7 @@ func (rp *relayerProxy) BuildProvidedServices(ctx context.Context) error {
 			serviceEndpoints = append(serviceEndpoints, server)
 		}
 
-		providedServices[serviceId.Id] = serviceEndpoints
+		providedServices[service.Id] = serviceEndpoints
 	}
 
 	rp.advertisedRelayServers = providedServices

--- a/proto/pocket/application/application.proto
+++ b/proto/pocket/application/application.proto
@@ -13,6 +13,6 @@ import "pocket/shared/service.proto";
 message Application {
   string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"]; // The Bech32 address of the application using cosmos' ScalarDescriptor to ensure deterministic encoding
   cosmos.base.v1beta1.Coin stake = 2; // The total amount of uPOKT the application has staked
-  repeated shared.ApplicationServiceConfig service_configs = 3; // The ID of the service this session is servicing
+  repeated shared.ApplicationServiceConfig service_configs = 3; // The list of services this appliccation is configured to request service for
   repeated string delegatee_gateway_addresses = 4 [(cosmos_proto.scalar) = "cosmos.AddressString", (gogoproto.nullable) = false]; // The Bech32 encoded addresses for all delegatee Gateways, in a non-nullable slice
 }

--- a/proto/pocket/session/query.proto
+++ b/proto/pocket/session/query.proto
@@ -38,7 +38,7 @@ message QueryParamsResponse {
 
 message QueryGetSessionRequest {
   string application_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"]; // The Bech32 address of the application using cosmos' ScalarDescriptor to ensure deterministic encoding
-  shared.ServiceId service_id = 2; // The service id to query the session for
+  shared.Service service = 2; // The service id to query the session for
   int64 block_height = 3; // The block height to query the session for
 }
 

--- a/proto/pocket/session/session.proto
+++ b/proto/pocket/session/session.proto
@@ -14,7 +14,7 @@ import "pocket/shared/supplier.proto";
 // It is the minimal amount of data required to hydrate & retrieve all data relevant to the session.
 message SessionHeader {
     string application_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"]; // The Bech32 address of the application using cosmos' ScalarDescriptor to ensure deterministic encoding
-    shared.ServiceId service_id = 2; // The ID of the service this session is servicing
+    shared.Service service = 2; // The service this session is for
     int64 session_start_block_height = 3; // The height at which this session started
     // NOTE: session_id can be derived from the above values using on-chain but is included in the header for convenience
     string session_id = 4; // A unique pseudoranom ID for this session

--- a/proto/pocket/shared/service.proto
+++ b/proto/pocket/shared/service.proto
@@ -8,8 +8,8 @@ option go_package = "github.com/pokt-network/poktroll/x/shared/types";
 
 // TODO_CLEANUP(@Olshansk): Add native optional identifiers once its supported; https://github.com/ignite/cli/issues/3698
 
-// ServiceId message to encapsulate unique and semantic identifiers for a service on the network
-message ServiceId {
+// Service message to encapsulate unique and semantic identifiers for a service on the network
+message Service {
     // NOTE: `ServiceId.Id` may seem redundant but was desigtned created to enable more complex service identification
     // For example, what if we want to request a session for a certain service but with some additional configs that identify it?
     string id = 1; // Unique identifier for the service
@@ -23,7 +23,7 @@ message ServiceId {
 
 // ApplicationServiceConfig holds the service configuration the application stakes for
 message ApplicationServiceConfig {
-    ServiceId service_id = 1; // Unique and semantic identifier for the service
+    Service service = 1; // Unique and semantic identifier for the service
 
     // TODO_RESEARCH: There is an opportunity for applications to advertise the max
     // they're willing to pay for a certain configuration/price, but this is outside of scope.
@@ -32,7 +32,7 @@ message ApplicationServiceConfig {
 
 // SupplierServiceConfig holds the service configuration the supplier stakes for
 message SupplierServiceConfig {
-    ServiceId service_id = 1; // Unique and semantic identifier for the service
+    Service service = 1; // Unique and semantic identifier for the service
     repeated SupplierEndpoint endpoints = 2; // List of endpoints for the service
     // TODO_RESEARCH: There is an opportunity for supplier to advertise the min
     // they're willing to earn for a certain configuration/price, but this is outside of scope.

--- a/proto/pocket/shared/service.proto
+++ b/proto/pocket/shared/service.proto
@@ -6,19 +6,14 @@ package pocket.shared;
 
 option go_package = "github.com/pokt-network/poktroll/x/shared/types";
 
-// TODO_CLEANUP(@Olshansk): Add native optional identifiers once its supported; https://github.com/ignite/cli/issues/3698
-
 // Service message to encapsulate unique and semantic identifiers for a service on the network
 message Service {
-    // NOTE: `ServiceId.Id` may seem redundant but was desigtned created to enable more complex service identification
+    // NOTE: `Service.Id` may seem redundant but was desigtned created to enable more complex service identification
     // For example, what if we want to request a session for a certain service but with some additional configs that identify it?
     string id = 1; // Unique identifier for the service
 
     // TODO_TECHDEBT: Name is currently unused but acts as a reminder than an optional onchain representation of the service is necessary
     string name = 2; // (Optional) Semantic human readable name for the service
-
-    // NOTE: `ServiceId.Id` may seem redundant but was designed to enable more complex service identification.
-    // For example, what if we want to request a session for a certain service but with some additional configs that identify it?
 }
 
 // ApplicationServiceConfig holds the service configuration the application stakes for

--- a/testutil/keeper/session.go
+++ b/testutil/keeper/session.go
@@ -36,10 +36,10 @@ var (
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		ServiceConfigs: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: TestServiceId1},
+				Service: &sharedtypes.Service{Id: TestServiceId1},
 			},
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: TestServiceId2},
+				Service: &sharedtypes.Service{Id: TestServiceId2},
 			},
 		},
 	}
@@ -50,10 +50,10 @@ var (
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		ServiceConfigs: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: TestServiceId1},
+				Service: &sharedtypes.Service{Id: TestServiceId1},
 			},
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: TestServiceId2},
+				Service: &sharedtypes.Service{Id: TestServiceId2},
 			},
 		},
 	}
@@ -65,7 +65,7 @@ var (
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.SupplierServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: TestServiceId1},
+				Service: &sharedtypes.Service{Id: TestServiceId1},
 				Endpoints: []*sharedtypes.SupplierEndpoint{
 					{
 						Url:     TestSupplierUrl,
@@ -75,7 +75,7 @@ var (
 				},
 			},
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: TestServiceId2},
+				Service: &sharedtypes.Service{Id: TestServiceId2},
 				Endpoints: []*sharedtypes.SupplierEndpoint{
 					{
 						Url:     TestSupplierUrl,

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -111,7 +111,7 @@ func DefaultApplicationModuleGenesisState(t *testing.T, n int) *apptypes.Genesis
 			Stake:   &stake,
 			ServiceConfigs: []*sharedtypes.ApplicationServiceConfig{
 				{
-					ServiceId: &sharedtypes.ServiceId{Id: fmt.Sprintf("svc%d", i)},
+					Service: &sharedtypes.Service{Id: fmt.Sprintf("svc%d", i)},
 				},
 			},
 		}
@@ -152,7 +152,7 @@ func DefaultSupplierModuleGenesisState(t *testing.T, n int) *suppliertypes.Genes
 			Stake:   &stake,
 			Services: []*sharedtypes.SupplierServiceConfig{
 				{
-					ServiceId: &sharedtypes.ServiceId{Id: fmt.Sprintf("svc%d", i)},
+					Service: &sharedtypes.Service{Id: fmt.Sprintf("svc%d", i)},
 					Endpoints: []*sharedtypes.SupplierEndpoint{
 						{
 							Url:     fmt.Sprintf("http://localhost:%d", i),

--- a/x/application/genesis_test.go
+++ b/x/application/genesis_test.go
@@ -24,7 +24,7 @@ func TestGenesis(t *testing.T) {
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				ServiceConfigs: []*sharedtypes.ApplicationServiceConfig{
 					{
-						ServiceId: &sharedtypes.ServiceId{Id: "svc1"},
+						Service: &sharedtypes.Service{Id: "svc1"},
 					},
 				},
 			},
@@ -33,7 +33,7 @@ func TestGenesis(t *testing.T) {
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				ServiceConfigs: []*sharedtypes.ApplicationServiceConfig{
 					{
-						ServiceId: &sharedtypes.ServiceId{Id: "svc2"},
+						Service: &sharedtypes.Service{Id: "svc2"},
 					},
 				},
 			},

--- a/x/application/keeper/application_test.go
+++ b/x/application/keeper/application_test.go
@@ -33,7 +33,7 @@ func createNApplication(keeper *keeper.Keeper, ctx sdk.Context, n int) []types.A
 		app.Stake = &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(int64(i))}
 		app.ServiceConfigs = []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: fmt.Sprintf("svc%d", i)},
+				Service: &sharedtypes.Service{Id: fmt.Sprintf("svc%d", i)},
 			},
 		}
 		keeper.SetApplication(ctx, *app)

--- a/x/application/keeper/msg_server_delegate_to_gateway_test.go
+++ b/x/application/keeper/msg_server_delegate_to_gateway_test.go
@@ -36,7 +36,7 @@ func TestMsgServer_DelegateToGateway_SuccessfullyDelegate(t *testing.T) {
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc1"},
+				Service: &sharedtypes.Service{Id: "svc1"},
 			},
 		},
 	}
@@ -100,7 +100,7 @@ func TestMsgServer_DelegateToGateway_FailDuplicate(t *testing.T) {
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc1"},
+				Service: &sharedtypes.Service{Id: "svc1"},
 			},
 		},
 	}
@@ -158,7 +158,7 @@ func TestMsgServer_DelegateToGateway_FailGatewayNotStaked(t *testing.T) {
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc1"},
+				Service: &sharedtypes.Service{Id: "svc1"},
 			},
 		},
 	}
@@ -203,7 +203,7 @@ func TestMsgServer_DelegateToGateway_FailMaxReached(t *testing.T) {
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc1"},
+				Service: &sharedtypes.Service{Id: "svc1"},
 			},
 		},
 	}

--- a/x/application/keeper/msg_server_stake_application_test.go
+++ b/x/application/keeper/msg_server_stake_application_test.go
@@ -31,7 +31,7 @@ func TestMsgServer_StakeApplication_SuccessfulCreateAndUpdate(t *testing.T) {
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc1"},
+				Service: &sharedtypes.Service{Id: "svc1"},
 			},
 		},
 	}
@@ -46,7 +46,7 @@ func TestMsgServer_StakeApplication_SuccessfulCreateAndUpdate(t *testing.T) {
 	require.Equal(t, addr, appFound.Address)
 	require.Equal(t, int64(100), appFound.Stake.Amount.Int64())
 	require.Len(t, appFound.ServiceConfigs, 1)
-	require.Equal(t, "svc1", appFound.ServiceConfigs[0].ServiceId.Id)
+	require.Equal(t, "svc1", appFound.ServiceConfigs[0].Service.Id)
 
 	// Prepare an updated application with a higher stake and another service
 	updateStakeMsg := &types.MsgStakeApplication{
@@ -54,10 +54,10 @@ func TestMsgServer_StakeApplication_SuccessfulCreateAndUpdate(t *testing.T) {
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(200)},
 		Services: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc1"},
+				Service: &sharedtypes.Service{Id: "svc1"},
 			},
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc2"},
+				Service: &sharedtypes.Service{Id: "svc2"},
 			},
 		},
 	}
@@ -69,8 +69,8 @@ func TestMsgServer_StakeApplication_SuccessfulCreateAndUpdate(t *testing.T) {
 	require.True(t, isAppFound)
 	require.Equal(t, int64(200), appFound.Stake.Amount.Int64())
 	require.Len(t, appFound.ServiceConfigs, 2)
-	require.Equal(t, "svc1", appFound.ServiceConfigs[0].ServiceId.Id)
-	require.Equal(t, "svc2", appFound.ServiceConfigs[1].ServiceId.Id)
+	require.Equal(t, "svc1", appFound.ServiceConfigs[0].Service.Id)
+	require.Equal(t, "svc2", appFound.ServiceConfigs[1].Service.Id)
 }
 
 func TestMsgServer_StakeApplication_FailRestakingDueToInvalidServices(t *testing.T) {
@@ -86,7 +86,7 @@ func TestMsgServer_StakeApplication_FailRestakingDueToInvalidServices(t *testing
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc1"},
+				Service: &sharedtypes.Service{Id: "svc1"},
 			},
 		},
 	}
@@ -111,7 +111,7 @@ func TestMsgServer_StakeApplication_FailRestakingDueToInvalidServices(t *testing
 	require.True(t, isAppFound)
 	require.Equal(t, appAddr, app.Address)
 	require.Len(t, app.ServiceConfigs, 1)
-	require.Equal(t, "svc1", app.ServiceConfigs[0].ServiceId.Id)
+	require.Equal(t, "svc1", app.ServiceConfigs[0].Service.Id)
 
 	// Prepare the application stake message with an invalid service ID
 	updateStakeMsg = &types.MsgStakeApplication{
@@ -119,7 +119,7 @@ func TestMsgServer_StakeApplication_FailRestakingDueToInvalidServices(t *testing
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc1 INVALID ! & *"},
+				Service: &sharedtypes.Service{Id: "svc1 INVALID ! & *"},
 			},
 		},
 	}
@@ -133,7 +133,7 @@ func TestMsgServer_StakeApplication_FailRestakingDueToInvalidServices(t *testing
 	require.True(t, isAppFound)
 	require.Equal(t, appAddr, app.Address)
 	require.Len(t, app.ServiceConfigs, 1)
-	require.Equal(t, "svc1", app.ServiceConfigs[0].ServiceId.Id)
+	require.Equal(t, "svc1", app.ServiceConfigs[0].Service.Id)
 }
 
 func TestMsgServer_StakeApplication_FailLoweringStake(t *testing.T) {
@@ -148,7 +148,7 @@ func TestMsgServer_StakeApplication_FailLoweringStake(t *testing.T) {
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc1"},
+				Service: &sharedtypes.Service{Id: "svc1"},
 			},
 		},
 	}
@@ -165,7 +165,7 @@ func TestMsgServer_StakeApplication_FailLoweringStake(t *testing.T) {
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(50)},
 		Services: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc1"},
+				Service: &sharedtypes.Service{Id: "svc1"},
 			},
 		},
 	}

--- a/x/application/keeper/msg_server_undelegate_from_gateway_test.go
+++ b/x/application/keeper/msg_server_undelegate_from_gateway_test.go
@@ -39,7 +39,7 @@ func TestMsgServer_UndelegateFromGateway_SuccessfullyUndelegate(t *testing.T) {
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc1"},
+				Service: &sharedtypes.Service{Id: "svc1"},
 			},
 		},
 	}
@@ -113,7 +113,7 @@ func TestMsgServer_UndelegateFromGateway_FailNotDelegated(t *testing.T) {
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc1"},
+				Service: &sharedtypes.Service{Id: "svc1"},
 			},
 		},
 	}
@@ -174,7 +174,7 @@ func TestMsgServer_UndelegateFromGateway_SuccessfullyUndelegateFromUnstakedGatew
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc1"},
+				Service: &sharedtypes.Service{Id: "svc1"},
 			},
 		},
 	}

--- a/x/application/keeper/msg_server_unstake_application_test.go
+++ b/x/application/keeper/msg_server_unstake_application_test.go
@@ -32,7 +32,7 @@ func TestMsgServer_UnstakeApplication_Success(t *testing.T) {
 		Stake:   &initialStake,
 		Services: []*sharedtypes.ApplicationServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc1"},
+				Service: &sharedtypes.Service{Id: "svc1"},
 			},
 		},
 	}

--- a/x/application/types/genesis_test.go
+++ b/x/application/types/genesis_test.go
@@ -15,13 +15,13 @@ func TestGenesisState_Validate(t *testing.T) {
 	addr1 := sample.AccAddress()
 	stake1 := sdk.NewCoin("upokt", sdk.NewInt(100))
 	svc1AppConfig := &sharedtypes.ApplicationServiceConfig{
-		ServiceId: &sharedtypes.ServiceId{Id: "svc1"},
+		Service: &sharedtypes.Service{Id: "svc1"},
 	}
 
 	addr2 := sample.AccAddress()
 	stake2 := sdk.NewCoin("upokt", sdk.NewInt(100))
 	svc2AppConfig := &sharedtypes.ApplicationServiceConfig{
-		ServiceId: &sharedtypes.ServiceId{Id: "svc2"},
+		Service: &sharedtypes.Service{Id: "svc2"},
 	}
 
 	emptyDelegatees := make([]string, 0)
@@ -314,7 +314,7 @@ func TestGenesisState_Validate(t *testing.T) {
 						Address: addr1,
 						Stake:   &stake1,
 						ServiceConfigs: []*sharedtypes.ApplicationServiceConfig{
-							{ServiceId: &sharedtypes.ServiceId{Id: "12345678901"}},
+							{Service: &sharedtypes.Service{Id: "12345678901"}},
 						},
 						DelegateeGatewayAddresses: emptyDelegatees,
 					},
@@ -333,7 +333,7 @@ func TestGenesisState_Validate(t *testing.T) {
 						Address: addr1,
 						Stake:   &stake1,
 						ServiceConfigs: []*sharedtypes.ApplicationServiceConfig{
-							{ServiceId: &sharedtypes.ServiceId{
+							{Service: &sharedtypes.Service{
 								Id:   "123",
 								Name: "abcdefghijklmnopqrstuvwxyzab-abcdefghijklmnopqrstuvwxyzab",
 							}},
@@ -355,7 +355,7 @@ func TestGenesisState_Validate(t *testing.T) {
 						Address: addr1,
 						Stake:   &stake1,
 						ServiceConfigs: []*sharedtypes.ApplicationServiceConfig{
-							{ServiceId: &sharedtypes.ServiceId{Id: "12 45 !"}},
+							{Service: &sharedtypes.Service{Id: "12 45 !"}},
 						},
 						DelegateeGatewayAddresses: emptyDelegatees,
 					},

--- a/x/application/types/message_stake_application.go
+++ b/x/application/types/message_stake_application.go
@@ -23,7 +23,7 @@ func NewMsgStakeApplication(
 	appServiceConfigs := make([]*sharedtypes.ApplicationServiceConfig, len(serviceIds))
 	for idx, serviceId := range serviceIds {
 		appServiceConfigs[idx] = &sharedtypes.ApplicationServiceConfig{
-			ServiceId: &sharedtypes.ServiceId{
+			Service: &sharedtypes.Service{
 				Id: serviceId,
 			},
 		}

--- a/x/application/types/message_stake_application_test.go
+++ b/x/application/types/message_stake_application_test.go
@@ -23,7 +23,7 @@ func TestMsgStakeApplication_ValidateBasic(t *testing.T) {
 				Address: "invalid_address",
 				// Stake explicitly nil
 				Services: []*sharedtypes.ApplicationServiceConfig{
-					{ServiceId: &sharedtypes.ServiceId{Id: "svc1"}},
+					{Service: &sharedtypes.Service{Id: "svc1"}},
 				},
 			},
 			err: ErrAppInvalidAddress,
@@ -36,7 +36,7 @@ func TestMsgStakeApplication_ValidateBasic(t *testing.T) {
 				Address: sample.AccAddress(),
 				// Stake explicitly nil
 				Services: []*sharedtypes.ApplicationServiceConfig{
-					{ServiceId: &sharedtypes.ServiceId{Id: "svc1"}},
+					{Service: &sharedtypes.Service{Id: "svc1"}},
 				},
 			},
 			err: ErrAppInvalidStake,
@@ -46,7 +46,7 @@ func TestMsgStakeApplication_ValidateBasic(t *testing.T) {
 				Address: sample.AccAddress(),
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.ApplicationServiceConfig{
-					{ServiceId: &sharedtypes.ServiceId{Id: "svc1"}},
+					{Service: &sharedtypes.Service{Id: "svc1"}},
 				},
 			},
 		}, {
@@ -55,7 +55,7 @@ func TestMsgStakeApplication_ValidateBasic(t *testing.T) {
 				Address: sample.AccAddress(),
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(0)},
 				Services: []*sharedtypes.ApplicationServiceConfig{
-					{ServiceId: &sharedtypes.ServiceId{Id: "svc1"}},
+					{Service: &sharedtypes.Service{Id: "svc1"}},
 				},
 			},
 			err: ErrAppInvalidStake,
@@ -65,7 +65,7 @@ func TestMsgStakeApplication_ValidateBasic(t *testing.T) {
 				Address: sample.AccAddress(),
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(-100)},
 				Services: []*sharedtypes.ApplicationServiceConfig{
-					{ServiceId: &sharedtypes.ServiceId{Id: "svc1"}},
+					{Service: &sharedtypes.Service{Id: "svc1"}},
 				},
 			},
 			err: ErrAppInvalidStake,
@@ -75,7 +75,7 @@ func TestMsgStakeApplication_ValidateBasic(t *testing.T) {
 				Address: sample.AccAddress(),
 				Stake:   &sdk.Coin{Denom: "invalid", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.ApplicationServiceConfig{
-					{ServiceId: &sharedtypes.ServiceId{Id: "svc1"}},
+					{Service: &sharedtypes.Service{Id: "svc1"}},
 				},
 			},
 			err: ErrAppInvalidStake,
@@ -85,7 +85,7 @@ func TestMsgStakeApplication_ValidateBasic(t *testing.T) {
 				Address: sample.AccAddress(),
 				Stake:   &sdk.Coin{Denom: "", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.ApplicationServiceConfig{
-					{ServiceId: &sharedtypes.ServiceId{Id: "svc1"}},
+					{Service: &sharedtypes.Service{Id: "svc1"}},
 				},
 			},
 			err: ErrAppInvalidStake,
@@ -98,8 +98,8 @@ func TestMsgStakeApplication_ValidateBasic(t *testing.T) {
 				Address: sample.AccAddress(),
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.ApplicationServiceConfig{
-					{ServiceId: &sharedtypes.ServiceId{Id: "svc1"}},
-					{ServiceId: &sharedtypes.ServiceId{Id: "svc2"}},
+					{Service: &sharedtypes.Service{Id: "svc1"}},
+					{Service: &sharedtypes.Service{Id: "svc2"}},
 				},
 			},
 		},
@@ -127,7 +127,7 @@ func TestMsgStakeApplication_ValidateBasic(t *testing.T) {
 				Address: sample.AccAddress(),
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.ApplicationServiceConfig{
-					{ServiceId: &sharedtypes.ServiceId{Id: "123456790"}},
+					{Service: &sharedtypes.Service{Id: "123456790"}},
 				},
 			},
 			err: ErrAppInvalidServiceConfigs,
@@ -138,7 +138,7 @@ func TestMsgStakeApplication_ValidateBasic(t *testing.T) {
 				Address: sample.AccAddress(),
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.ApplicationServiceConfig{
-					{ServiceId: &sharedtypes.ServiceId{
+					{Service: &sharedtypes.Service{
 						Id:   "123",
 						Name: "abcdefghijklmnopqrstuvwxyzab-abcdefghijklmnopqrstuvwxyzab",
 					}},
@@ -152,7 +152,7 @@ func TestMsgStakeApplication_ValidateBasic(t *testing.T) {
 				Address: sample.AccAddress(),
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.ApplicationServiceConfig{
-					{ServiceId: &sharedtypes.ServiceId{Id: "12 45 !"}},
+					{Service: &sharedtypes.Service{Id: "12 45 !"}},
 				},
 			},
 			err: ErrAppInvalidServiceConfigs,

--- a/x/session/keeper/query_get_session.go
+++ b/x/session/keeper/query_get_session.go
@@ -17,7 +17,7 @@ func (k Keeper) GetSession(goCtx context.Context, req *types.QueryGetSessionRequ
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	sessionHydrator := NewSessionHydrator(req.ApplicationAddress, req.ServiceId.Id, req.BlockHeight)
+	sessionHydrator := NewSessionHydrator(req.ApplicationAddress, req.Service.Id, req.BlockHeight)
 	session, err := k.HydrateSession(ctx, sessionHydrator)
 	if err != nil {
 		return nil, err

--- a/x/session/keeper/query_get_session_test.go
+++ b/x/session/keeper/query_get_session_test.go
@@ -56,7 +56,7 @@ func TestSession_GetSession_Success(t *testing.T) {
 
 			req := &types.QueryGetSessionRequest{
 				ApplicationAddress: tt.appAddr,
-				ServiceId: &sharedtypes.ServiceId{
+				Service: &sharedtypes.Service{
 					Id: tt.serviceId,
 				},
 				BlockHeight: 1,
@@ -115,7 +115,7 @@ func TestSession_GetSession_Failure(t *testing.T) {
 
 			req := &types.QueryGetSessionRequest{
 				ApplicationAddress: tt.appAddr,
-				ServiceId: &sharedtypes.ServiceId{
+				Service: &sharedtypes.Service{
 					Id: tt.serviceId,
 				},
 				BlockHeight: 1,

--- a/x/session/keeper/session_hydrator.go
+++ b/x/session/keeper/session_hydrator.go
@@ -105,7 +105,7 @@ func (k Keeper) hydrateSessionID(ctx sdk.Context, sh *sessionHydrator) error {
 	prevHashBz := []byte("TODO_BLOCKER: See the comment above")
 	appPubKeyBz := []byte(sh.sessionHeader.ApplicationAddress)
 
-	// TODO_TECHDEBT: In the future, we will need to valid that the ServiceId is a valid service depending on whether
+	// TODO_TECHDEBT: In the future, we will need to valid that the Service is a valid service depending on whether
 	// or not its permissioned  or permissionless
 	// TODO(@Olshansk): Add a check to make sure `IsValidServiceName(Service.Id)` returns True
 	serviceIdBz := []byte(sh.sessionHeader.Service.Id)

--- a/x/session/keeper/session_hydrator.go
+++ b/x/session/keeper/session_hydrator.go
@@ -107,8 +107,8 @@ func (k Keeper) hydrateSessionID(ctx sdk.Context, sh *sessionHydrator) error {
 
 	// TODO_TECHDEBT: In the future, we will need to valid that the ServiceId is a valid service depending on whether
 	// or not its permissioned  or permissionless
-	// TODO(@Olshansk): Add a check to make sure `IsValidServiceName(ServiceId.Id)` returns True
-	serviceIdBz := []byte(sh.sessionHeader.ServiceId.Id)
+	// TODO(@Olshansk): Add a check to make sure `IsValidServiceName(Service.Id)` returns True
+	serviceIdBz := []byte(sh.sessionHeader.Service.Id)
 
 	sessionHeightBz := make([]byte, 8)
 	binary.LittleEndian.PutUint64(sessionHeightBz, uint64(sh.sessionHeader.SessionStartBlockHeight))
@@ -144,7 +144,7 @@ func (k Keeper) hydrateSessionSuppliers(ctx sdk.Context, sh *sessionHydrator) er
 	for _, supplier := range suppliers {
 		// TODO_OPTIMIZE: If `supplier.Services` was a map[string]struct{}, we could eliminate `slices.Contains()`'s loop
 		for _, supplierServiceConfig := range supplier.Services {
-			if supplierServiceConfig.ServiceId.Id == sh.sessionHeader.ServiceId.Id {
+			if supplierServiceConfig.Service.Id == sh.sessionHeader.Service.Id {
 				candidateSuppliers = append(candidateSuppliers, &supplier)
 				break
 			}

--- a/x/session/keeper/session_hydrator.go
+++ b/x/session/keeper/session_hydrator.go
@@ -45,7 +45,7 @@ func NewSessionHydrator(
 ) *sessionHydrator {
 	sessionHeader := &types.SessionHeader{
 		ApplicationAddress: appAddress,
-		ServiceId:          &sharedtypes.ServiceId{Id: serviceId},
+		Service:            &sharedtypes.Service{Id: serviceId},
 	}
 	return &sessionHydrator{
 		sessionHeader: sessionHeader,
@@ -153,7 +153,7 @@ func (k Keeper) hydrateSessionSuppliers(ctx sdk.Context, sh *sessionHydrator) er
 
 	if len(candidateSuppliers) == 0 {
 		logger.Error("[ERROR] no suppliers found for session")
-		return sdkerrors.Wrapf(types.ErrSuppliersNotFound, "could not find suppliers for service %s at height %d", sh.sessionHeader.ServiceId, sh.sessionHeader.SessionStartBlockHeight)
+		return sdkerrors.Wrapf(types.ErrSuppliersNotFound, "could not find suppliers for service %s at height %d", sh.sessionHeader.Service, sh.sessionHeader.SessionStartBlockHeight)
 	}
 
 	if len(candidateSuppliers) < NumSupplierPerSession {

--- a/x/session/keeper/session_hydrator_test.go
+++ b/x/session/keeper/session_hydrator_test.go
@@ -22,8 +22,8 @@ func TestSession_HydrateSession_Success_BaseCase(t *testing.T) {
 	// Check the header
 	sessionHeader := session.Header
 	require.Equal(t, keepertest.TestApp1Address, sessionHeader.ApplicationAddress)
-	require.Equal(t, keepertest.TestServiceId1, sessionHeader.ServiceId.Id)
-	require.Equal(t, "", sessionHeader.ServiceId.Name)
+	require.Equal(t, keepertest.TestServiceId1, sessionHeader.Service.Id)
+	require.Equal(t, "", sessionHeader.Service.Name)
 	require.Equal(t, int64(8), sessionHeader.SessionStartBlockHeight)
 	require.Equal(t, "23f037a10f9d51d020d27763c42dd391d7e71765016d95d0d61f36c4a122efd0", sessionHeader.SessionId)
 

--- a/x/shared/helpers/service.go
+++ b/x/shared/helpers/service.go
@@ -3,6 +3,8 @@ package helpers
 import (
 	"net/url"
 	"regexp"
+
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
 
 const (
@@ -23,6 +25,11 @@ func init() {
 	regexExprServiceId = regexp.MustCompile(regexServiceId)
 	regexExprServiceName = regexp.MustCompile(regexServiceName)
 
+}
+
+// IsValidService checks if the input service is valid
+func IsValidService(service *sharedtypes.Service) bool {
+	return service != nil && IsValidServiceId(service.Id) && IsValidServiceName(service.Name)
 }
 
 // IsValidServiceId checks if the input string is a valid serviceId

--- a/x/shared/helpers/service_configs.go
+++ b/x/shared/helpers/service_configs.go
@@ -15,17 +15,9 @@ func ValidateAppServiceConfigs(services []*sharedtypes.ApplicationServiceConfig)
 		if serviceConfig == nil {
 			return fmt.Errorf("serviceConfig cannot be nil: %v", services)
 		}
-		if serviceConfig.ServiceId == nil {
-			return fmt.Errorf("serviceId cannot be nil: %v", serviceConfig)
-		}
-		if serviceConfig.ServiceId.Id == "" {
-			return fmt.Errorf("serviceId.Id cannot be empty: %v", serviceConfig)
-		}
-		if !IsValidServiceId(serviceConfig.ServiceId.Id) {
-			return fmt.Errorf("invalid serviceId.Id: %v", serviceConfig)
-		}
-		if !IsValidServiceName(serviceConfig.ServiceId.Name) {
-			return fmt.Errorf("invalid serviceId.Name: %v", serviceConfig)
+		// Check the Service
+		if IsValidService(serviceConfig.Service) {
+			return fmt.Errorf("invalid service: %v", serviceConfig.Service)
 		}
 	}
 	return nil
@@ -41,18 +33,9 @@ func ValidateSupplierServiceConfigs(services []*sharedtypes.SupplierServiceConfi
 			return fmt.Errorf("serviceConfig cannot be nil: %v", services)
 		}
 
-		// Check the ServiceId
-		if serviceConfig.ServiceId == nil {
-			return fmt.Errorf("serviceId cannot be nil: %v", serviceConfig)
-		}
-		if serviceConfig.ServiceId.Id == "" {
-			return fmt.Errorf("serviceId.Id cannot be empty: %v", serviceConfig)
-		}
-		if !IsValidServiceId(serviceConfig.ServiceId.Id) {
-			return fmt.Errorf("invalid serviceId.Id: %v", serviceConfig)
-		}
-		if !IsValidServiceName(serviceConfig.ServiceId.Name) {
-			return fmt.Errorf("invalid serviceId.Name: %v", serviceConfig)
+		// Check the Service
+		if IsValidService(serviceConfig.Service) {
+			return fmt.Errorf("invalid service: %v", serviceConfig.Service)
 		}
 
 		// Check the Endpoints

--- a/x/shared/helpers/service_configs.go
+++ b/x/shared/helpers/service_configs.go
@@ -16,7 +16,7 @@ func ValidateAppServiceConfigs(services []*sharedtypes.ApplicationServiceConfig)
 			return fmt.Errorf("serviceConfig cannot be nil: %v", services)
 		}
 		// Check the Service
-		if IsValidService(serviceConfig.Service) {
+		if !IsValidService(serviceConfig.Service) {
 			return fmt.Errorf("invalid service: %v", serviceConfig.Service)
 		}
 	}
@@ -34,7 +34,7 @@ func ValidateSupplierServiceConfigs(services []*sharedtypes.SupplierServiceConfi
 		}
 
 		// Check the Service
-		if IsValidService(serviceConfig.Service) {
+		if !IsValidService(serviceConfig.Service) {
 			return fmt.Errorf("invalid service: %v", serviceConfig.Service)
 		}
 

--- a/x/shared/helpers/service_test.go
+++ b/x/shared/helpers/service_test.go
@@ -1,28 +1,130 @@
 package helpers
 
-import "testing"
+import (
+	"testing"
 
-func TestIsValidServiceId(t *testing.T) {
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+)
+
+func TestIsValidService(t *testing.T) {
 	tests := []struct {
-		input    string
+		testCase string
+		id       string
+		name     string
 		expected bool
 	}{
-		{"Hello-1", true},
-		{"Hello_2", true},
-		{"hello-world", false}, // exceeds maxServiceIdLength
-		{"Hello@", false},      // contains invalid character '@'
-		{"HELLO", true},
-		{"12345678", true},     // exactly maxServiceIdLength
-		{"123456789", false},   // exceeds maxServiceIdLength
-		{"Hello.World", false}, // contains invalid character '.'
-		{"", false},            // empty string
+		{
+			testCase: "Valid ID and Name",
+			id:       "Service1",
+			name:     "Valid Service Name",
+			expected: true,
+		},
+		{
+			testCase: "Valid ID and empty Name",
+			id:       "Srv",
+			name:     "", // Valid because the service name can be empty
+			expected: true,
+		},
+		{
+			testCase: "ID exceeds max length",
+			id:       "TooLongId123", // Exceeds maxServiceIdLength
+			name:     "Valid Name",
+			expected: false,
+		},
+		{
+			testCase: "Name exceeds max length",
+			id:       "ValidID",
+			name:     "This service name is way too long to be considered valid since it exceeds the max length",
+			expected: false,
+		},
+		{
+			testCase: "Empty ID",
+			id:       "", // Invalid because the service ID cannot be empty
+			name:     "Valid Name",
+			expected: false,
+		},
+		{
+			testCase: "Invalid characters in ID",
+			id:       "ID@Invalid", // Invalid character '@'
+			name:     "Valid Name",
+			expected: false,
+		},
 	}
 
 	for _, test := range tests {
-		t.Run(test.input, func(t *testing.T) {
+		t.Run(test.testCase, func(t *testing.T) {
+			service := &sharedtypes.Service{
+				Id:   test.id,
+				Name: test.name,
+			}
+			result := IsValidService(service)
+			if result != test.expected {
+				t.Errorf("Test Case '%s' - IsValidService() with Id: '%s', Name: '%s', expected %v, got %v",
+					test.testCase, test.id, test.name, test.expected, result)
+			}
+		})
+	}
+}
+
+func TestIsValidServiceId(t *testing.T) {
+	tests := []struct {
+		testCase string
+		input    string
+		expected bool
+	}{
+		{
+			testCase: "Valid alphanumeric with hyphen",
+			input:    "Hello-1",
+			expected: true,
+		},
+		{
+			testCase: "Valid alphanumeric with underscore",
+			input:    "Hello_2",
+			expected: true,
+		},
+		{
+			testCase: "Exceeds maximum length",
+			input:    "hello-world",
+			expected: false, // exceeds maxServiceIdLength
+		},
+		{
+			testCase: "Contains invalid character '@'",
+			input:    "Hello@",
+			expected: false, // contains invalid character '@'
+		},
+		{
+			testCase: "All uppercase",
+			input:    "HELLO",
+			expected: true,
+		},
+		{
+			testCase: "Maximum length boundary",
+			input:    "12345678",
+			expected: true, // exactly maxServiceIdLength
+		},
+		{
+			testCase: "Above maximum length boundary",
+			input:    "123456789",
+			expected: false, // exceeds maxServiceIdLength
+		},
+		{
+			testCase: "Contains invalid character '.'",
+			input:    "Hello.World",
+			expected: false, // contains invalid character '.'
+		},
+		{
+			testCase: "Empty string",
+			input:    "",
+			expected: false, // empty string
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testCase, func(t *testing.T) {
 			result := IsValidServiceId(test.input)
 			if result != test.expected {
-				t.Errorf("For input %s, expected %v but got %v", test.input, test.expected, result)
+				t.Errorf("Test Case '%s' - IsValidServiceId(%q) = %v, want %v",
+					test.testCase, test.input, result, test.expected)
 			}
 		})
 	}
@@ -30,49 +132,50 @@ func TestIsValidServiceId(t *testing.T) {
 
 func TestIsValidEndpointUrl(t *testing.T) {
 	tests := []struct {
-		name     string
+		testCase string
+
 		input    string
 		expected bool
 	}{
 		{
-			name:     "valid http URL",
+			testCase: "valid http URL",
 			input:    "http://example.com",
 			expected: true,
 		},
 		{
-			name:     "valid https URL",
+			testCase: "valid https URL",
 			input:    "https://example.com/path?query=value#fragment",
 			expected: true,
 		},
 		{
-			name:     "valid localhost URL with scheme",
+			testCase: "valid localhost URL with scheme",
 			input:    "https://localhost:8081",
 			expected: true,
 		},
 		{
-			name:     "valid loopback URL with scheme",
+			testCase: "valid loopback URL with scheme",
 			input:    "http://127.0.0.1:8081",
 			expected: true,
 		},
 		{
-			name:     "invalid scheme",
+			testCase: "invalid scheme",
 			input:    "ftp://example.com",
 			expected: false,
 		},
 		{
-			name:     "missing scheme",
+			testCase: "missing scheme",
 			input:    "example.com",
 			expected: false,
 		},
 		{
-			name:     "invalid URL",
+			testCase: "invalid URL",
 			input:    "not-a-valid-url",
 			expected: false,
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.testCase, func(t *testing.T) {
 			got := IsValidEndpointUrl(tt.input)
 			if got != tt.expected {
 				t.Errorf("IsValidEndpointUrl(%q) = %v, want %v", tt.input, got, tt.expected)

--- a/x/supplier/client/cli/tx_stake_supplier.go
+++ b/x/supplier/client/cli/tx_stake_supplier.go
@@ -84,7 +84,7 @@ func hackStringToServices(servicesArg string) ([]*sharedtypes.SupplierServiceCon
 			return nil, fmt.Errorf("invalid service string: %s. Expected it to be of the form 'service;url'", serviceString)
 		}
 		service := &sharedtypes.SupplierServiceConfig{
-			ServiceId: &sharedtypes.ServiceId{
+			Service: &sharedtypes.Service{
 				Id: serviceParts[0],
 			},
 			Endpoints: []*sharedtypes.SupplierEndpoint{

--- a/x/supplier/genesis_test.go
+++ b/x/supplier/genesis_test.go
@@ -24,7 +24,7 @@ func TestGenesis(t *testing.T) {
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.SupplierServiceConfig{
 					{
-						ServiceId: &sharedtypes.ServiceId{
+						Service: &sharedtypes.Service{
 							Id: "svcId1",
 						},
 						Endpoints: []*sharedtypes.SupplierEndpoint{
@@ -42,7 +42,7 @@ func TestGenesis(t *testing.T) {
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.SupplierServiceConfig{
 					{
-						ServiceId: &sharedtypes.ServiceId{
+						Service: &sharedtypes.Service{
 							Id: "svcId2",
 						},
 						Endpoints: []*sharedtypes.SupplierEndpoint{

--- a/x/supplier/keeper/msg_server_stake_supplier_test.go
+++ b/x/supplier/keeper/msg_server_stake_supplier_test.go
@@ -31,7 +31,7 @@ func TestMsgServer_StakeSupplier_SuccessfulCreateAndUpdate(t *testing.T) {
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.SupplierServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{
+				Service: &sharedtypes.Service{
 					Id: "svcId",
 				},
 				Endpoints: []*sharedtypes.SupplierEndpoint{
@@ -55,7 +55,7 @@ func TestMsgServer_StakeSupplier_SuccessfulCreateAndUpdate(t *testing.T) {
 	require.Equal(t, addr, supplierFound.Address)
 	require.Equal(t, int64(100), supplierFound.Stake.Amount.Int64())
 	require.Len(t, supplierFound.Services, 1)
-	require.Equal(t, "svcId", supplierFound.Services[0].ServiceId.Id)
+	require.Equal(t, "svcId", supplierFound.Services[0].Service.Id)
 	require.Len(t, supplierFound.Services[0].Endpoints, 1)
 	require.Equal(t, "http://localhost:8080", supplierFound.Services[0].Endpoints[0].Url)
 
@@ -65,7 +65,7 @@ func TestMsgServer_StakeSupplier_SuccessfulCreateAndUpdate(t *testing.T) {
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(200)},
 		Services: []*sharedtypes.SupplierServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{
+				Service: &sharedtypes.Service{
 					Id: "svcId2",
 				},
 				Endpoints: []*sharedtypes.SupplierEndpoint{
@@ -86,7 +86,7 @@ func TestMsgServer_StakeSupplier_SuccessfulCreateAndUpdate(t *testing.T) {
 	require.True(t, isSupplierFound)
 	require.Equal(t, int64(200), supplierFound.Stake.Amount.Int64())
 	require.Len(t, supplierFound.Services, 1)
-	require.Equal(t, "svcId2", supplierFound.Services[0].ServiceId.Id)
+	require.Equal(t, "svcId2", supplierFound.Services[0].Service.Id)
 	require.Len(t, supplierFound.Services[0].Endpoints, 1)
 	require.Equal(t, "http://localhost:8082", supplierFound.Services[0].Endpoints[0].Url)
 }
@@ -104,7 +104,7 @@ func TestMsgServer_StakeSupplier_FailRestakingDueToInvalidServices(t *testing.T)
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.SupplierServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{
+				Service: &sharedtypes.Service{
 					Id: "svcId",
 				},
 				Endpoints: []*sharedtypes.SupplierEndpoint{
@@ -128,7 +128,7 @@ func TestMsgServer_StakeSupplier_FailRestakingDueToInvalidServices(t *testing.T)
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.SupplierServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svcId"},
+				Service:   &sharedtypes.Service{Id: "svcId"},
 				Endpoints: []*sharedtypes.SupplierEndpoint{},
 			},
 		},
@@ -143,7 +143,7 @@ func TestMsgServer_StakeSupplier_FailRestakingDueToInvalidServices(t *testing.T)
 	require.True(t, isSupplierFound)
 	require.Equal(t, supplierAddr, supplierFound.Address)
 	require.Len(t, supplierFound.Services, 1)
-	require.Equal(t, "svcId", supplierFound.Services[0].ServiceId.Id)
+	require.Equal(t, "svcId", supplierFound.Services[0].Service.Id)
 	require.Len(t, supplierFound.Services[0].Endpoints, 1)
 	require.Equal(t, "http://localhost:8080", supplierFound.Services[0].Endpoints[0].Url)
 
@@ -153,7 +153,7 @@ func TestMsgServer_StakeSupplier_FailRestakingDueToInvalidServices(t *testing.T)
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.SupplierServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: "svc1 INVALID ! & *"},
+				Service: &sharedtypes.Service{Id: "svc1 INVALID ! & *"},
 			},
 		},
 	}
@@ -167,7 +167,7 @@ func TestMsgServer_StakeSupplier_FailRestakingDueToInvalidServices(t *testing.T)
 	require.True(t, isSupplierFound)
 	require.Equal(t, supplierAddr, supplierFound.Address)
 	require.Len(t, supplierFound.Services, 1)
-	require.Equal(t, "svcId", supplierFound.Services[0].ServiceId.Id)
+	require.Equal(t, "svcId", supplierFound.Services[0].Service.Id)
 	require.Len(t, supplierFound.Services[0].Endpoints, 1)
 	require.Equal(t, "http://localhost:8080", supplierFound.Services[0].Endpoints[0].Url)
 }
@@ -184,7 +184,7 @@ func TestMsgServer_StakeSupplier_FailLoweringStake(t *testing.T) {
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 		Services: []*sharedtypes.SupplierServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{
+				Service: &sharedtypes.Service{
 					Id: "svcId",
 				},
 				Endpoints: []*sharedtypes.SupplierEndpoint{
@@ -210,7 +210,7 @@ func TestMsgServer_StakeSupplier_FailLoweringStake(t *testing.T) {
 		Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(50)},
 		Services: []*sharedtypes.SupplierServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{
+				Service: &sharedtypes.Service{
 					Id: "svcId",
 				},
 				Endpoints: []*sharedtypes.SupplierEndpoint{

--- a/x/supplier/keeper/msg_server_unstake_supplier_test.go
+++ b/x/supplier/keeper/msg_server_unstake_supplier_test.go
@@ -32,7 +32,7 @@ func TestMsgServer_UnstakeSupplier_Success(t *testing.T) {
 		Stake:   &initialStake,
 		Services: []*sharedtypes.SupplierServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{
+				Service: &sharedtypes.Service{
 					Id: "svcId",
 				},
 				Endpoints: []*sharedtypes.SupplierEndpoint{

--- a/x/supplier/keeper/supplier.go
+++ b/x/supplier/keeper/supplier.go
@@ -64,5 +64,5 @@ func (k Keeper) GetAllSupplier(ctx sdk.Context) (suppliers []sharedtypes.Supplie
 	return
 }
 
-// TODO_OPTIMIZE: Index suppliers by serviceId so we can easily query `k.GetAllSupplier(ctx, ServiceId)`
+// TODO_OPTIMIZE: Index suppliers by serviceId so we can easily query `k.GetAllSupplier(ctx, Service)`
 // func (k Keeper) GetAllSupplier(ctx, sdkContext, serviceId string) (suppliers []sharedtypes.Supplier) {}

--- a/x/supplier/keeper/supplier_test.go
+++ b/x/supplier/keeper/supplier_test.go
@@ -33,7 +33,7 @@ func createNSupplier(keeper *keeper.Keeper, ctx sdk.Context, n int) []sharedtype
 		supplier.Stake = &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(int64(i))}
 		supplier.Services = []*sharedtypes.SupplierServiceConfig{
 			{
-				ServiceId: &sharedtypes.ServiceId{Id: fmt.Sprintf("svc%d", i)},
+				Service: &sharedtypes.Service{Id: fmt.Sprintf("svc%d", i)},
 				Endpoints: []*sharedtypes.SupplierEndpoint{
 					{
 						Url:     fmt.Sprintf("http://localhost:%d", i),

--- a/x/supplier/types/errors.go
+++ b/x/supplier/types/errors.go
@@ -8,9 +8,11 @@ import (
 
 // x/supplier module sentinel errors
 var (
-	ErrSupplierInvalidStake         = sdkerrors.Register(ModuleName, 1, "invalid supplier stake")
-	ErrSupplierInvalidAddress       = sdkerrors.Register(ModuleName, 2, "invalid supplier address")
-	ErrSupplierUnauthorized         = sdkerrors.Register(ModuleName, 3, "unauthorized supplier signer")
-	ErrSupplierNotFound             = sdkerrors.Register(ModuleName, 4, "supplier not found")
-	ErrSupplierInvalidServiceConfig = sdkerrors.Register(ModuleName, 5, "invalid service config")
+	ErrSupplierInvalidStake              = sdkerrors.Register(ModuleName, 1, "invalid supplier stake")
+	ErrSupplierInvalidAddress            = sdkerrors.Register(ModuleName, 2, "invalid supplier address")
+	ErrSupplierUnauthorized              = sdkerrors.Register(ModuleName, 3, "unauthorized supplier signer")
+	ErrSupplierNotFound                  = sdkerrors.Register(ModuleName, 4, "supplier not found")
+	ErrSupplierInvalidServiceConfig      = sdkerrors.Register(ModuleName, 5, "invalid service config")
+	ErrSupplierInvalidSessionStartHeight = sdkerrors.Register(ModuleName, 6, "invalid session start height")
+	ErrSupplierInvalidSessionId          = sdkerrors.Register(ModuleName, 7, "invalid session ID")
 )

--- a/x/supplier/types/genesis.go
+++ b/x/supplier/types/genesis.go
@@ -56,7 +56,6 @@ func (gs GenesisState) Validate() error {
 			return sdkerrors.Wrapf(ErrSupplierInvalidStake, "invalid stake amount denom for supplier %v", supplier.Stake)
 		}
 
-		// Valid the application service configs
 		// Validate the application service configs
 		if err := servicehelpers.ValidateSupplierServiceConfigs(supplier.Services); err != nil {
 			return sdkerrors.Wrapf(ErrSupplierInvalidServiceConfig, err.Error())

--- a/x/supplier/types/genesis_test.go
+++ b/x/supplier/types/genesis_test.go
@@ -15,7 +15,7 @@ func TestGenesisState_Validate(t *testing.T) {
 	addr1 := sample.AccAddress()
 	stake1 := sdk.NewCoin("upokt", sdk.NewInt(100))
 	serviceConfig1 := &sharedtypes.SupplierServiceConfig{
-		ServiceId: &sharedtypes.ServiceId{
+		Service: &sharedtypes.Service{
 			Id: "svcId1",
 		},
 		Endpoints: []*sharedtypes.SupplierEndpoint{
@@ -31,7 +31,7 @@ func TestGenesisState_Validate(t *testing.T) {
 	addr2 := sample.AccAddress()
 	stake2 := sdk.NewCoin("upokt", sdk.NewInt(100))
 	serviceConfig2 := &sharedtypes.SupplierServiceConfig{
-		ServiceId: &sharedtypes.ServiceId{
+		Service: &sharedtypes.Service{
 			Id: "svcId2",
 		},
 		Endpoints: []*sharedtypes.SupplierEndpoint{
@@ -250,7 +250,7 @@ func TestGenesisState_Validate(t *testing.T) {
 						Stake:   &stake2,
 						Services: []*sharedtypes.SupplierServiceConfig{
 							{
-								ServiceId: &sharedtypes.ServiceId{
+								Service: &sharedtypes.Service{
 									Id: "svcId1",
 								},
 								Endpoints: []*sharedtypes.SupplierEndpoint{
@@ -281,7 +281,7 @@ func TestGenesisState_Validate(t *testing.T) {
 						Stake:   &stake2,
 						Services: []*sharedtypes.SupplierServiceConfig{
 							{
-								ServiceId: &sharedtypes.ServiceId{
+								Service: &sharedtypes.Service{
 									Id: "svcId1",
 								},
 								Endpoints: []*sharedtypes.SupplierEndpoint{

--- a/x/supplier/types/message_stake_supplier_test.go
+++ b/x/supplier/types/message_stake_supplier_test.go
@@ -17,7 +17,7 @@ func TestMsgStakeSupplier_ValidateBasic(t *testing.T) {
 
 	defaultServicesList := []*sharedtypes.SupplierServiceConfig{
 		{
-			ServiceId: &sharedtypes.ServiceId{
+			Service: &sharedtypes.Service{
 				Id: "svcId1",
 			},
 			Endpoints: []*sharedtypes.SupplierEndpoint{
@@ -103,7 +103,7 @@ func TestMsgStakeSupplier_ValidateBasic(t *testing.T) {
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.SupplierServiceConfig{
 					{
-						ServiceId: &sharedtypes.ServiceId{
+						Service: &sharedtypes.Service{
 							Id: "svcId1",
 						},
 						Endpoints: []*sharedtypes.SupplierEndpoint{
@@ -115,7 +115,7 @@ func TestMsgStakeSupplier_ValidateBasic(t *testing.T) {
 						},
 					},
 					{
-						ServiceId: &sharedtypes.ServiceId{
+						Service: &sharedtypes.Service{
 							Id: "svcId2",
 						},
 						Endpoints: []*sharedtypes.SupplierEndpoint{
@@ -154,7 +154,7 @@ func TestMsgStakeSupplier_ValidateBasic(t *testing.T) {
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.SupplierServiceConfig{
 					{
-						ServiceId: &sharedtypes.ServiceId{
+						Service: &sharedtypes.Service{
 							Id: "123456790",
 						},
 						Endpoints: []*sharedtypes.SupplierEndpoint{
@@ -176,7 +176,7 @@ func TestMsgStakeSupplier_ValidateBasic(t *testing.T) {
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.SupplierServiceConfig{
 					{
-						ServiceId: &sharedtypes.ServiceId{
+						Service: &sharedtypes.Service{
 							Id:   "123",
 							Name: "abcdefghijklmnopqrstuvwxyzab-abcdefghijklmnopqrstuvwxyzab",
 						},
@@ -199,7 +199,7 @@ func TestMsgStakeSupplier_ValidateBasic(t *testing.T) {
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.SupplierServiceConfig{
 					{
-						ServiceId: &sharedtypes.ServiceId{
+						Service: &sharedtypes.Service{
 							Id: "12 45 !",
 						},
 						Endpoints: []*sharedtypes.SupplierEndpoint{
@@ -221,7 +221,7 @@ func TestMsgStakeSupplier_ValidateBasic(t *testing.T) {
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.SupplierServiceConfig{
 					{
-						ServiceId: &sharedtypes.ServiceId{
+						Service: &sharedtypes.Service{
 							Id:   "svcId",
 							Name: "name",
 						},
@@ -244,7 +244,7 @@ func TestMsgStakeSupplier_ValidateBasic(t *testing.T) {
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.SupplierServiceConfig{
 					{
-						ServiceId: &sharedtypes.ServiceId{
+						Service: &sharedtypes.Service{
 							Id:   "svcId",
 							Name: "name",
 						},
@@ -267,7 +267,7 @@ func TestMsgStakeSupplier_ValidateBasic(t *testing.T) {
 				Stake:   &sdk.Coin{Denom: "upokt", Amount: sdk.NewInt(100)},
 				Services: []*sharedtypes.SupplierServiceConfig{
 					{
-						ServiceId: &sharedtypes.ServiceId{
+						Service: &sharedtypes.Service{
 							Id:   "svcId",
 							Name: "name",
 						},


### PR DESCRIPTION
## Summary

Renamed the `ServiceId` proto to `Service` so `ServiceId.Id` is more semantic and less confusing.

## Issue

- Thought it is not directly related to #140, it was driven out of confusion by the author while beginning to implement this piece of work

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
