### PR TITLE
[AppGate] feat: Add app gate config

### DIFF
--- a/localnet/poktrolld/config/appgate_server_config.yaml
+++ b/localnet/poktrolld/config/appgate_server_config.yaml
@@ -1,6 +1,6 @@
 # Whether the server should sign all incoming requests with its own ring (for applications)
 self_signing: true
-# The name of the key that will be used to sign relays
+# The name of the key (in the keyring) that will be used to sign relays
 signing_key: app1
 # The host and port that the appgate server will listen on
 listening_endpoint: http://localhost:42069

--- a/localnet/poktrolld/config/appgate_server_config.yaml
+++ b/localnet/poktrolld/config/appgate_server_config.yaml
@@ -1,0 +1,8 @@
+# Whether the server should sign all incoming requests with its own ring (for applications)
+self_signing: true
+# The name of the key that will be used to sign relays
+signing_key: app1
+# The host and port that the appgate server will listen on
+listening_endpoint: http://localhost:42069
+# tcp://<host>:<port> to a full pocket node for reading data and listening for on-chain events
+query_node_url: tcp://127.0.0.1:36657

--- a/pkg/appgateserver/cmd/cmd.go
+++ b/pkg/appgateserver/cmd/cmd.go
@@ -80,7 +80,7 @@ func runAppGateServer(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	appGateConfigs, err := appgateconfig.ParseAppGateConfigs(configContent)
+	appGateConfigs, err := appgateconfig.ParseAppGateServerConfigs(configContent)
 	if err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func runAppGateServer(cmd *cobra.Command, _ []string) error {
 func setupAppGateServerDependencies(
 	ctx context.Context,
 	cmd *cobra.Command,
-	appGateConfig *appgateconfig.AppGateConfig,
+	appGateConfig *appgateconfig.AppGateServerConfig,
 ) (depinject.Config, error) {
 	pocketNodeWebsocketUrl := fmt.Sprintf("ws://%s/websocket", appGateConfig.QueryNodeUrl.Host)
 

--- a/pkg/appgateserver/cmd/cmd.go
+++ b/pkg/appgateserver/cmd/cmd.go
@@ -34,10 +34,10 @@ func AppGateServerCmd() *cobra.Command {
 the necessary on-chain interactions (sessions, suppliers, etc) to receive the
 respective relay response.
 
--- App Mode--
+-- App Mode --
 If the server is started with a defined 'self-signing' configuration directive,
 it will behave as an Application. Any incoming requests will be signed by using
-the private key and ring associated with the 'signing_key' directive.
+the private key and ring associated with the 'signing_key' configuration directive.
 
 -- Gateway Mode --
 If the 'self_signing' configuration directive is not provided, the server will

--- a/pkg/appgateserver/cmd/cmd.go
+++ b/pkg/appgateserver/cmd/cmd.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/url"
+	"os"
 
 	"cosmossdk.io/depinject"
 	cosmosclient "github.com/cosmos/cosmos-sdk/client"
@@ -15,6 +15,7 @@ import (
 
 	"github.com/pokt-network/poktroll/cmd/signals"
 	"github.com/pokt-network/poktroll/pkg/appgateserver"
+	appgateconfig "github.com/pokt-network/poktroll/pkg/appgateserver/config"
 	"github.com/pokt-network/poktroll/pkg/deps/config"
 )
 
@@ -22,10 +23,7 @@ import (
 const omittedDefaultFlagValue = "explicitly omitting default"
 
 var (
-	flagSigningKey        string
-	flagSelfSigning       bool
-	flagListeningEndpoint string
-	flagQueryNodeUrl      string
+	flagAppGateConfig string
 )
 
 func AppGateServerCmd() *cobra.Command {
@@ -36,32 +34,31 @@ func AppGateServerCmd() *cobra.Command {
 the necessary on-chain interactions (sessions, suppliers, etc) to receive the
 respective relay response.
 
--- App Mode (Flag)- -
-If the server is started with a defined '--self-signing' flag, it will behave
-as an Application. Any incoming requests will be signed by using the private
-key and ring associated with the '--signing-key' flag.
+-- App Mode--
+If the server is started with a defined 'self-signing' configuration directive,
+it will behave as an Application. Any incoming requests will be signed by using
+the private key and ring associated with the 'signing_key' directive.
 
--- Gateway Mode (Flag)--
-If the '--self-signing' flag is not provided, the server will behave as a Gateway.
+-- Gateway Mode --
+If the 'self_signing' configuration directive is not provided, the server will
+behave as a Gateway.
 It will sign relays on behalf of any Application sending it relays, provided
-that the address associated with '--signing-key' has been delegated to. This is
+that the address associated with 'signing_key' has been delegated to. This is
 necessary for the application<->gateway ring signature to function.
 
 -- App Mode (HTTP) --
-If an application doesn't provide the '--self-signing' flag, it can still send
-relays to the AppGate server and function as an Application, provided that:
+If an application doesn't provide the 'self_signing' configuration directive,
+it can still send relays to the AppGate server and function as an Application,
+provided that:
 1. Each request contains the '?senderAddress=[address]' query parameter
-2. The key associated with the '--signing-key' flag belongs to the address
-   provided in the request, otherwise the ring signature will not be valid.`,
+2. The key associated with the 'signing_key' configuration directive belongs
+   to the address provided in the request, otherwise the ring signature will not be valid.`,
 		Args: cobra.NoArgs,
 		RunE: runAppGateServer,
 	}
 
 	// Custom flags
-	cmd.Flags().StringVar(&flagSigningKey, "signing-key", "", "The name of the key that will be used to sign relays")
-	cmd.Flags().StringVar(&flagListeningEndpoint, "listening-endpoint", "http://localhost:42069", "The host and port that the appgate server will listen on")
-	cmd.Flags().BoolVar(&flagSelfSigning, "self-signing", false, "Whether the server should sign all incoming requests with its own ring (for applications)")
-	cmd.Flags().StringVar(&flagQueryNodeUrl, "query-node", omittedDefaultFlagValue, "tcp://<host>:<port> to a full pocket node for reading data and listening for on-chain events")
+	cmd.Flags().StringVar(&flagAppGateConfig, "config", "", "The path to the appgate config file")
 
 	// Cosmos flags
 	cmd.Flags().String(cosmosflags.FlagKeyringBackend, "", "Select keyring's backend (os|file|kwallet|pass|test)")
@@ -78,14 +75,18 @@ func runAppGateServer(cmd *cobra.Command, _ []string) error {
 	// Handle interrupt and kill signals asynchronously.
 	signals.GoOnExitSignal(cancelCtx)
 
-	// Parse the listening endpoint.
-	listeningUrl, err := url.Parse(flagListeningEndpoint)
+	configContent, err := os.ReadFile(flagAppGateConfig)
 	if err != nil {
-		return fmt.Errorf("failed to parse listening endpoint: %w", err)
+		return err
+	}
+
+	appGateConfigs, err := appgateconfig.ParseAppGateConfigs(configContent)
+	if err != nil {
+		return err
 	}
 
 	// Setup the AppGate server dependencies.
-	appGateServerDeps, err := setupAppGateServerDependencies(ctx, cmd)
+	appGateServerDeps, err := setupAppGateServerDependencies(ctx, cmd, appGateConfigs)
 	if err != nil {
 		return fmt.Errorf("failed to setup AppGate server dependencies: %w", err)
 	}
@@ -97,18 +98,18 @@ func runAppGateServer(cmd *cobra.Command, _ []string) error {
 		appGateServerDeps,
 		appgateserver.WithSigningInformation(&appgateserver.SigningInformation{
 			// provide the name of the key to use for signing all incoming requests
-			SigningKeyName: flagSigningKey,
+			SigningKeyName: appGateConfigs.SigningKey,
 			// provide whether the appgate server should sign all incoming requests
 			// with its own ring (for applications) or not (for gateways)
-			SelfSigning: flagSelfSigning,
+			SelfSigning: appGateConfigs.SelfSigning,
 		}),
-		appgateserver.WithListeningUrl(listeningUrl),
+		appgateserver.WithListeningUrl(appGateConfigs.ListeningEndpoint),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create AppGate server: %w", err)
 	}
 
-	log.Printf("INFO: Starting AppGate server, listening on %s...", listeningUrl.String())
+	log.Printf("INFO: Starting AppGate server, listening on %s...", appGateConfigs.ListeningEndpoint.String())
 
 	// Start the AppGate server.
 	if err := appGateServer.Start(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -123,34 +124,17 @@ func runAppGateServer(cmd *cobra.Command, _ []string) error {
 func setupAppGateServerDependencies(
 	ctx context.Context,
 	cmd *cobra.Command,
+	appGateConfig *appgateconfig.AppGateConfig,
 ) (depinject.Config, error) {
-	pocketNodeWebsocketUrl, err := getPocketNodeWebsocketUrl()
-	if err != nil {
-		return nil, err
-	}
+	pocketNodeWebsocketUrl := fmt.Sprintf("ws://%s/websocket", appGateConfig.QueryNodeUrl.Host)
 
 	supplierFuncs := []config.SupplierFn{
 		config.NewSupplyEventsQueryClientFn(pocketNodeWebsocketUrl),
 		config.NewSupplyBlockClientFn(pocketNodeWebsocketUrl),
-		newSupplyQueryClientContextFn(flagQueryNodeUrl),
+		newSupplyQueryClientContextFn(appGateConfig.QueryNodeUrl.String()),
 	}
 
 	return config.SupplyConfig(ctx, cmd, supplierFuncs)
-}
-
-// getPocketNodeWebsocketUrl returns the websocket URL of the Pocket Node to
-// connect to for subscribing to on-chain events.
-func getPocketNodeWebsocketUrl() (string, error) {
-	if flagQueryNodeUrl == omittedDefaultFlagValue {
-		return "", errors.New("missing required flag: --query-node")
-	}
-
-	pocketNodeURL, err := url.Parse(flagQueryNodeUrl)
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf("ws://%s/websocket", pocketNodeURL.Host), nil
 }
 
 // newSupplyQueryClientContextFn returns a new depinject.Config which is supplied with

--- a/pkg/appgateserver/config/appgate_configs_reader.go
+++ b/pkg/appgateserver/config/appgate_configs_reader.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"net/url"
+
+	"gopkg.in/yaml.v2"
+)
+
+// YAMLAppGateConfig is the structure used to unmarshal the AppGateServer config file
+type YAMLAppGateConfig struct {
+	SelfSigning       bool   `yaml:"self_signing"`
+	SigningKey        string `yaml:"signing_key"`
+	ListeningEndpoint string `yaml:"listening_endpoint"`
+	QueryNodeUrl      string `yaml:"query_node_url"`
+}
+
+// AppGateConfig is the structure describing the AppGateServer config
+type AppGateConfig struct {
+	SelfSigning       bool
+	SigningKey        string
+	ListeningEndpoint *url.URL
+	QueryNodeUrl      *url.URL
+}
+
+// ParseSupplierServiceConfig parses the stake config file into a SupplierServiceConfig
+func ParseAppGateConfigs(configContent []byte) (*AppGateConfig, error) {
+	var yamlAppGateConfig YAMLAppGateConfig
+
+	// Unmarshal the stake config file into a stakeConfig
+	if err := yaml.Unmarshal(configContent, &yamlAppGateConfig); err != nil {
+		return nil, ErrAppGateConfigUnmarshalYAML.Wrapf("%s", err)
+	}
+
+	if yamlAppGateConfig.SigningKey == "" {
+		return nil, ErrAppGateConfigEmptySigningKey
+	}
+
+	if yamlAppGateConfig.ListeningEndpoint == "" {
+		return nil, ErrAppGateConfigInvalidListeningEndpoint
+	}
+
+	listeningEndpoint, err := url.Parse(yamlAppGateConfig.ListeningEndpoint)
+	if err != nil {
+		return nil, ErrAppGateConfigInvalidListeningEndpoint.Wrapf("%s", err)
+	}
+
+	if yamlAppGateConfig.QueryNodeUrl == "" {
+		return nil, ErrAppGateConfigInvalidQueryNodeUrl
+	}
+
+	queryNodeUrl, err := url.Parse(yamlAppGateConfig.QueryNodeUrl)
+	if err != nil {
+		return nil, ErrAppGateConfigInvalidQueryNodeUrl.Wrapf("%s", err)
+	}
+
+	// Populate the supplierServiceConfig
+	appGateCMDConfig := &AppGateConfig{
+		SelfSigning:       yamlAppGateConfig.SelfSigning,
+		SigningKey:        yamlAppGateConfig.SigningKey,
+		ListeningEndpoint: listeningEndpoint,
+		QueryNodeUrl:      queryNodeUrl,
+	}
+
+	return appGateCMDConfig, nil
+}

--- a/pkg/appgateserver/config/appgate_configs_reader.go
+++ b/pkg/appgateserver/config/appgate_configs_reader.go
@@ -22,11 +22,12 @@ type AppGateConfig struct {
 	QueryNodeUrl      *url.URL
 }
 
-// ParseSupplierServiceConfig parses the stake config file into a SupplierServiceConfig
+// ParseAppGateConfigs parses the stake config file into a AppGateConfig
+// NOTE: If SelfSigning is not defined in the config file, it will default to false
 func ParseAppGateConfigs(configContent []byte) (*AppGateConfig, error) {
 	var yamlAppGateConfig YAMLAppGateConfig
 
-	// Unmarshal the stake config file into a stakeConfig
+	// Unmarshal the stake config file into a yamlAppGateConfig
 	if err := yaml.Unmarshal(configContent, &yamlAppGateConfig); err != nil {
 		return nil, ErrAppGateConfigUnmarshalYAML.Wrapf("%s", err)
 	}

--- a/pkg/appgateserver/config/appgate_configs_reader.go
+++ b/pkg/appgateserver/config/appgate_configs_reader.go
@@ -6,61 +6,62 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// YAMLAppGateConfig is the structure used to unmarshal the AppGateServer config file
-type YAMLAppGateConfig struct {
+// YAMLAppGateServerConfig is the structure used to unmarshal the AppGateServer config file
+// TODO_DOCUMENT(@red-0ne): Add proper README documentation for yaml config files.
+type YAMLAppGateServerConfig struct {
 	SelfSigning       bool   `yaml:"self_signing"`
 	SigningKey        string `yaml:"signing_key"`
 	ListeningEndpoint string `yaml:"listening_endpoint"`
 	QueryNodeUrl      string `yaml:"query_node_url"`
 }
 
-// AppGateConfig is the structure describing the AppGateServer config
-type AppGateConfig struct {
+// AppGateServerConfig is the structure describing the AppGateServer config
+type AppGateServerConfig struct {
 	SelfSigning       bool
 	SigningKey        string
 	ListeningEndpoint *url.URL
 	QueryNodeUrl      *url.URL
 }
 
-// ParseAppGateConfigs parses the stake config file into a AppGateConfig
+// ParseAppGateServerConfigs parses the stake config file into a AppGateConfig
 // NOTE: If SelfSigning is not defined in the config file, it will default to false
-func ParseAppGateConfigs(configContent []byte) (*AppGateConfig, error) {
-	var yamlAppGateConfig YAMLAppGateConfig
+func ParseAppGateServerConfigs(configContent []byte) (*AppGateServerConfig, error) {
+	var yamlAppGateServerConfig YAMLAppGateServerConfig
 
 	// Unmarshal the stake config file into a yamlAppGateConfig
-	if err := yaml.Unmarshal(configContent, &yamlAppGateConfig); err != nil {
+	if err := yaml.Unmarshal(configContent, &yamlAppGateServerConfig); err != nil {
 		return nil, ErrAppGateConfigUnmarshalYAML.Wrapf("%s", err)
 	}
 
-	if yamlAppGateConfig.SigningKey == "" {
+	if yamlAppGateServerConfig.SigningKey == "" {
 		return nil, ErrAppGateConfigEmptySigningKey
 	}
 
-	if yamlAppGateConfig.ListeningEndpoint == "" {
+	if yamlAppGateServerConfig.ListeningEndpoint == "" {
 		return nil, ErrAppGateConfigInvalidListeningEndpoint
 	}
 
-	listeningEndpoint, err := url.Parse(yamlAppGateConfig.ListeningEndpoint)
+	listeningEndpoint, err := url.Parse(yamlAppGateServerConfig.ListeningEndpoint)
 	if err != nil {
 		return nil, ErrAppGateConfigInvalidListeningEndpoint.Wrapf("%s", err)
 	}
 
-	if yamlAppGateConfig.QueryNodeUrl == "" {
+	if yamlAppGateServerConfig.QueryNodeUrl == "" {
 		return nil, ErrAppGateConfigInvalidQueryNodeUrl
 	}
 
-	queryNodeUrl, err := url.Parse(yamlAppGateConfig.QueryNodeUrl)
+	queryNodeUrl, err := url.Parse(yamlAppGateServerConfig.QueryNodeUrl)
 	if err != nil {
 		return nil, ErrAppGateConfigInvalidQueryNodeUrl.Wrapf("%s", err)
 	}
 
-	// Populate the supplierServiceConfig
-	appGateCMDConfig := &AppGateConfig{
-		SelfSigning:       yamlAppGateConfig.SelfSigning,
-		SigningKey:        yamlAppGateConfig.SigningKey,
+	// Populate the appGateServerConfig with the values from the yamlAppGateServerConfig
+	appGateServerConfig := &AppGateServerConfig{
+		SelfSigning:       yamlAppGateServerConfig.SelfSigning,
+		SigningKey:        yamlAppGateServerConfig.SigningKey,
 		ListeningEndpoint: listeningEndpoint,
 		QueryNodeUrl:      queryNodeUrl,
 	}
 
-	return appGateCMDConfig, nil
+	return appGateServerConfig, nil
 }

--- a/pkg/appgateserver/config/appgate_configs_reader_test.go
+++ b/pkg/appgateserver/config/appgate_configs_reader_test.go
@@ -1,0 +1,115 @@
+package config_test
+
+import (
+	"net/url"
+	"testing"
+
+	sdkerrors "cosmossdk.io/errors"
+	"github.com/gogo/status"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/poktroll/pkg/appgateserver/config"
+	"github.com/pokt-network/poktroll/testutil/yaml"
+)
+
+func Test_ParseAppGateConfigs(t *testing.T) {
+	tests := []struct {
+		desc     string
+		err      *sdkerrors.Error
+		expected *config.AppGateConfig
+		config   string
+	}{
+		// Valid Configs
+		{
+			desc: "appgate_config_test: valid app gate config",
+			err:  nil,
+			expected: &config.AppGateConfig{
+				SelfSigning:       true,
+				SigningKey:        "app1",
+				ListeningEndpoint: &url.URL{Scheme: "http", Host: "localhost:42069"},
+				QueryNodeUrl:      &url.URL{Scheme: "tcp", Host: "127.0.0.1:36657"},
+			},
+			config: `
+				self_signing: true
+				signing_key: app1
+				listening_endpoint: http://localhost:42069
+				query_node_url: tcp://127.0.0.1:36657
+				`,
+		},
+		{
+			desc: "appgate_config_test: valid app gate config with undefined self signing",
+			err:  nil,
+			expected: &config.AppGateConfig{
+				SelfSigning:       false,
+				SigningKey:        "app1",
+				ListeningEndpoint: &url.URL{Scheme: "http", Host: "localhost:42069"},
+				QueryNodeUrl:      &url.URL{Scheme: "tcp", Host: "127.0.0.1:36657"},
+			},
+			config: `
+				signing_key: app1
+				listening_endpoint: http://localhost:42069
+				query_node_url: tcp://127.0.0.1:36657
+				`,
+		},
+		// Invalid Configs
+		{
+			desc:   "appgate_config_test: invalid appgate config",
+			err:    config.ErrAppGateConfigUnmarshalYAML,
+			config: ``,
+		},
+		{
+			desc: "appgate_config_test: no signing key",
+			err:  config.ErrAppGateConfigEmptySigningKey,
+			config: `
+				self_signing: true
+				signing_key:
+				listening_endpoint: http://localhost:42069
+				query_node_url: tcp://127.0.0.1:36657
+				`,
+		},
+		{
+			desc: "appgate_config_test: invalid listening endpoint",
+			err:  config.ErrAppGateConfigInvalidListeningEndpoint,
+			config: `
+				self_signing: true
+				signing_key: app1
+				listening_endpoint: &localhost:42069
+				query_node_url: tcp://127.0.0.1:36657
+				`,
+		},
+		{
+			desc: "appgate_config_test: invalid query node url",
+			err:  config.ErrAppGateConfigInvalidQueryNodeUrl,
+			config: `
+				self_signing: true
+				signing_key: app1
+				listening_endpoint: http://localhost:42069
+				query_node_url: &127.0.0.1:36657
+				`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			normalizedConfig := yaml.NormalizeYAMLIndentation(tt.config)
+			config, err := config.ParseAppGateConfigs([]byte(normalizedConfig))
+
+			if tt.err != nil {
+				require.Error(t, err)
+				require.Nil(t, config)
+				stat, ok := status.FromError(tt.err)
+				require.True(t, ok)
+				require.Contains(t, stat.Message(), tt.err.Error())
+				require.Nil(t, config)
+				return
+			}
+
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expected.SelfSigning, config.SelfSigning)
+			require.Equal(t, tt.expected.SigningKey, config.SigningKey)
+			require.Equal(t, tt.expected.ListeningEndpoint.String(), config.ListeningEndpoint.String())
+			require.Equal(t, tt.expected.QueryNodeUrl.String(), config.QueryNodeUrl.String())
+		})
+	}
+}

--- a/pkg/appgateserver/config/errors.go
+++ b/pkg/appgateserver/config/errors.go
@@ -1,0 +1,11 @@
+package config
+
+import sdkerrors "cosmossdk.io/errors"
+
+var (
+	codespace                                = "appgate_config"
+	ErrAppGateConfigUnmarshalYAML            = sdkerrors.Register(codespace, 1, "config reader cannot unmarshal yaml content")
+	ErrAppGateConfigEmptySigningKey          = sdkerrors.Register(codespace, 2, "empty signing key in app gate config")
+	ErrAppGateConfigInvalidListeningEndpoint = sdkerrors.Register(codespace, 3, "invalid listening endpoint in app gate config")
+	ErrAppGateConfigInvalidQueryNodeUrl      = sdkerrors.Register(codespace, 4, "invalid query node url in app gate config")
+)

--- a/pkg/appgateserver/config/errors.go
+++ b/pkg/appgateserver/config/errors.go
@@ -7,5 +7,5 @@ var (
 	ErrAppGateConfigUnmarshalYAML            = sdkerrors.Register(codespace, 1, "config reader cannot unmarshal yaml content")
 	ErrAppGateConfigEmptySigningKey          = sdkerrors.Register(codespace, 2, "empty signing key in AppGateServer config")
 	ErrAppGateConfigInvalidListeningEndpoint = sdkerrors.Register(codespace, 3, "invalid listening endpoint in AppGateServer config")
-	ErrAppGateConfigInvalidQueryNodeUrl      = sdkerrors.Register(codespace, 4, "invalid query node url in AppGateServer config")
+	ErrAppGateConfigInvalidQueryNodeUrl      = sdkerrors.Register(codespace, 4, "invalid pocket query node url in AppGateServer config")
 )

--- a/pkg/appgateserver/config/errors.go
+++ b/pkg/appgateserver/config/errors.go
@@ -5,7 +5,7 @@ import sdkerrors "cosmossdk.io/errors"
 var (
 	codespace                                = "appgate_config"
 	ErrAppGateConfigUnmarshalYAML            = sdkerrors.Register(codespace, 1, "config reader cannot unmarshal yaml content")
-	ErrAppGateConfigEmptySigningKey          = sdkerrors.Register(codespace, 2, "empty signing key in app gate config")
-	ErrAppGateConfigInvalidListeningEndpoint = sdkerrors.Register(codespace, 3, "invalid listening endpoint in app gate config")
-	ErrAppGateConfigInvalidQueryNodeUrl      = sdkerrors.Register(codespace, 4, "invalid query node url in app gate config")
+	ErrAppGateConfigEmptySigningKey          = sdkerrors.Register(codespace, 2, "empty signing key in AppGateServer config")
+	ErrAppGateConfigInvalidListeningEndpoint = sdkerrors.Register(codespace, 3, "invalid listening endpoint in AppGateServer config")
+	ErrAppGateConfigInvalidQueryNodeUrl      = sdkerrors.Register(codespace, 4, "invalid query node url in AppGateServer config")
 )

--- a/testutil/yaml/yaml.go
+++ b/testutil/yaml/yaml.go
@@ -1,0 +1,31 @@
+package yaml
+
+import "strings"
+
+// YAML is indentation sensitive, so we need to remove the extra indentation from the test cases and make sure
+// it is space-indented instead of tab-indented, otherwise the YAML parser will fail
+func NormalizeYAMLIndentation(rawContent string) string {
+	var processedContent = rawContent
+	// Remove extra newlines
+	processedContent = strings.TrimPrefix(processedContent, "\n")
+
+	// Replace tab indentation with 2 spaces as our code is tab-indented but YAML is expecting double spaces
+	processedContent = strings.ReplaceAll(processedContent, "\t", "  ")
+
+	// Get the extra indentation from the first line that will serve as the basis for the rest of the lines
+	extraIndentationCount := len(processedContent) - len(strings.TrimLeft(processedContent, " "))
+
+	// Create a prefix to trim from the beginning of each line
+	extraIndentation := strings.Repeat(" ", extraIndentationCount)
+
+	// Split the content into lines, trim the extra indentation from each line, and rejoin the lines
+	lines := strings.Split(processedContent, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimPrefix(lines[i], extraIndentation)
+	}
+
+	// Recover the processed content
+	processedContent = strings.Trim(strings.Join(lines, "\n"), "\n")
+
+	return processedContent
+}


### PR DESCRIPTION
## Summary

### Human Summary


Replace custom configuration flags with a `--config` flag that sources config. directives from a yaml file

```yaml
# Whether the server should sign all incoming requests with its own ring (for applications)
self_signing: true
# The name of the key that will be used to sign relays
signing_key: app1
# The host and port that the appgate server will listen on
listening_endpoint: http://localhost:42069
# tcp://<host>:<port> to a full pocket node for reading data and listening for on-chain events
query_node_url: tcp://127.0.0.1:36657
```


### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 22 Nov 23 07:15 UTC
This pull request introduces several changes across multiple files. Here is a summary:

- A new file named "yaml.go" was added in the "testutil/yaml" directory. This file contains a function called "NormalizeYAMLIndentation", which removes extra indentation and converts tab indentation to space indentation in YAML content. This utility function ensures correct parsing by handling indentation sensitivity in YAML.

- Another new file, "appgate_server_config.yaml", was added. It includes the following changes:
  - The server now signs all incoming requests with its own ring for applications.
  - The key name for signing relays is set to "app1".
  - The appgate server listens on `http://localhost:42069`.
  - The `query_node_url` is set to `tcp://127.0.0.1:36657`, which is the URL of a full pocket node.

- The file "errors.go" in the "pkg/appgateserver/config" package was also added. It defines several error variables related to the `AppGateServer` configuration, such as `ErrAppGateConfigUnmarshalYAML`, `ErrAppGateConfigEmptySigningKey`, `ErrAppGateConfigInvalidListeningEndpoint`, and `ErrAppGateConfigInvalidQueryNodeUrl`. These errors are registered using the `sdkerrors` package.

- The file "appgate_configs_reader.go" underwent changes, including:
  - Addition of a new file with package `config`.
  - Import statements for "net/url" and "gopkg.in/yaml.v2".
  - Definition of two structs, `YAMLAppGateServerConfig` and `AppGateServerConfig`, which handle unmarshaling and represent the AppGateServer configuration.
  - Addition of a function called `ParseAppGateServerConfigs`, which parses the stake config file into an `AppGateServerConfig`.
  - Error handling and validation for config settings such as `SigningKey`, `ListeningEndpoint`, and `QueryNodeUrl`.

- The file "appgate_configs_reader_test.go" was added in the "pkg/appgateserver/config" package. This file contains a test function named `Test_ParseAppGateConfigs`, which tests the `ParseAppGateServerConfigs` function. The test function covers valid and invalid configurations, ensuring correct parsing and error handling.

These changes introduce improvements to the AppGate server's configuration handling and overall functionality. Let me know if you have any specific questions or need further assistance.
<!-- reviewpad:summarize:end -->

## Issue

- #203 

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updated documentation and left TODOs throughout the codebase
