### PR TITLE
feat: Add session_end_block_height to SessionHeader

### DIFF
--- a/proto/pocket/session/session.proto
+++ b/proto/pocket/session/session.proto
@@ -18,6 +18,7 @@ message SessionHeader {
     int64 session_start_block_height = 3; // The height at which this session started
     // NOTE: session_id can be derived from the above values using on-chain but is included in the header for convenience
     string session_id = 4; // A unique pseudoranom ID for this session
+    int64 session_end_block_height = 5; // The height at which this session ended, this is the last block of the session
 }
 
 // Session is a fully hydrated session object that contains all the information for the Session

--- a/x/session/keeper/session_hydrator.go
+++ b/x/session/keeper/session_hydrator.go
@@ -93,6 +93,7 @@ func (k Keeper) hydrateSessionMetadata(ctx sdk.Context, sh *sessionHydrator) err
 	sh.session.NumBlocksPerSession = NumBlocksPerSession
 	sh.session.SessionNumber = int64(sh.blockHeight / NumBlocksPerSession)
 	sh.sessionHeader.SessionStartBlockHeight = sh.blockHeight - (sh.blockHeight % NumBlocksPerSession)
+	sh.sessionHeader.SessionEndBlockHeight = sh.sessionHeader.SessionStartBlockHeight + NumBlocksPerSession
 	return nil
 }
 

--- a/x/session/keeper/session_hydrator_test.go
+++ b/x/session/keeper/session_hydrator_test.go
@@ -25,6 +25,7 @@ func TestSession_HydrateSession_Success_BaseCase(t *testing.T) {
 	require.Equal(t, keepertest.TestServiceId1, sessionHeader.ServiceId.Id)
 	require.Equal(t, "", sessionHeader.ServiceId.Name)
 	require.Equal(t, int64(8), sessionHeader.SessionStartBlockHeight)
+	require.Equal(t, int64(12), sessionHeader.SessionEndBlockHeight)
 	require.Equal(t, "23f037a10f9d51d020d27763c42dd391d7e71765016d95d0d61f36c4a122efd0", sessionHeader.SessionId)
 
 	// Check the session
@@ -53,6 +54,7 @@ func TestSession_HydrateSession_Metadata(t *testing.T) {
 		expectedNumBlocksPerSession int64
 		expectedSessionNumber       int64
 		expectedSessionStartBlock   int64
+		expectedSessionEndBlock     int64
 	}
 
 	// TODO_TECHDEBT: Extend these tests once `NumBlocksPerSession` is configurable.
@@ -65,6 +67,7 @@ func TestSession_HydrateSession_Metadata(t *testing.T) {
 			expectedNumBlocksPerSession: 4,
 			expectedSessionNumber:       0,
 			expectedSessionStartBlock:   0,
+			expectedSessionEndBlock:     4,
 		},
 		{
 			name:        "blockHeight = 1",
@@ -73,6 +76,7 @@ func TestSession_HydrateSession_Metadata(t *testing.T) {
 			expectedNumBlocksPerSession: 4,
 			expectedSessionNumber:       0,
 			expectedSessionStartBlock:   0,
+			expectedSessionEndBlock:     4,
 		},
 		{
 			name:        "blockHeight = sessionHeight",
@@ -81,6 +85,7 @@ func TestSession_HydrateSession_Metadata(t *testing.T) {
 			expectedNumBlocksPerSession: 4,
 			expectedSessionNumber:       1,
 			expectedSessionStartBlock:   4,
+			expectedSessionEndBlock:     8,
 		},
 		{
 			name:        "blockHeight != sessionHeight",
@@ -89,6 +94,7 @@ func TestSession_HydrateSession_Metadata(t *testing.T) {
 			expectedNumBlocksPerSession: 4,
 			expectedSessionNumber:       1,
 			expectedSessionStartBlock:   4,
+			expectedSessionEndBlock:     8,
 		},
 	}
 
@@ -105,6 +111,7 @@ func TestSession_HydrateSession_Metadata(t *testing.T) {
 			require.Equal(t, tt.expectedNumBlocksPerSession, session.NumBlocksPerSession)
 			require.Equal(t, tt.expectedSessionNumber, session.SessionNumber)
 			require.Equal(t, tt.expectedSessionStartBlock, session.Header.SessionStartBlockHeight)
+			require.Equal(t, tt.expectedSessionEndBlock, session.Header.SessionEndBlockHeight)
 		})
 	}
 }


### PR DESCRIPTION
<!-- DELETE THIS COMMENT BLOCK
  After completing the following:
    1. Add a descriptive title `[<Tag>] <DESCRIPTION>`
    2. Update _Assignee(s)_
    3. Add _Label(s)_
    4. Set _Project(s)_
    5. Specify _Epic_ and _Iteration_ under _Project_
    6. Set _Milestone_
-->

## Summary

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Nov 23 19:17 UTC
This pull request adds the `session_end_block_height` field to the `SessionHeader` message in the `proto/pocket/session/session.proto` file. The `session_end_block_height` represents the height at which a session ended, which is the last block of the session. This patch also updates the `session_hydrator.go` file to set the `session_end_block_height` based on the `session_start_block_height` and `NumBlocksPerSession` values. Additionally, the `session_hydrator_test.go` file is updated to include test cases for the `session_end_block_height` field, ensuring that it is set correctly.
<!-- reviewpad:summarize:end -->

## Issue

<!-- DELETE THIS COMMENT BLOCK
     Specify the ticket number below if there is a relevant issue. Keep the `-` so the full issue is referenced.
-->

- #161 

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
