### PR TITLE
[Sessions] chore: Use depinject for sessions mgr construction

### DIFF
--- a/pkg/relayer/interface.go
+++ b/pkg/relayer/interface.go
@@ -72,6 +72,8 @@ type RelayerSessionsManager interface {
 	EnsureSessionTree(sessionHeader *sessiontypes.SessionHeader) (SessionTree, error)
 }
 
+type RelayerSessionsManagerOption func(RelayerSessionsManager)
+
 // SessionTree is an interface that wraps an SMST (Sparse Merkle State Tree) and its corresponding session.
 type SessionTree interface {
 	// GetSessionHeader returns the header of the session corresponding to the SMST.

--- a/pkg/relayer/session/errors.go
+++ b/pkg/relayer/session/errors.go
@@ -3,10 +3,10 @@ package session
 import sdkerrors "cosmossdk.io/errors"
 
 var (
-	codespace                       = "relayer/session"
-	ErrSessionTreeClosed            = sdkerrors.Register(codespace, 1, "session tree already closed")
-	ErrSessionTreeNotClosed         = sdkerrors.Register(codespace, 2, "session tree not closed")
-	ErrSessionStorePathExists       = sdkerrors.Register(codespace, 3, "session store path already exists")
-	ErrSessionTreeProofPathMismatch = sdkerrors.Register(codespace, 4, "session tree proof path mismatch")
-	ErrUndefinedStoresDirectory     = sdkerrors.Register(codespace, 5, "undefined stores directory")
+	codespace                              = "relayer_session"
+	ErrSessionTreeClosed                   = sdkerrors.Register(codespace, 1, "session tree already closed")
+	ErrSessionTreeNotClosed                = sdkerrors.Register(codespace, 2, "session tree not closed")
+	ErrSessionTreeStorePathExists          = sdkerrors.Register(codespace, 3, "session tree store path already exists")
+	ErrSessionTreeProofPathMismatch        = sdkerrors.Register(codespace, 4, "session tree proof path mismatch")
+	ErrSessionTreeUndefinedStoresDirectory = sdkerrors.Register(codespace, 5, "session tree key-value store directory undefined for where they will be saved on disk")
 )

--- a/pkg/relayer/session/errors.go
+++ b/pkg/relayer/session/errors.go
@@ -8,4 +8,5 @@ var (
 	ErrSessionTreeNotClosed         = sdkerrors.Register(codespace, 2, "session tree not closed")
 	ErrSessionStorePathExists       = sdkerrors.Register(codespace, 3, "session store path already exists")
 	ErrSessionTreeProofPathMismatch = sdkerrors.Register(codespace, 4, "session tree proof path mismatch")
+	ErrUndefinedStoresDirectory     = sdkerrors.Register(codespace, 5, "undefined stores directory")
 )

--- a/pkg/relayer/session/options.go
+++ b/pkg/relayer/session/options.go
@@ -4,7 +4,8 @@ import (
 	"github.com/pokt-network/poktroll/pkg/relayer"
 )
 
-// WithStoresDirectory sets the path on disk where KVStore data files are created.
+// WithStoresDirectory sets the path on disk where KVStore data files used to store
+// SMST of work sessions are created.
 func WithStoresDirectory(storesDirectory string) relayer.RelayerSessionsManagerOption {
 	return func(relSessionMgr relayer.RelayerSessionsManager) {
 		relSessionMgr.(*relayerSessionsManager).storesDirectory = storesDirectory

--- a/pkg/relayer/session/options.go
+++ b/pkg/relayer/session/options.go
@@ -1,0 +1,11 @@
+package session
+
+import (
+	"github.com/pokt-network/poktroll/pkg/relayer"
+)
+
+func WithStoresDirectory(storesDirectory string) relayer.RelayerSessionsManagerOption {
+	return func(relSessionMgr relayer.RelayerSessionsManager) {
+		relSessionMgr.(*relayerSessionsManager).storesDirectory = storesDirectory
+	}
+}

--- a/pkg/relayer/session/options.go
+++ b/pkg/relayer/session/options.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pokt-network/poktroll/pkg/relayer"
 )
 
+// WithStoresDirectory sets the path on disk where KVStore data files are created.
 func WithStoresDirectory(storesDirectory string) relayer.RelayerSessionsManagerOption {
 	return func(relSessionMgr relayer.RelayerSessionsManager) {
 		relSessionMgr.(*relayerSessionsManager).storesDirectory = storesDirectory

--- a/pkg/relayer/session/session.go
+++ b/pkg/relayer/session/session.go
@@ -149,9 +149,10 @@ func (rs *relayerSessionsManager) removeFromRelayerSessions(sessionHeader *sessi
 }
 
 // validateConfig validates the relayerSessionsManager's configuration.
+// TODO_TEST: Add unit tests to validate these configurations.
 func (rp *relayerSessionsManager) validateConfig() error {
 	if rp.storesDirectory == "" {
-		return ErrUndefinedStoresDirectory
+		return ErrSessionTreeUndefinedStoresDirectory
 	}
 
 	return nil

--- a/pkg/relayer/session/session.go
+++ b/pkg/relayer/session/session.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"sync"
 
+	"cosmossdk.io/depinject"
 	"github.com/pokt-network/poktroll/pkg/client"
 	"github.com/pokt-network/poktroll/pkg/observable"
 	"github.com/pokt-network/poktroll/pkg/observable/channel"
@@ -21,9 +22,6 @@ type sessionsTreesMap = map[int64]map[string]relayer.SessionTree
 type relayerSessionsManager struct {
 	// sessionsToClaim notifies about sessions that are ready to be claimed.
 	sessionsToClaim observable.Observable[relayer.SessionTree]
-
-	// sessionsToClaimPublisher is the channel used to publish sessions to claim.
-	sessionsToClaimPublisher chan<- relayer.SessionTree
 
 	// sessionTrees is a map of block heights pointing to a map of SessionTrees
 	// indexed by their sessionId.
@@ -42,22 +40,35 @@ type relayerSessionsManager struct {
 // NewRelayerSessions creates a new relayerSessions.
 func NewRelayerSessions(
 	ctx context.Context,
-	storesDirectory string,
-	blockClient client.BlockClient,
-) relayer.RelayerSessionsManager {
+	deps depinject.Config,
+	opts ...relayer.RelayerSessionsManagerOption,
+) (relayer.RelayerSessionsManager, error) {
 	rs := &relayerSessionsManager{
-		sessionsTrees:   make(sessionsTreesMap),
-		storesDirectory: storesDirectory,
-		blockClient:     blockClient,
+		sessionsTrees: make(sessionsTreesMap),
+	}
+
+	if err := depinject.Inject(
+		deps,
+		&rs.blockClient,
+	); err != nil {
+		return nil, err
+	}
+
+	for _, opt := range opts {
+		opt(rs)
+	}
+
+	if err := rs.validateConfig(); err != nil {
+		return nil, err
 	}
 
 	rs.sessionsToClaim = channel.MapExpand[client.Block, relayer.SessionTree](
 		ctx,
-		blockClient.CommittedBlocksSequence(ctx),
+		rs.blockClient.CommittedBlocksSequence(ctx),
 		rs.mapBlockToSessionsToClaim,
 	)
 
-	return rs
+	return rs, nil
 }
 
 // SessionsToClaim returns an observable that notifies when sessions are ready to be claimed.
@@ -135,4 +146,13 @@ func (rs *relayerSessionsManager) removeFromRelayerSessions(sessionHeader *sessi
 	if len(sessionsTreesEndingAtBlockHeight) == 0 {
 		delete(rs.sessionsTrees, sessionHeader.SessionEndBlockHeight)
 	}
+}
+
+// validateConfig validates the relayerSessionsManager's configuration.
+func (rp *relayerSessionsManager) validateConfig() error {
+	if rp.storesDirectory == "" {
+		return ErrUndefinedStoresDirectory
+	}
+
+	return nil
 }

--- a/pkg/relayer/session/sessiontree.go
+++ b/pkg/relayer/session/sessiontree.go
@@ -69,7 +69,7 @@ func NewSessionTree(
 
 	// Make sure storePath does not exist when creating a new SessionTree
 	if _, err := os.Stat(storePath); !os.IsNotExist(err) {
-		return nil, ErrSessionStorePathExists
+		return nil, ErrSessionTreeUndefinedStoresDirectory
 	}
 
 	treeStore, err := smt.NewKVStore(storePath)


### PR DESCRIPTION
## Summary

<!-- DELETE THIS COMMENT BLOCK
      - Provide a quick summary of the changes yourself
      - Let reviewpad summarize your PR under AI summary
      - You can leave a `/reviewpad summarize` comment at any time to trigger it manually.
-->

### Human Summary

Use depinject to construct `relayerSessionsManager`.

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 09 Nov 23 23:19 UTC
This pull request introduces several changes. 

The first patch (1/3) adds a new file `options.go` to the `pkg/relayer/session` package, which contains a new function `WithStoresDirectory`. This function sets the path on disk where KVStore data files are created. 

The second patch (2/3) adds a small improvement to the `WithStoresDirectory` function. It changes the error message when the session tree store path already exists. 

The third patch (3/3) improves the readability of the error messages in the `errors.go` file. It updates the error codespace and the error messages to make them more descriptive. It also updates the error message when the session tree store path already exists.

Overall, these changes aim to enhance the management of sessions and their corresponding data files in the `relayer` package.
<!-- reviewpad:summarize:end -->

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updated documentation and left TODOs throughout the codebase
