### PR TITLE
[Off-chain] refactor: `MapFn`s receive context arg

### DIFF
--- a/pkg/client/block/client.go
+++ b/pkg/client/block/client.go
@@ -69,7 +69,10 @@ type blockClient struct {
 // function which maps event subscription message bytes into block event objects.
 // This is used as a transformFn in a channel.Map() call and is the type returned
 // by the newEventsBytesToBlockMapFn factory function.
-type eventBytesToBlockMapFn func(either.Either[[]byte]) (client.Block, bool)
+type eventBytesToBlockMapFn = func(
+	context.Context,
+	either.Bytes,
+) (client.Block, bool)
 
 // NewBlockClient creates a new block client from the given dependencies and cometWebsocketURL.
 func NewBlockClient(
@@ -158,8 +161,12 @@ func (bClient *blockClient) retryPublishBlocksFactory(ctx context.Context) func(
 		// client.BlocksObservable cannot be an alias due to gomock's lack of
 		// support for generic types.
 		eventsBz := observable.Observable[either.Either[[]byte]](eventsBzObsvbl)
-		blockEventFromEventBz := newEventsBytesToBlockMapFn(errCh)
-		blocksObsvbl := channel.MapReplay(ctx, latestBlockReplayBufferSize, eventsBz, blockEventFromEventBz)
+		blocksObsvbl := channel.MapReplay(
+			ctx,
+			latestBlockReplayBufferSize,
+			eventsBz,
+			newEventsBytesToBlockMapFn(errCh),
+		)
 
 		// Initially set latestBlockObsvbls and update if after retrying on error.
 		bClient.latestBlockObsvblsReplayPublishCh <- blocksObsvbl
@@ -181,7 +188,10 @@ func (bClient *blockClient) retryPublishBlocksFactory(ctx context.Context) func(
 // this value is also skipped.
 // If deserialization failed for some other reason, this function panics.
 func newEventsBytesToBlockMapFn(errCh chan<- error) eventBytesToBlockMapFn {
-	return func(eitherEventBz either.Either[[]byte]) (_ client.Block, skip bool) {
+	return func(
+		_ context.Context,
+		eitherEventBz either.Bytes,
+	) (_ client.Block, skip bool) {
 		eventBz, err := eitherEventBz.ValueOrError()
 		if err != nil {
 			errCh <- err

--- a/pkg/client/tx/client.go
+++ b/pkg/client/tx/client.go
@@ -494,6 +494,7 @@ func (tClient *txClient) goTimeoutPendingTransactions(ctx context.Context) {
 //   - skip: A flag denoting if the event should be bypassed. A value of true
 //     suggests the event be disregarded, progressing to the succeeding message.
 func (tClient *txClient) txEventFromEventBz(
+	_ context.Context,
 	eitherEventBz either.Bytes,
 ) (eitherTxEvent either.Either[*TxEvent], skip bool) {
 

--- a/pkg/observable/channel/map.go
+++ b/pkg/observable/channel/map.go
@@ -20,7 +20,7 @@ func Map[S, D any](
 	dstObservable, dstProducer := NewObservable[D]()
 	srcObserver := srcObservable.Subscribe(ctx)
 
-	mapInternal[S, D](
+	go goMapTransformNotification(
 		ctx,
 		srcObserver,
 		transformFn,
@@ -30,25 +30,6 @@ func Map[S, D any](
 	)
 
 	return dstObservable
-}
-
-func mapInternal[S, D any](
-	ctx context.Context,
-	srcObserver observable.Observer[S],
-	transformFn MapFn[S, D],
-	publishFn func(dstNotifications D),
-) {
-	go func() {
-		for srcNotification := range srcObserver.Ch() {
-			dstNotifications, skip := transformFn(ctx, srcNotification)
-			if skip {
-				continue
-			}
-
-			publishFn(dstNotifications)
-		}
-	}()
-
 }
 
 // MapReplay transforms the given observable by applying the given transformFn to
@@ -61,22 +42,38 @@ func MapReplay[S, D any](
 	ctx context.Context,
 	replayBufferSize int,
 	srcObservable observable.Observable[S],
-	// TODO_CONSIDERATION: if this were variadic, it could simplify serial transformations.
-	transformFn func(src S) (dst D, skip bool),
+	transformFn MapFn[S, D],
 ) observable.ReplayObservable[D] {
 	dstObservable, dstProducer := NewReplayObservable[D](ctx, replayBufferSize)
 	srcObserver := srcObservable.Subscribe(ctx)
 
-	go func() {
-		for srcNotification := range srcObserver.Ch() {
-			dstNotification, skip := transformFn(srcNotification)
-			if skip {
-				continue
-			}
-
+	go goMapTransformNotification(
+		ctx,
+		srcObserver,
+		transformFn,
+		func(dstNotification D) {
 			dstProducer <- dstNotification
-		}
-	}()
+		},
+	)
 
 	return dstObservable
+}
+
+// goMapTransformNotification transforms, optionally skips, and publishes
+// notifications via the given publishFn.
+func goMapTransformNotification[S, D any](
+	ctx context.Context,
+	srcObserver observable.Observer[S],
+	transformFn MapFn[S, D],
+	publishFn func(dstNotifications D),
+) {
+	for srcNotification := range srcObserver.Ch() {
+		dstNotifications, skip := transformFn(ctx, srcNotification)
+		if skip {
+			continue
+		}
+
+		publishFn(dstNotifications)
+	}
+
 }

--- a/pkg/observable/channel/map_test.go
+++ b/pkg/observable/channel/map_test.go
@@ -39,9 +39,6 @@ func TestMap_Word_BytesToPalindrome(t *testing.T) {
 
 			// set up source bytes observable
 			bzObservable, bzPublishCh := channel.NewObservable[[]byte]()
-			bytesToPalindrome := func(wordBz []byte) (palindrome, bool) {
-				return newPalindrome(string(wordBz)), false
-			}
 
 			// map bytes observable to palindrome observable
 			palindromeObservable := channel.Map(ctx, bzObservable, bytesToPalindrome)
@@ -95,6 +92,10 @@ func newPalindrome(word string) palindrome {
 // IsValid returns true if the word actually is a palindrome.
 func (p *palindrome) IsValid() bool {
 	return p.forwards == (p.backwards)
+}
+
+func bytesToPalindrome(_ context.Context, wordBz []byte) (palindrome, bool) {
+	return newPalindrome(string(wordBz)), false
 }
 
 // reverseString reverses a string, character-by-character.


### PR DESCRIPTION
## Summary

### Human Summary

Simplifies usage of `channel.Map` for consumers which need a context reference, a common case.

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Nov 23 19:39 UTC
This pull request includes three patches:

- Patch 1/3: Refactors the `MapFn` type in the `map.go` file to receive a context argument.
- Patch 2/3: Makes improvements based on review feedback in the `map.go` file.
- Patch 3/3: Fixes usage of `MapReplay` after the refactor in the `client.go` file.

Overall, these patches aim to enhance the functionality and readability of the codebase.
<!-- reviewpad:summarize:end -->

## Issue

Relates to:
- #13 
- #169 
- #168 

Many consumers of `channel.Map` require a context reference in their map/transform functions.

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updated documentation and left TODOs throughout the codebase
