### PR TITLE
[Proxy] chore: Use depinject for relayerProxy

### DIFF
--- a/pkg/relayer/interface.go
+++ b/pkg/relayer/interface.go
@@ -45,6 +45,8 @@ type RelayerProxy interface {
 	SignRelayResponse(relayResponse *types.RelayResponse) error
 }
 
+type RelayerProxyOption func(RelayerProxy)
+
 // RelayServer is the interface of the advertised relay servers provided by the RelayerProxy.
 type RelayServer interface {
 	// Start starts the service server and returns an error if it fails.

--- a/pkg/relayer/proxy/errors.go
+++ b/pkg/relayer/proxy/errors.go
@@ -3,9 +3,11 @@ package proxy
 import sdkerrors "cosmossdk.io/errors"
 
 var (
-	codespace                       = "relayer/proxy"
-	ErrUnsupportedRPCType           = sdkerrors.Register(codespace, 1, "unsupported rpc type")
-	ErrInvalidRelayRequestSignature = sdkerrors.Register(codespace, 2, "invalid relay request signature")
-	ErrInvalidSession               = sdkerrors.Register(codespace, 3, "invalid session")
-	ErrInvalidSupplier              = sdkerrors.Register(codespace, 4, "invalid supplier")
+	codespace                            = "relayer/proxy"
+	ErrUnsupportedRPCType                = sdkerrors.Register(codespace, 1, "unsupported rpc type")
+	ErrInvalidRelayRequestSignature      = sdkerrors.Register(codespace, 2, "invalid relay request signature")
+	ErrInvalidSession                    = sdkerrors.Register(codespace, 3, "invalid session")
+	ErrInvalidSupplier                   = sdkerrors.Register(codespace, 4, "invalid supplier")
+	ErrUndefinedSigningKeyName           = sdkerrors.Register(codespace, 5, "undefined signing key name")
+	ErrUndefinedProxiedServicesEndpoints = sdkerrors.Register(codespace, 6, "undefined proxied services endpoints")
 )

--- a/pkg/relayer/proxy/errors.go
+++ b/pkg/relayer/proxy/errors.go
@@ -3,11 +3,11 @@ package proxy
 import sdkerrors "cosmossdk.io/errors"
 
 var (
-	codespace                            = "relayer/proxy"
-	ErrUnsupportedRPCType                = sdkerrors.Register(codespace, 1, "unsupported rpc type")
-	ErrInvalidRelayRequestSignature      = sdkerrors.Register(codespace, 2, "invalid relay request signature")
-	ErrInvalidSession                    = sdkerrors.Register(codespace, 3, "invalid session")
-	ErrInvalidSupplier                   = sdkerrors.Register(codespace, 4, "invalid supplier")
-	ErrUndefinedSigningKeyName           = sdkerrors.Register(codespace, 5, "undefined signing key name")
-	ErrUndefinedProxiedServicesEndpoints = sdkerrors.Register(codespace, 6, "undefined proxied services endpoints")
+	codespace                                        = "relayer_proxy"
+	ErrRelayerProxyUnsupportedRPCType                = sdkerrors.Register(codespace, 1, "unsupported relayer proxy rpc type")
+	ErrRelayerProxyInvalidRelayRequestSignature      = sdkerrors.Register(codespace, 2, "invalid relay request signature")
+	ErrRelayerProxyInvalidSession                    = sdkerrors.Register(codespace, 3, "invalid session in relayer request")
+	ErrRelayerProxyInvalidSupplier                   = sdkerrors.Register(codespace, 4, "invalid relayer proxy supplier")
+	ErrRelayerProxyUndefinedSigningKeyName           = sdkerrors.Register(codespace, 5, "undefined relayer proxy signing key name")
+	ErrRelayerProxyUndefinedProxiedServicesEndpoints = sdkerrors.Register(codespace, 6, "undefined proxied services endpoints for relayer proxy")
 )

--- a/pkg/relayer/proxy/options.go
+++ b/pkg/relayer/proxy/options.go
@@ -1,0 +1,17 @@
+package proxy
+
+import (
+	"github.com/pokt-network/poktroll/pkg/relayer"
+)
+
+func WithSigningKeyName(keyName string) relayer.RelayerProxyOption {
+	return func(relProxy relayer.RelayerProxy) {
+		relProxy.(*relayerProxy).signingKeyName = keyName
+	}
+}
+
+func WithProxiedServicesEndpoints(proxiedServicesEndpoints servicesEndpointsMap) relayer.RelayerProxyOption {
+	return func(relProxy relayer.RelayerProxy) {
+		relProxy.(*relayerProxy).proxiedServicesEndpoints = proxiedServicesEndpoints
+	}
+}

--- a/pkg/relayer/proxy/options.go
+++ b/pkg/relayer/proxy/options.go
@@ -4,12 +4,15 @@ import (
 	"github.com/pokt-network/poktroll/pkg/relayer"
 )
 
+// WithSigningKeyName sets the signing key name used by the relayer proxy to sign relay responses.
+// It is used along with the keyring to get the supplier address and sign the relay responses.
 func WithSigningKeyName(keyName string) relayer.RelayerProxyOption {
 	return func(relProxy relayer.RelayerProxy) {
 		relProxy.(*relayerProxy).signingKeyName = keyName
 	}
 }
 
+// WithProxiedServicesEndpoints sets the endpoints of the proxied services.
 func WithProxiedServicesEndpoints(proxiedServicesEndpoints servicesEndpointsMap) relayer.RelayerProxyOption {
 	return func(relProxy relayer.RelayerProxy) {
 		relProxy.(*relayerProxy).proxiedServicesEndpoints = proxiedServicesEndpoints

--- a/pkg/relayer/proxy/proxy.go
+++ b/pkg/relayer/proxy/proxy.go
@@ -158,13 +158,14 @@ func (rp *relayerProxy) ServedRelays() observable.Observable[*types.Relay] {
 }
 
 // validateConfig validates the relayer proxy's configuration options and returns an error if it is invalid.
+// TODO_TEST: Add tests for validating these configurations.
 func (rp *relayerProxy) validateConfig() error {
 	if rp.signingKeyName == "" {
-		return ErrUndefinedSigningKeyName
+		return ErrRelayerProxyUndefinedSigningKeyName
 	}
 
 	if rp.proxiedServicesEndpoints == nil {
-		return ErrUndefinedProxiedServicesEndpoints
+		return ErrRelayerProxyUndefinedProxiedServicesEndpoints
 	}
 
 	return nil

--- a/pkg/relayer/proxy/proxy.go
+++ b/pkg/relayer/proxy/proxy.go
@@ -103,7 +103,7 @@ func NewRelayerProxy(
 		opt(rp)
 	}
 
-	if err := rp.validateConfigAndSetDefaults(); err != nil {
+	if err := rp.validateConfig(); err != nil {
 		return nil, err
 	}
 
@@ -155,7 +155,7 @@ func (rp *relayerProxy) ServedRelays() observable.Observable[*types.Relay] {
 	return rp.servedRelays
 }
 
-func (rp *relayerProxy) validateConfigAndSetDefaults() error {
+func (rp *relayerProxy) validateConfig() error {
 	if rp.signingKeyName == "" {
 		return ErrUndefinedSigningKeyName
 	}

--- a/pkg/relayer/proxy/proxy.go
+++ b/pkg/relayer/proxy/proxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 
+	"cosmossdk.io/depinject"
 	sdkclient "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	accounttypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -32,10 +33,10 @@ type (
 // when the miner enters the claim/proof phase.
 // TODO_TEST: Have tests for the relayer proxy.
 type relayerProxy struct {
-	// keyName is the supplier's key name in the Cosmos's keybase. It is used along with the keyring to
+	// signingKeyName is the supplier's key name in the Cosmos's keybase. It is used along with the keyring to
 	// get the supplier address and sign the relay responses.
-	keyName string
-	keyring keyring.Keyring
+	signingKeyName string
+	keyring        keyring.Keyring
 
 	// blocksClient is the client used to get the block at the latest height from the blockchain
 	// and be notified of new incoming blocks. It is used to update the current session data.
@@ -76,29 +77,37 @@ type relayerProxy struct {
 }
 
 func NewRelayerProxy(
-	clientCtx sdkclient.Context,
-	keyName string,
-	keyring keyring.Keyring,
-	proxiedServicesEndpoints servicesEndpointsMap,
-	blockClient blocktypes.BlockClient,
-) relayer.RelayerProxy {
-	accountQuerier := accounttypes.NewQueryClient(clientCtx)
-	supplierQuerier := suppliertypes.NewQueryClient(clientCtx)
-	sessionQuerier := sessiontypes.NewQueryClient(clientCtx)
+	deps depinject.Config,
+	opts ...relayer.RelayerProxyOption,
+) (relayer.RelayerProxy, error) {
+	rp := &relayerProxy{}
+
+	if err := depinject.Inject(
+		deps,
+		&rp.clientCtx,
+		&rp.blockClient,
+	); err != nil {
+		return nil, err
+	}
+
 	servedRelays, servedRelaysProducer := channel.NewObservable[*types.Relay]()
 
-	return &relayerProxy{
-		blockClient:              blockClient,
-		keyName:                  keyName,
-		keyring:                  keyring,
-		accountsQuerier:          accountQuerier,
-		supplierQuerier:          supplierQuerier,
-		sessionQuerier:           sessionQuerier,
-		proxiedServicesEndpoints: proxiedServicesEndpoints,
-		servedRelays:             servedRelays,
-		servedRelaysProducer:     servedRelaysProducer,
-		clientCtx:                clientCtx,
+	rp.servedRelays = servedRelays
+	rp.servedRelaysProducer = servedRelaysProducer
+	rp.accountsQuerier = accounttypes.NewQueryClient(rp.clientCtx)
+	rp.supplierQuerier = suppliertypes.NewQueryClient(rp.clientCtx)
+	rp.sessionQuerier = sessiontypes.NewQueryClient(rp.clientCtx)
+	rp.keyring = rp.clientCtx.Keyring
+
+	for _, opt := range opts {
+		opt(rp)
 	}
+
+	if err := rp.validateConfigAndSetDefaults(); err != nil {
+		return nil, err
+	}
+
+	return rp, nil
 }
 
 // Start concurrently starts all advertised relay servers and returns an error if any of them fails to start.
@@ -144,4 +153,16 @@ func (rp *relayerProxy) Stop(ctx context.Context) error {
 // and its RelayResponse has been signed and successfully sent to the client.
 func (rp *relayerProxy) ServedRelays() observable.Observable[*types.Relay] {
 	return rp.servedRelays
+}
+
+func (rp *relayerProxy) validateConfigAndSetDefaults() error {
+	if rp.signingKeyName == "" {
+		return ErrUndefinedSigningKeyName
+	}
+
+	if rp.proxiedServicesEndpoints == nil {
+		return ErrUndefinedProxiedServicesEndpoints
+	}
+
+	return nil
 }

--- a/pkg/relayer/proxy/proxy.go
+++ b/pkg/relayer/proxy/proxy.go
@@ -76,6 +76,8 @@ type relayerProxy struct {
 	supplierAddress string
 }
 
+// NewRelayerProxy creates a new relayer proxy with the given dependencies or returns
+// an error if the dependencies fail to resolve or the options are invalid.
 func NewRelayerProxy(
 	deps depinject.Config,
 	opts ...relayer.RelayerProxyOption,
@@ -155,6 +157,7 @@ func (rp *relayerProxy) ServedRelays() observable.Observable[*types.Relay] {
 	return rp.servedRelays
 }
 
+// validateConfig validates the relayer proxy's configuration options and returns an error if it is invalid.
 func (rp *relayerProxy) validateConfig() error {
 	if rp.signingKeyName == "" {
 		return ErrUndefinedSigningKeyName

--- a/pkg/relayer/proxy/relay_signer.go
+++ b/pkg/relayer/proxy/relay_signer.go
@@ -19,7 +19,7 @@ func (rp *relayerProxy) SignRelayResponse(relayResponse *types.RelayResponse) er
 	}
 
 	hash := crypto.Sha256(responseBz)
-	relayResponse.Meta.SupplierSignature, _, err = rp.keyring.Sign(rp.keyName, hash)
+	relayResponse.Meta.SupplierSignature, _, err = rp.keyring.Sign(rp.signingKeyName, hash)
 
 	return err
 }

--- a/pkg/relayer/proxy/relay_verifier.go
+++ b/pkg/relayer/proxy/relay_verifier.go
@@ -37,7 +37,7 @@ func (rp *relayerProxy) VerifyRelayRequest(
 	}
 
 	if !account.GetPubKey().VerifySignature(hash, relayRequest.Meta.Signature) {
-		return ErrInvalidRelayRequestSignature
+		return ErrRelayerProxyInvalidRelayRequestSignature
 	}
 
 	// Query for the current session to check if relayRequest sessionId matches the current session.
@@ -62,7 +62,7 @@ func (rp *relayerProxy) VerifyRelayRequest(
 	// matches the relayRequest sessionId.
 	// TODO_INVESTIGATE: Revisit the assumptions above at some point in the future, but good enough for now.
 	if session.SessionId != relayRequest.Meta.SessionHeader.SessionId {
-		return ErrInvalidSession
+		return ErrRelayerProxyInvalidSession
 	}
 
 	// Check if the relayRequest is allowed to be served by the relayer proxy.
@@ -72,5 +72,5 @@ func (rp *relayerProxy) VerifyRelayRequest(
 		}
 	}
 
-	return ErrInvalidSupplier
+	return ErrRelayerProxyInvalidSupplier
 }

--- a/pkg/relayer/proxy/server_builder.go
+++ b/pkg/relayer/proxy/server_builder.go
@@ -48,7 +48,7 @@ func (rp *relayerProxy) BuildProvidedServices(ctx context.Context) error {
 					rp,
 				)
 			default:
-				return ErrUnsupportedRPCType
+				return ErrRelayerProxyUnsupportedRPCType
 			}
 
 			serviceEndpoints = append(serviceEndpoints, server)

--- a/pkg/relayer/proxy/server_builder.go
+++ b/pkg/relayer/proxy/server_builder.go
@@ -13,7 +13,7 @@ import (
 // is responsible for listening for incoming relay requests and relaying them to the supported proxied service.
 func (rp *relayerProxy) BuildProvidedServices(ctx context.Context) error {
 	// Get the supplier address from the keyring
-	supplierAddress, err := rp.keyring.Key(rp.keyName)
+	supplierAddress, err := rp.keyring.Key(rp.signingKeyName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

### Human Summary

Use `depinject` and options functions to construct the `RelayerProxy`

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Nov 23 23:53 UTC
This pull request introduces changes to the relayer package. 

The diff includes the following modifications:
- Added a new RelayerProxyOption type to configure the relayer proxy.
- Changed the error codespace from "relayer/proxy" to "relayer_proxy".
- Renamed error variables according to the new error codespace.
- Added a new file options.go that defines options for the relayer proxy.
- Added a NewRelayerProxy function to create a new relayer proxy.
- Refactored the relayerProxy struct to use the new options and validate the configuration.
- Modified the SignRelayResponse and VerifyRelayRequest methods to use the signing key name.
- Updated the error messages in the VerifyRelayRequest method.
- Added a function to validate the relayer proxy's configuration options.
- Modified the BuildProvidedServices method to use the signing key name.

Please review these changes and provide feedback.
<!-- reviewpad:summarize:end -->

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updated documentation and left TODOs throughout the codebase
