### PR TITLE
[AppGate] Use depinject and refactor cmd

### DIFF
--- a/pkg/appgateserver/endpoint_selector.go
+++ b/pkg/appgateserver/endpoint_selector.go
@@ -41,5 +41,5 @@ func (app *appGateServer) getRelayerUrl(
 	}
 
 	// Return an error if no relayer endpoints were found.
-	return nil, "", ErrNoRelayEndpoints
+	return nil, "", ErrAppGateNoRelayEndpoints
 }

--- a/pkg/appgateserver/errors.go
+++ b/pkg/appgateserver/errors.go
@@ -3,8 +3,10 @@ package appgateserver
 import sdkerrors "cosmossdk.io/errors"
 
 var (
-	codespace                        = "appclient"
-	ErrInvalidRelayResponseSignature = sdkerrors.Register(codespace, 1, "invalid relay response signature")
-	ErrNoRelayEndpoints              = sdkerrors.Register(codespace, 2, "no relay endpoints found")
-	ErrInvalidRequestURL             = sdkerrors.Register(codespace, 3, "invalid request URL")
+	codespace                               = "appgateserver"
+	ErrAppGateInvalidRelayResponseSignature = sdkerrors.Register(codespace, 1, "invalid relay response signature")
+	ErrAppGateNoRelayEndpoints              = sdkerrors.Register(codespace, 2, "no relay endpoints found")
+	ErrAppGateInvalidRequestURL             = sdkerrors.Register(codespace, 3, "invalid request URL")
+	ErrAppGateMissingAppAddress             = sdkerrors.Register(codespace, 4, "missing application address")
+	ErrAppGateMissingListeningEndpoint      = sdkerrors.Register(codespace, 5, "missing app client listening endpoint")
 )

--- a/pkg/appgateserver/errors.go
+++ b/pkg/appgateserver/errors.go
@@ -8,5 +8,6 @@ var (
 	ErrAppGateNoRelayEndpoints              = sdkerrors.Register(codespace, 2, "no relay endpoints found")
 	ErrAppGateInvalidRequestURL             = sdkerrors.Register(codespace, 3, "invalid request URL")
 	ErrAppGateMissingAppAddress             = sdkerrors.Register(codespace, 4, "missing application address")
-	ErrAppGateMissingListeningEndpoint      = sdkerrors.Register(codespace, 5, "missing app client listening endpoint")
+	ErrAppGateMissingSigningInformation     = sdkerrors.Register(codespace, 5, "missing app client signing information")
+	ErrAppGateMissingListeningEndpoint      = sdkerrors.Register(codespace, 6, "missing app client listening endpoint")
 )

