### PR TITLE
[Supplier] chore: improve supplier not found error message

### DIFF
--- a/x/supplier/keeper/query_supplier.go
+++ b/x/supplier/keeper/query_supplier.go
@@ -53,6 +53,7 @@ func (k Keeper) Supplier(goCtx context.Context, req *types.QueryGetSupplierReque
 		req.Address,
 	)
 	if !found {
+		// TODO_TECHDEBT(#181): conform to logging conventions once established
 		msg := fmt.Sprintf("supplier with address %q", req.GetAddress())
 		return nil, status.Error(codes.NotFound, msg)
 	}

--- a/x/supplier/keeper/query_supplier.go
+++ b/x/supplier/keeper/query_supplier.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -52,7 +53,8 @@ func (k Keeper) Supplier(goCtx context.Context, req *types.QueryGetSupplierReque
 		req.Address,
 	)
 	if !found {
-		return nil, status.Error(codes.NotFound, "not found")
+		msg := fmt.Sprintf("supplier with address %q", req.GetAddress())
+		return nil, status.Error(codes.NotFound, msg)
 	}
 
 	return &types.QueryGetSupplierResponse{Supplier: val}, nil

--- a/x/supplier/keeper/query_supplier_test.go
+++ b/x/supplier/keeper/query_supplier_test.go
@@ -47,7 +47,7 @@ func TestSupplierQuerySingle(t *testing.T) {
 			request: &types.QueryGetSupplierRequest{
 				Address: strconv.Itoa(100000),
 			},
-			err: status.Error(codes.NotFound, "not found"),
+			err: status.Error(codes.NotFound, "supplier with address \"100000\""),
 		},
 		{
 			desc: "InvalidRequest",


### PR DESCRIPTION
## Summary

### Human Summary

Add context to the "key not found" error message that is returned when querying for a supplier which hasn't staked yet:
![image](https://github.com/pokt-network/poktroll/assets/600733/78ed2f61-f8a2-42d8-9e89-9493c750495d)

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 14 Nov 23 10:24 UTC
This pull request improves the error message seen by RPC consumers when the given supplier is not found on-chain. It adds a formatted message that includes the address of the supplier.
<!-- reviewpad:summarize:end -->

## Issue

- #126 

![image](https://github.com/pokt-network/poktroll/assets/600733/e7f91934-ccbf-4ea5-9663-c2e51c31dede)

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