--- a/pkg/appgateserver/jsonrpc.go
+++ b/pkg/appgateserver/jsonrpc.go
@@ -48,8 +48,8 @@ func (app *appGateServer) handleJSONRPCRelay(
 	// Create the relay request.
 	relayRequest := &types.RelayRequest{
 		Meta: &types.RelayRequestMetadata{
-			// SessionHeader: session.Header,
-			Signature: nil,
+			SessionHeader: session.Header,
+			Signature:     nil,
 		},
 		Payload: relayRequestPayload,
 	}
@@ -67,6 +67,7 @@ func (app *appGateServer) handleJSONRPCRelay(
 	if err != nil {
 		return err
 	}
+
 	hash := crypto.Sha256(signableBz)
 	signature, err := signer.Sign(hash)
 	if err != nil {

--- a/pkg/appgateserver/options.go
+++ b/pkg/appgateserver/options.go
@@ -1,0 +1,17 @@
+package appgateserver
+
+import "net/url"
+
+// WithSigningKeyName sets the signing key name for the app gate server.
+func WithSigningKeyName(signingKeyName string) appGateServerOption {
+	return func(appGateServer *appGateServer) {
+		appGateServer.signingKeyName = signingKeyName
+	}
+}
+
+// WithListeningUrl sets the listening URL for the app gate server.
+func WithListeningUrl(listeningUrl *url.URL) appGateServerOption {
+	return func(appGateServer *appGateServer) {
+		appGateServer.listeningEndpoint = listeningUrl
+	}
+}

--- a/pkg/appgateserver/options.go
+++ b/pkg/appgateserver/options.go
@@ -1,11 +1,13 @@
 package appgateserver
 
-import "net/url"
+import (
+	"net/url"
+)
 
-// WithSigningKeyName sets the signing key name for the app gate server.
-func WithSigningKeyName(signingKeyName string) appGateServerOption {
+// WithSigningInformation sets the signing key and app address for server.
+func WithSigningInformation(signingInfo *SigningInformation) appGateServerOption {
 	return func(appGateServer *appGateServer) {
-		appGateServer.signingKeyName = signingKeyName
+		appGateServer.signingInformation = signingInfo
 	}
 }
 

--- a/pkg/appgateserver/relay_verifier.go
+++ b/pkg/appgateserver/relay_verifier.go
@@ -34,7 +34,7 @@ func (app *appGateServer) verifyResponse(
 
 	// Verify the relay response signature.
 	if !pubKey.VerifySignature(hash, signature) {
-		return ErrInvalidRelayResponseSignature
+		return ErrAppGateInvalidRelayResponseSignature
 	}
 
 	return nil

--- a/pkg/appgateserver/server.go
+++ b/pkg/appgateserver/server.go
@@ -180,7 +180,7 @@ func (app *appGateServer) ServeHTTP(writer http.ResponseWriter, request *http.Re
 	serviceId := strings.Split(path, "/")[1]
 	var appAddress string
 
-	if app.appAddress != "" {
+	if app.appAddress == "" {
 		appAddress = request.URL.Query().Get("senderAddr")
 	} else {
 		appAddress = app.appAddress

--- a/x/service/types/relay.go
+++ b/x/service/types/relay.go
@@ -5,16 +5,10 @@ package types
 // A value receiver is used to avoid overwriting any pre-existing signature
 func (req RelayRequest) GetSignableBytes() ([]byte, error) {
 	// set signature to nil
-	sig := req.Meta.Signature
 	req.Meta.Signature = nil
 
-	bz, err := req.Marshal()
-	if err == nil {
-		req.Meta.Signature = sig
-	}
-
 	// return the marshaled message
-	return bz, nil
+	return req.Marshal()
 }
 
 // GetSignableBytes returns the signable bytes for the relay response
@@ -22,14 +16,8 @@ func (req RelayRequest) GetSignableBytes() ([]byte, error) {
 // A value receiver is used to avoid overwriting any pre-existing signature
 func (res RelayResponse) GetSignableBytes() ([]byte, error) {
 	// set signature to nil
-	sig := res.Meta.SupplierSignature
 	res.Meta.SupplierSignature = nil
 
-	bz, err := res.Marshal()
-	if err == nil {
-		res.Meta.SupplierSignature = sig
-	}
-
 	// return the marshaled message
-	return bz, err
+	return res.Marshal()
 }

--- a/x/service/types/relay.go
+++ b/x/service/types/relay.go
@@ -5,9 +5,16 @@ package types
 // A value receiver is used to avoid overwriting any pre-existing signature
 func (req RelayRequest) GetSignableBytes() ([]byte, error) {
 	// set signature to nil
+	sig := req.Meta.Signature
 	req.Meta.Signature = nil
+
+	bz, err := req.Marshal()
+	if err == nil {
+		req.Meta.Signature = sig
+	}
+
 	// return the marshaled message
-	return req.Marshal()
+	return bz, nil
 }
 
 // GetSignableBytes returns the signable bytes for the relay response
@@ -15,7 +22,14 @@ func (req RelayRequest) GetSignableBytes() ([]byte, error) {
 // A value receiver is used to avoid overwriting any pre-existing signature
 func (res RelayResponse) GetSignableBytes() ([]byte, error) {
 	// set signature to nil
+	sig := res.Meta.SupplierSignature
 	res.Meta.SupplierSignature = nil
+
+	bz, err := res.Marshal()
+	if err == nil {
+		res.Meta.SupplierSignature = sig
+	}
+
 	// return the marshaled message
-	return res.Marshal()
+	return bz, err
 }


### PR DESCRIPTION
## Summary

### Human Summary

* Use `depinject` to construct the `appGateServer`.
* Attempt to simplify dependencies
* Rely on context to stop the `sppGateServer` and its dependencies

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 10 Nov 23 20:04 UTC
This pull request includes the following changes:

1. In the `relay.go` file:
   - Three blank lines have been added.
   - The SessionHeader field of Meta in the RelayRequest struct was uncommented.
   - The Signature field of Meta in the RelayRequest struct was assigned a value of nil.
   - An extra blank line was added at line 67.

2. In the `options.go` file:
   - A new file `options.go` has been added in the `pkg/appgateserver` package. It defines two functions: `WithSigningInformation` and `WithListeningUrl`.

3. In the `errors.go` file:
   - The `codespace` variable has been updated to `"appgateserver"`.
   - The error variable names have been updated to have the prefix `ErrAppGate`.
   - Various error variables have been added and renamed.
  
4. In the `relay_verifier.go` file:
   - An error constant has been updated from `ErrInvalidRelayResponseSignature` to `ErrAppGateInvalidRelayResponseSignature`.

5. In the `main.go` file:
   - Various import statements, variable declarations, and function implementations have been removed or modified.

Please review these changes and ensure they align with the desired functionality. Let me know if you require any further assistance.
<!-- reviewpad:summarize:end -->

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
