### PR TITLE
[RelayMiner] feat: Add relay miner config file handling

### DIFF
--- a/localnet/poktrolld/config/relayminer_config.yaml
+++ b/localnet/poktrolld/config/relayminer_config.yaml
@@ -1,8 +1,8 @@
 # tcp://<host>:<port> to a full pocket node for reading data and listening for on-chain events
 query_node_url: tcp://localhost:26657
-# tcp://<host>:<port> to a pocket node that gossips transactions throughout the network (may or may not be the sequencer
+# tcp://<host>:<port> to a pocket node that gossips transactions throughout the network (may or may not be the sequencer)
 network_node_url: tcp://127.0.0.1:36657
-# Name of the key to sign transactions
+# Name of the key (in the keyring) to sign transactions
 signing_key_name: servicer1
 # TODO_TECHDEBT(#137, #130): Once the `relayer.json` config file is implemented AND a local LLM RPC service
 # is supported on LocalNet, this needs to be expanded to include more than one service. The ability to support

--- a/localnet/poktrolld/config/relayminer_config.yaml
+++ b/localnet/poktrolld/config/relayminer_config.yaml
@@ -1,0 +1,14 @@
+# tcp://<host>:<port> to a full pocket node for reading data and listening for on-chain events
+query_node_url: tcp://localhost:26657
+# tcp://<host>:<port> to a pocket node that gossips transactions throughout the network (may or may not be the sequencer
+network_node_url: tcp://127.0.0.1:36657
+# Name of the key to sign transactions
+signing_key_name: servicer1
+# TODO_TECHDEBT(#137, #130): Once the `relayer.json` config file is implemented AND a local LLM RPC service
+# is supported on LocalNet, this needs to be expanded to include more than one service. The ability to support
+# multiple services is already in place but currently (as seen below) is hardcoded.
+# TODO_UPNEXT(@okdas): this hostname should be updated to match that of the in-tilt anvil service.
+proxied_service_endpoints:
+  anvil: http://anvil:8080
+# Path to where the data backing SMT KV store exists on disk
+smt_store_path: smt_stores

--- a/pkg/relayer/cmd/cmd.go
+++ b/pkg/relayer/cmd/cmd.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/url"
+	"os"
 
 	"cosmossdk.io/depinject"
 	cosmosclient "github.com/cosmos/cosmos-sdk/client"
@@ -17,6 +17,7 @@ import (
 	"github.com/pokt-network/poktroll/pkg/client/tx"
 	"github.com/pokt-network/poktroll/pkg/deps/config"
 	"github.com/pokt-network/poktroll/pkg/relayer"
+	relayerconfig "github.com/pokt-network/poktroll/pkg/relayer/config"
 	"github.com/pokt-network/poktroll/pkg/relayer/miner"
 	"github.com/pokt-network/poktroll/pkg/relayer/proxy"
 	"github.com/pokt-network/poktroll/pkg/relayer/session"
@@ -27,10 +28,7 @@ const omittedDefaultFlagValue = "explicitly omitting default"
 
 // TODO_CONSIDERATION: Consider moving all flags defined in `/pkg` to a `flags.go` file.
 var (
-	flagSigningKeyName string
-	flagSmtStorePath   string
-	flagNetworkNodeUrl string
-	flagQueryNodeUrl   string
+	flagRelayMinerConfig string
 )
 
 func RelayerCmd() *cobra.Command {
@@ -55,15 +53,6 @@ for such operations.`,
 	}
 
 	cmd.Flags().String(cosmosflags.FlagKeyringBackend, "", "Select keyring's backend (os|file|kwallet|pass|test)")
-
-	// TODO_TECHDEBT: integrate these flags with the client context (i.e. cosmosflags, config, viper, etc.)
-	// This is simpler to do with server-side configs (see rootCmd#PersistentPreRunE) and requires more effort than currently justifiable.
-	cmd.Flags().StringVar(&flagSigningKeyName, "signing-key", "", "Name of the key to sign transactions")
-	// TODO_TECHDEBT(#137): This, alongside other flags, should be part of a config file suppliers provide.
-	cmd.Flags().StringVar(&flagSmtStorePath, "smt-store", "smt", "Path to where the data backing SMT KV store exists on disk")
-	// Communication flags
-	cmd.Flags().StringVar(&flagNetworkNodeUrl, "network-node", omittedDefaultFlagValue, "tcp://<host>:<port> to a pocket node that gossips transactions throughout the network (may or may not be the sequencer")
-	cmd.Flags().StringVar(&flagQueryNodeUrl, "query-node", omittedDefaultFlagValue, "tcp://<host>:<port> to a full pocket node for reading data and listening for on-chain events")
 	cmd.Flags().String(cosmosflags.FlagNode, omittedDefaultFlagValue, "registering the default cosmos node flag; needed to initialize the cosmostx and query contexts correctly and uses flagQueryNodeUrl underneath")
 
 	return cmd
@@ -77,10 +66,20 @@ func runRelayer(cmd *cobra.Command, _ []string) error {
 	// Handle interrupt and kill signals asynchronously.
 	signals.GoOnExitSignal(cancelCtx)
 
+	configContent, err := os.ReadFile(flagRelayMinerConfig)
+	if err != nil {
+		return err
+	}
+
+	relayMinerConfig, err := relayerconfig.ParseRelayMinerConfigs(configContent)
+	if err != nil {
+		return err
+	}
+
 	// Sets up the following dependencies:
 	// Miner, EventsQueryClient, BlockClient, cosmosclient.Context, TxFactory,
 	// TxContext, TxClient, SupplierClient, RelayerProxy, RelayerSessionsManager.
-	deps, err := setupRelayerDependencies(ctx, cmd)
+	deps, err := setupRelayerDependencies(ctx, cmd, relayMinerConfig)
 	if err != nil {
 		return err
 	}
@@ -108,42 +107,30 @@ func runRelayer(cmd *cobra.Command, _ []string) error {
 func setupRelayerDependencies(
 	ctx context.Context,
 	cmd *cobra.Command,
+	relayMinerConfig *relayerconfig.RelayMinerConfig,
 ) (deps depinject.Config, err error) {
-	pocketNodeWebsocketUrl, err := getPocketNodeWebsocketUrl()
-	if err != nil {
-		return nil, err
-	}
+	pocketNodeWebsocketUrl := relayMinerConfig.PocketNodeWebsocketUrl
+	queryNodeUrl := relayMinerConfig.QueryNodeUrl.String()
+	networkNodeUrl := relayMinerConfig.NetworkNodeUrl.String()
+	signingKeyName := relayMinerConfig.SigningKeyName
+	proxiedServiceEndpoints := relayMinerConfig.ProxiedServiceEndpoints
+	smtStorePath := relayMinerConfig.SmtStorePath
 
 	supplierFuncs := []config.SupplierFn{
 		config.NewSupplyEventsQueryClientFn(pocketNodeWebsocketUrl), // leaf
 		config.NewSupplyBlockClientFn(pocketNodeWebsocketUrl),
-		supplyMiner,              // leaf
-		supplyQueryClientContext, // leaf
-		supplyTxClientContext,    // leaf
+		supplyMiner, // leaf
+		newSupplyQueryClientContextFn(queryNodeUrl), // leaf
+		newSupplyTxClientContextFn(networkNodeUrl),  // leaf
 		supplyTxFactory,
 		supplyTxContext,
-		supplyTxClient,
-		supplySupplierClient,
-		supplyRelayerProxy,
-		supplyRelayerSessionsManager,
+		newSupplyTxClientFn(signingKeyName),
+		newSupplySupplierClientFn(signingKeyName),
+		newSupplyRelayerProxyFn(signingKeyName, proxiedServiceEndpoints),
+		newSupplyRelayerSessionsManagerFn(smtStorePath),
 	}
 
 	return config.SupplyConfig(ctx, cmd, supplierFuncs)
-}
-
-// getPocketNodeWebsocketUrl returns the websocket URL of the Pocket Node to
-// connect to for subscribing to on-chain events.
-func getPocketNodeWebsocketUrl() (string, error) {
-	if flagQueryNodeUrl == omittedDefaultFlagValue {
-		return "", fmt.Errorf("--query-node flag is required")
-	}
-
-	pocketNodeURL, err := url.Parse(flagQueryNodeUrl)
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf("ws://%s/websocket", pocketNodeURL.Host), nil
 }
 
 // supplyMiner constructs a Miner instance and returns a new depinject.Config
@@ -161,66 +148,70 @@ func supplyMiner(
 	return depinject.Configs(deps, depinject.Supply(mnr)), nil
 }
 
-// supplyQueryClientContext returns a function with constructs a ClientContext
+// newSupplyQueryClientContextFn returns a function which constructs a ClientContext
 // instance with the given cmd and returns a new depinject.Config which is
 // supplied with the given deps and the new ClientContext.
-func supplyQueryClientContext(
-	_ context.Context,
-	deps depinject.Config,
-	cmd *cobra.Command,
-) (depinject.Config, error) {
-	// Set --node flag to the --query-node for the client context
-	// This flag is read by cosmosclient.GetClientQueryContext.
-	err := cmd.Flags().Set(cosmosflags.FlagNode, flagQueryNodeUrl)
-	if err != nil {
-		return nil, err
-	}
+func newSupplyQueryClientContextFn(queryNodeUrl string) config.SupplierFn {
+	return func(
+		_ context.Context,
+		deps depinject.Config,
+		cmd *cobra.Command,
+	) (depinject.Config, error) {
+		// Set --node flag to the relayerConfig.QueryNodeUrl config for the client context
+		// This flag is read by cosmosclient.GetClientQueryContext.
+		err := cmd.Flags().Set(cosmosflags.FlagNode, queryNodeUrl)
+		if err != nil {
+			return nil, err
+		}
 
-	// NB: Currently, the implementations of GetClientTxContext() and
-	// GetClientQueryContext() are identical, allowing for their interchangeable
-	// use in both querying and transaction operations. However, in order to support
-	// independent configuration of client contexts for distinct querying and
-	// transacting purposes. E.g.: transactions are dispatched to the sequencer
-	// while queries are handled by a trusted full-node.
-	queryClientCtx, err := cosmosclient.GetClientQueryContext(cmd)
-	if err != nil {
-		return nil, err
+		// NB: Currently, the implementations of GetClientTxContext() and
+		// GetClientQueryContext() are identical, allowing for their interchangeable
+		// use in both querying and transaction operations. However, in order to support
+		// independent configuration of client contexts for distinct querying and
+		// transacting purposes. E.g.: transactions are dispatched to the sequencer
+		// while queries are handled by a trusted full-node.
+		queryClientCtx, err := cosmosclient.GetClientQueryContext(cmd)
+		if err != nil {
+			return nil, err
+		}
+		deps = depinject.Configs(deps, depinject.Supply(
+			relayer.QueryClientContext(queryClientCtx),
+		))
+		return deps, nil
 	}
-	deps = depinject.Configs(deps, depinject.Supply(
-		relayer.QueryClientContext(queryClientCtx),
-	))
-	return deps, nil
 }
 
-// supplyTxClientContext constructs a cosmosclient.Context instance and returns a
-// new depinject.Config which is supplied with the given deps and the new
-// cosmosclient.Context.
-func supplyTxClientContext(
-	_ context.Context,
-	deps depinject.Config,
-	cmd *cobra.Command,
-) (depinject.Config, error) {
-	// Set --node flag to the --network-node for this client context.
-	// This flag is read by cosmosclient.GetClientTxContext.
-	err := cmd.Flags().Set(cosmosflags.FlagNode, flagNetworkNodeUrl)
-	if err != nil {
-		return nil, err
-	}
+// newSupplyTxClientContextFn returns a function which constructs a
+// cosmosclient.Context instance and returns a new depinject.Config
+// which is supplied with the given deps and the new cosmosclient.Context.
+func newSupplyTxClientContextFn(networkNodeUrl string) config.SupplierFn {
+	return func(
+		_ context.Context,
+		deps depinject.Config,
+		cmd *cobra.Command,
+	) (depinject.Config, error) {
+		// Set --node flag to relayerConfig.NetworkNodeUrl for this client context.
+		// This flag is read by cosmosclient.GetClientTxContext.
+		err := cmd.Flags().Set(cosmosflags.FlagNode, networkNodeUrl)
+		if err != nil {
+			return nil, err
+		}
 
-	// NB: Currently, the implementations of GetClientTxContext() and
-	// GetClientQueryContext() are identical, allowing for their interchangeable
-	// use in both querying and transaction operations. However, in order to support
-	// independent configuration of client contexts for distinct querying and
-	// transacting purposes. E.g.: transactions are dispatched to the sequencer
-	// while queries are handled by a trusted full-node.
-	txClientCtx, err := cosmosclient.GetClientTxContext(cmd)
-	if err != nil {
-		return nil, err
+		// NB: Currently, the implementations of GetClientTxContext() and
+		// GetClientQueryContext() are identical, allowing for their interchangeable
+		// use in both querying and transaction operations. However, in order to support
+		// independent configuration of client contexts for distinct querying and
+		// transacting purposes. E.g.: transactions are dispatched to the sequencer
+		// while queries are handled by a trusted full-node.
+		txClientCtx, err := cosmosclient.GetClientTxContext(cmd)
+		if err != nil {
+			return nil, err
+		}
+		deps = depinject.Configs(deps, depinject.Supply(
+			relayer.TxClientContext(txClientCtx),
+		))
+		return deps, nil
 	}
-	deps = depinject.Configs(deps, depinject.Supply(
-		relayer.TxClientContext(txClientCtx),
-	))
-	return deps, nil
 }
 
 // supplyTxFactory constructs a cosmostx.Factory instance and returns a new
@@ -258,97 +249,93 @@ func supplyTxContext(
 	return depinject.Configs(deps, depinject.Supply(txContext)), nil
 }
 
-// supplyTxClient constructs a TxClient instance and returns a new
-// depinject.Config which is supplied with the given deps and the new TxClient.
-func supplyTxClient(
-	ctx context.Context,
-	deps depinject.Config,
-	_ *cobra.Command,
-) (depinject.Config, error) {
-	txClient, err := tx.NewTxClient(
-		ctx,
-		deps,
-		tx.WithSigningKeyName(flagSigningKeyName),
-		// TODO_TECHDEBT: populate this from some config.
-		tx.WithCommitTimeoutBlocks(tx.DefaultCommitTimeoutHeightOffset),
-	)
-	if err != nil {
-		return nil, err
-	}
+// newSupplyTxClientFn returns a function which constructs a TxClient
+// instance and returns a new depinject.Config which is supplied with
+// the given deps and the new TxClient.
+func newSupplyTxClientFn(signingKeyName string) config.SupplierFn {
+	return func(
+		ctx context.Context,
+		deps depinject.Config,
+		_ *cobra.Command,
+	) (depinject.Config, error) {
+		txClient, err := tx.NewTxClient(
+			ctx,
+			deps,
+			tx.WithSigningKeyName(signingKeyName),
+			// TODO_TECHDEBT: populate this from some config.
+			tx.WithCommitTimeoutBlocks(tx.DefaultCommitTimeoutHeightOffset),
+		)
+		if err != nil {
+			return nil, err
+		}
 
-	return depinject.Configs(deps, depinject.Supply(txClient)), nil
+		return depinject.Configs(deps, depinject.Supply(txClient)), nil
+	}
 }
 
-// supplySupplierClient constructs a SupplierClient instance and returns a new
-// depinject.Config which is supplied with the given deps and the new
-// SupplierClient.
-func supplySupplierClient(
-	_ context.Context,
-	deps depinject.Config,
-	_ *cobra.Command,
-) (depinject.Config, error) {
-	supplierClient, err := supplier.NewSupplierClient(
-		deps,
-		supplier.WithSigningKeyName(flagSigningKeyName),
-	)
-	if err != nil {
-		return nil, err
-	}
+// newSupplySupplierClientFn returns a function which constructs a
+// SupplierClient instance and returns a new depinject.Config which is
+// supplied with the given deps and the new SupplierClient.
+func newSupplySupplierClientFn(signingKeyName string) config.SupplierFn {
+	return func(
+		_ context.Context,
+		deps depinject.Config,
+		_ *cobra.Command,
+	) (depinject.Config, error) {
+		supplierClient, err := supplier.NewSupplierClient(
+			deps,
+			supplier.WithSigningKeyName(signingKeyName),
+		)
+		if err != nil {
+			return nil, err
+		}
 
-	return depinject.Configs(deps, depinject.Supply(supplierClient)), nil
+		return depinject.Configs(deps, depinject.Supply(supplierClient)), nil
+	}
 }
 
-// supplyRelayerProxy constructs a RelayerProxy instance and returns a new
-// depinject.Config which is supplied with the given deps and the new
-// RelayerProxy.
-func supplyRelayerProxy(
-	_ context.Context,
-	deps depinject.Config,
-	_ *cobra.Command,
-) (depinject.Config, error) {
-	// TODO_BLOCKER:(#137, @red-0ne): This MUST be populated via the `relayer.json` config file
-	// TODO_UPNEXT(@okdas): this hostname should be updated to match that of the in-tilt anvil service.
-	proxyServiceURL, err := url.Parse("http://localhost:8547/")
-	if err != nil {
-		return nil, err
-	}
+// newSupplyRelayerProxyFn returns a function which constructs a
+// RelayerProxy instance and returns a new depinject.Config which
+// is supplied with the given deps and the new RelayerProxy.
+func newSupplyRelayerProxyFn(
+	signingKeyName string,
+	proxiedServiceEndpoints map[string]*url.URL,
+) config.SupplierFn {
+	return func(
+		_ context.Context,
+		deps depinject.Config,
+		_ *cobra.Command,
+	) (depinject.Config, error) {
+		relayerProxy, err := proxy.NewRelayerProxy(
+			deps,
+			proxy.WithSigningKeyName(signingKeyName),
+			proxy.WithProxiedServicesEndpoints(proxiedServiceEndpoints),
+		)
+		if err != nil {
+			return nil, err
+		}
 
-	// TODO_TECHDEBT(#137, #130): Once the `relayer.json` config file is implemented AND a local LLM RPC service
-	// is supported on LocalNet, this needs to be expanded to include more than one service. The ability to support
-	// multiple services is already in place but currently (as seen below) is hardcoded.
-	proxiedServiceEndpoints := map[string]url.URL{
-		"anvil": *proxyServiceURL,
+		return depinject.Configs(deps, depinject.Supply(relayerProxy)), nil
 	}
-
-	relayerProxy, err := proxy.NewRelayerProxy(
-		deps,
-		proxy.WithSigningKeyName(flagSigningKeyName),
-		proxy.WithProxiedServicesEndpoints(proxiedServiceEndpoints),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return depinject.Configs(deps, depinject.Supply(relayerProxy)), nil
 }
 
-// supplyRelayerSessionsManager constructs a RelayerSessionsManager instance
-// and returns a new depinject.Config which is supplied with the given deps and
-// the new RelayerSessionsManager.
-// See the comment next to `flagQueryNodeUrl` (if it still exists) on how/why
-// we have multiple flags pointing to different node types.
-func supplyRelayerSessionsManager(
-	ctx context.Context,
-	deps depinject.Config,
-	_ *cobra.Command,
-) (depinject.Config, error) {
-	relayerSessionsManager, err := session.NewRelayerSessions(
-		ctx, deps,
-		session.WithStoresDirectory(flagSmtStorePath),
-	)
-	if err != nil {
-		return nil, err
-	}
+// newSupplyRelayerSessionsManagerFn returns a function which constructs a
+// RelayerSessionsManager instance and returns a new depinject.Config which
+// is supplied with the given deps and the new RelayerSessionsManager.
+func newSupplyRelayerSessionsManagerFn(smtStorePath string) config.SupplierFn {
+	return func(
+		ctx context.Context,
+		deps depinject.Config,
+		_ *cobra.Command,
+	) (depinject.Config, error) {
+		relayerSessionsManager, err := session.NewRelayerSessions(
+			ctx, deps,
+			session.WithStoresDirectory(smtStorePath),
+		)
+		if err != nil {
+			return nil, err
+		}
 
-	return depinject.Configs(deps, depinject.Supply(relayerSessionsManager)), nil
+		return depinject.Configs(deps, depinject.Supply(relayerSessionsManager)), nil
+	}
 }

--- a/pkg/relayer/config/errors.go
+++ b/pkg/relayer/config/errors.go
@@ -5,9 +5,9 @@ import sdkerrors "cosmossdk.io/errors"
 var (
 	codespace                                 = "relayminer_config"
 	ErrRelayMinerConfigUnmarshalYAML          = sdkerrors.Register(codespace, 1, "config reader cannot unmarshal yaml content")
-	ErrRelayMinerConfigInvalidQueryNodeUrl    = sdkerrors.Register(codespace, 2, "invalid query node url in relay miner config")
-	ErrRelayMinerConfigInvalidNetworkNodeUrl  = sdkerrors.Register(codespace, 3, "invalid network node url in relay miner config")
-	ErrRelayMinerConfigInvalidServiceEndpoint = sdkerrors.Register(codespace, 4, "invalid service endpoint in relay miner config")
-	ErrRelayMinerConfigInvalidSigningKeyName  = sdkerrors.Register(codespace, 5, "invalid signing key name in relay miner config")
-	ErrRelayMinerConfigInvalidSmtStorePath    = sdkerrors.Register(codespace, 6, "invalid smt store path in relay miner config")
+	ErrRelayMinerConfigInvalidQueryNodeUrl    = sdkerrors.Register(codespace, 2, "invalid query node url in RelayMiner config")
+	ErrRelayMinerConfigInvalidNetworkNodeUrl  = sdkerrors.Register(codespace, 3, "invalid network node url in RelayMiner config")
+	ErrRelayMinerConfigInvalidServiceEndpoint = sdkerrors.Register(codespace, 4, "invalid service endpoint in RelayMiner config")
+	ErrRelayMinerConfigInvalidSigningKeyName  = sdkerrors.Register(codespace, 5, "invalid signing key name in RelayMiner config")
+	ErrRelayMinerConfigInvalidSmtStorePath    = sdkerrors.Register(codespace, 6, "invalid smt store path in RelayMiner config")
 )

--- a/pkg/relayer/config/errors.go
+++ b/pkg/relayer/config/errors.go
@@ -1,0 +1,13 @@
+package config
+
+import sdkerrors "cosmossdk.io/errors"
+
+var (
+	codespace                                 = "relayminer_config"
+	ErrRelayMinerConfigUnmarshalYAML          = sdkerrors.Register(codespace, 1, "config reader cannot unmarshal yaml content")
+	ErrRelayMinerConfigInvalidQueryNodeUrl    = sdkerrors.Register(codespace, 2, "invalid query node url in relay miner config")
+	ErrRelayMinerConfigInvalidNetworkNodeUrl  = sdkerrors.Register(codespace, 3, "invalid network node url in relay miner config")
+	ErrRelayMinerConfigInvalidServiceEndpoint = sdkerrors.Register(codespace, 4, "invalid service endpoint in relay miner config")
+	ErrRelayMinerConfigInvalidSigningKeyName  = sdkerrors.Register(codespace, 5, "invalid signing key name in relay miner config")
+	ErrRelayMinerConfigInvalidSmtStorePath    = sdkerrors.Register(codespace, 6, "invalid smt store path in relay miner config")
+)

--- a/pkg/relayer/config/relayminer_configs_reader.go
+++ b/pkg/relayer/config/relayminer_configs_reader.go
@@ -8,6 +8,7 @@ import (
 )
 
 // YAMLRelayMinerConfig is the structure used to unmarshal the RelayMiner config file
+// TODO_DOCUMENT(@red-0ne): Add proper README documentation for yaml config files.
 type YAMLRelayMinerConfig struct {
 	QueryNodeUrl            string            `yaml:"query_node_url"`
 	NetworkNodeUrl          string            `yaml:"network_node_url"`

--- a/pkg/relayer/config/relayminer_configs_reader.go
+++ b/pkg/relayer/config/relayminer_configs_reader.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+
+	"gopkg.in/yaml.v2"
+)
+
+// YAMLRelayMinerConfig is the structure used to unmarshal the RelayMiner config file
+type YAMLRelayMinerConfig struct {
+	QueryNodeUrl            string            `yaml:"query_node_url"`
+	NetworkNodeUrl          string            `yaml:"network_node_url"`
+	PocketNodeWebsocketUrl  string            `yaml:"pocket_node_websocket_url"`
+	SigningKeyName          string            `yaml:"signing_key_name"`
+	ProxiedServiceEndpoints map[string]string `yaml:"proxied_service_endpoints"`
+	SmtStorePath            string            `yaml:"smt_store_path"`
+}
+
+// RelayMinerConfig is the structure describing the RelayMiner config
+type RelayMinerConfig struct {
+	QueryNodeUrl            *url.URL
+	NetworkNodeUrl          *url.URL
+	PocketNodeWebsocketUrl  string
+	SigningKeyName          string
+	ProxiedServiceEndpoints map[string]*url.URL
+	SmtStorePath            string
+}
+
+// ParseRelayMinerConfigs parses the relay miner config file into a RelayMinerConfig
+func ParseRelayMinerConfigs(configContent []byte) (*RelayMinerConfig, error) {
+	var yamlRelayMinerConfig YAMLRelayMinerConfig
+
+	// Unmarshal the stake config file into a yamlAppGateConfig
+	if err := yaml.Unmarshal(configContent, &yamlRelayMinerConfig); err != nil {
+		return nil, ErrRelayMinerConfigUnmarshalYAML.Wrapf("%s", err)
+	}
+
+	// Check that the query node URL is provided
+	if yamlRelayMinerConfig.QueryNodeUrl == "" {
+		return nil, ErrRelayMinerConfigInvalidQueryNodeUrl.Wrapf("query node url is required")
+	}
+
+	// Parse the query node URL
+	queryNodeUrl, err := url.Parse(yamlRelayMinerConfig.QueryNodeUrl)
+	if err != nil {
+		return nil, ErrRelayMinerConfigInvalidQueryNodeUrl.Wrapf("%s", err)
+	}
+
+	// Check that the network node URL is provided
+	if yamlRelayMinerConfig.NetworkNodeUrl == "" {
+		return nil, ErrRelayMinerConfigInvalidNetworkNodeUrl.Wrapf("network node url is required")
+	}
+
+	// Parse the network node URL
+	networkNodeUrl, err := url.Parse(yamlRelayMinerConfig.NetworkNodeUrl)
+	if err != nil {
+		return nil, ErrRelayMinerConfigInvalidNetworkNodeUrl.Wrapf("%s", err)
+	}
+
+	// Parse the websocket URL of the Pocket Node to connect to for subscribing to on-chain events.
+	pocketNodeWebsocketUrl := fmt.Sprintf("ws://%s/websocket", queryNodeUrl.Host)
+
+	if yamlRelayMinerConfig.SigningKeyName == "" {
+		return nil, ErrRelayMinerConfigInvalidSigningKeyName
+	}
+
+	if yamlRelayMinerConfig.SmtStorePath == "" {
+		return nil, ErrRelayMinerConfigInvalidSmtStorePath
+	}
+
+	if yamlRelayMinerConfig.ProxiedServiceEndpoints == nil {
+		return nil, ErrRelayMinerConfigInvalidServiceEndpoint.Wrapf("proxied service endpoints are required")
+	}
+
+	if len(yamlRelayMinerConfig.ProxiedServiceEndpoints) == 0 {
+		return nil, ErrRelayMinerConfigInvalidServiceEndpoint.Wrapf("no proxied service endpoints provided")
+	}
+
+	// Parse the proxied service endpoints
+	proxiedServiceEndpoints := make(map[string]*url.URL, len(yamlRelayMinerConfig.ProxiedServiceEndpoints))
+	for serviceId, endpointUrl := range yamlRelayMinerConfig.ProxiedServiceEndpoints {
+		endpoint, err := url.Parse(endpointUrl)
+		if err != nil {
+			return nil, ErrRelayMinerConfigInvalidServiceEndpoint.Wrapf("%s", err)
+		}
+		proxiedServiceEndpoints[serviceId] = endpoint
+	}
+
+	relayMinerCMDConfig := &RelayMinerConfig{
+		QueryNodeUrl:            queryNodeUrl,
+		NetworkNodeUrl:          networkNodeUrl,
+		PocketNodeWebsocketUrl:  pocketNodeWebsocketUrl,
+		SigningKeyName:          yamlRelayMinerConfig.SigningKeyName,
+		ProxiedServiceEndpoints: proxiedServiceEndpoints,
+		SmtStorePath:            yamlRelayMinerConfig.SmtStorePath,
+	}
+
+	return relayMinerCMDConfig, nil
+}

--- a/pkg/relayer/config/relayminer_configs_reader_test.go
+++ b/pkg/relayer/config/relayminer_configs_reader_test.go
@@ -1,0 +1,190 @@
+package config_test
+
+import (
+	"net/url"
+	"testing"
+
+	sdkerrors "cosmossdk.io/errors"
+	"github.com/gogo/status"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/poktroll/pkg/relayer/config"
+	"github.com/pokt-network/poktroll/testutil/yaml"
+)
+
+func Test_ParseAppGateConfigs(t *testing.T) {
+	tests := []struct {
+		desc     string
+		err      *sdkerrors.Error
+		expected *config.RelayMinerConfig
+		config   string
+	}{
+		// Valid Configs
+		{
+			desc: "relayminer_config_test: valid relay miner config",
+			err:  nil,
+			expected: &config.RelayMinerConfig{
+				QueryNodeUrl:   &url.URL{Scheme: "tcp", Host: "localhost:26657"},
+				NetworkNodeUrl: &url.URL{Scheme: "tcp", Host: "127.0.0.1:36657"},
+				SigningKeyName: "servicer1",
+				ProxiedServiceEndpoints: map[string]*url.URL{
+					"anvil": {Scheme: "http", Host: "anvil:8080"},
+					"svc1":  {Scheme: "http", Host: "svc1:8080"},
+				},
+				SmtStorePath: "smt_stores",
+			},
+			config: `
+				query_node_url: tcp://localhost:26657
+				network_node_url: tcp://127.0.0.1:36657
+				signing_key_name: servicer1
+				proxied_service_endpoints:
+				  anvil: http://anvil:8080
+				  svc1: http://svc1:8080
+				smt_store_path: smt_stores
+				`,
+		},
+		// Invalid Configs
+		{
+			desc: "relayminer_config_test: invalid network node url",
+			err:  config.ErrRelayMinerConfigInvalidNetworkNodeUrl,
+			config: `
+				query_node_url: tcp://localhost:26657
+				network_node_url: &tcp://127.0.0.1:36657
+				signing_key_name: servicer1
+				proxied_service_endpoints:
+				  anvil: http://anvil:8080
+				  svc1: http://svc1:8080
+				smt_store_path: smt_stores
+				`,
+		},
+		{
+			desc: "relayminer_config_test: missing network node url",
+			err:  config.ErrRelayMinerConfigInvalidNetworkNodeUrl,
+			config: `
+				query_node_url: tcp://localhost:26657
+				signing_key_name: servicer1
+				proxied_service_endpoints:
+				  anvil: http://anvil:8080
+				  svc1: http://svc1:8080
+				smt_store_path: smt_stores
+				`,
+		},
+		{
+			desc: "relayminer_config_test: invalid query node url",
+			err:  config.ErrRelayMinerConfigInvalidNetworkNodeUrl,
+			config: `
+				query_node_url: &tcp://localhost:26657
+				network_node_url: tcp://127.0.0.1:36657
+				signing_key_name: servicer1
+				proxied_service_endpoints:
+				  anvil: http://anvil:8080
+				  svc1: http://svc1:8080
+				smt_store_path: smt_stores
+				`,
+		},
+		{
+			desc: "relayminer_config_test: missing query node url",
+			err:  config.ErrRelayMinerConfigInvalidNetworkNodeUrl,
+			config: `
+				network_node_url: tcp://127.0.0.1:36657
+				signing_key_name: servicer1
+				proxied_service_endpoints:
+				  anvil: http://anvil:8080
+				  svc1: http://svc1:8080
+				smt_store_path: smt_stores
+				`,
+		},
+		{
+			desc: "relayminer_config_test: missing signing key name",
+			err:  config.ErrRelayMinerConfigInvalidNetworkNodeUrl,
+			config: `
+				query_node_url: tcp://localhost:26657
+				network_node_url: &tcp://127.0.0.1:36657
+				signing_key_name:
+				proxied_service_endpoints:
+				  anvil: http://anvil:8080
+				  svc1: http://svc1:8080
+				smt_store_path: smt_stores
+				`,
+		},
+		{
+			desc: "relayminer_config_test: missing smt store path",
+			err:  config.ErrRelayMinerConfigInvalidNetworkNodeUrl,
+			config: `
+				query_node_url: tcp://localhost:26657
+				network_node_url: &tcp://127.0.0.1:36657
+				signing_key_name: servicer1
+				proxied_service_endpoints:
+				  anvil: http://anvil:8080
+				  svc1: http://svc1:8080
+				`,
+		},
+		{
+			desc: "relayminer_config_test: empty proxied service endpoints",
+			err:  config.ErrRelayMinerConfigInvalidNetworkNodeUrl,
+			config: `
+				query_node_url: tcp://localhost:26657
+				network_node_url: &tcp://127.0.0.1:36657
+				signing_key_name: servicer1
+				proxied_service_endpoints:
+				smt_store_path: smt_stores
+				`,
+		},
+		{
+			desc: "relayminer_config_test: invalid proxied service endpoint",
+			err:  config.ErrRelayMinerConfigInvalidNetworkNodeUrl,
+			config: `
+				query_node_url: tcp://localhost:26657
+				network_node_url: &tcp://127.0.0.1:36657
+				signing_key_name: servicer1
+				proxied_service_endpoints:
+				  anvil: &http://anvil:8080
+				  svc1: http://svc1:8080
+				smt_store_path: smt_stores
+				`,
+		},
+		{
+			desc: "relayminer_config_test: invalid network node url",
+			err:  config.ErrRelayMinerConfigUnmarshalYAML,
+			config: `
+				query_node_url: tcp://localhost:26657
+				network_node_url: &tcp://127.0.0.1:36657
+				signing_key_name: servicer1
+				smt_store_path: smt_stores
+				`,
+		},
+		{
+			desc:   "relayminer_config_test: invalid relay miner config file",
+			err:    config.ErrRelayMinerConfigUnmarshalYAML,
+			config: ``,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			normalizedConfig := yaml.NormalizeYAMLIndentation(tt.config)
+			config, err := config.ParseRelayMinerConfigs([]byte(normalizedConfig))
+
+			if tt.err != nil {
+				require.Error(t, err)
+				require.Nil(t, config)
+				stat, ok := status.FromError(tt.err)
+				require.True(t, ok)
+				require.Contains(t, stat.Message(), tt.err.Error())
+				require.Nil(t, config)
+				return
+			}
+
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expected.QueryNodeUrl.String(), config.QueryNodeUrl.String())
+			require.Equal(t, tt.expected.NetworkNodeUrl.String(), config.NetworkNodeUrl.String())
+			require.Equal(t, tt.expected.SigningKeyName, config.SigningKeyName)
+			require.Equal(t, tt.expected.SmtStorePath, config.SmtStorePath)
+			require.Equal(t, len(tt.expected.ProxiedServiceEndpoints), len(config.ProxiedServiceEndpoints))
+			for serviceId, endpoint := range tt.expected.ProxiedServiceEndpoints {
+				require.Equal(t, endpoint.String(), config.ProxiedServiceEndpoints[serviceId].String())
+			}
+		})
+	}
+}

--- a/pkg/relayer/proxy/jsonrpc.go
+++ b/pkg/relayer/proxy/jsonrpc.go
@@ -40,7 +40,7 @@ type jsonRPCServer struct {
 func NewJSONRPCServer(
 	service *sharedtypes.Service,
 	supplierEndpointHost string,
-	proxiedServiceEndpoint url.URL,
+	proxiedServiceEndpoint *url.URL,
 	servedRelaysProducer chan<- *types.Relay,
 	proxy relayer.RelayerProxy,
 ) relayer.RelayServer {
@@ -48,7 +48,7 @@ func NewJSONRPCServer(
 		service:                service,
 		server:                 &http.Server{Addr: supplierEndpointHost},
 		relayerProxy:           proxy,
-		proxiedServiceEndpoint: proxiedServiceEndpoint,
+		proxiedServiceEndpoint: *proxiedServiceEndpoint,
 		servedRelaysProducer:   servedRelaysProducer,
 	}
 }

--- a/pkg/relayer/proxy/proxy.go
+++ b/pkg/relayer/proxy/proxy.go
@@ -26,7 +26,7 @@ var _ relayer.RelayerProxy = (*relayerProxy)(nil)
 type (
 	serviceId            = string
 	relayServersMap      = map[serviceId][]relayer.RelayServer
-	servicesEndpointsMap = map[serviceId]url.URL
+	servicesEndpointsMap = map[serviceId]*url.URL
 )
 
 // relayerProxy is the main relayer proxy that takes relay requests of supported services from the client

--- a/testutil/yaml/yaml.go
+++ b/testutil/yaml/yaml.go
@@ -1,0 +1,31 @@
+package yaml
+
+import "strings"
+
+// YAML is indentation sensitive, so we need to remove the extra indentation from the test cases and make sure
+// it is space-indented instead of tab-indented, otherwise the YAML parser will fail
+func NormalizeYAMLIndentation(rawContent string) string {
+	var processedContent = rawContent
+	// Remove extra newlines
+	processedContent = strings.TrimPrefix(processedContent, "\n")
+
+	// Replace tab indentation with 2 spaces as our code is tab-indented but YAML is expecting double spaces
+	processedContent = strings.ReplaceAll(processedContent, "\t", "  ")
+
+	// Get the extra indentation from the first line that will serve as the basis for the rest of the lines
+	extraIndentationCount := len(processedContent) - len(strings.TrimLeft(processedContent, " "))
+
+	// Create a prefix to trim from the beginning of each line
+	extraIndentation := strings.Repeat(" ", extraIndentationCount)
+
+	// Split the content into lines, trim the extra indentation from each line, and rejoin the lines
+	lines := strings.Split(processedContent, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimPrefix(lines[i], extraIndentation)
+	}
+
+	// Recover the processed content
+	processedContent = strings.Trim(strings.Join(lines, "\n"), "\n")
+
+	return processedContent
+}


### PR DESCRIPTION
## Summary

### Human Summary

Source the RelayMiner configuration from a yaml config file instead of flags

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 22 Nov 23 08:52 UTC
This pull request introduces several changes across multiple files. 

In the file `proxy.go`, the type `servicesEndpointsMap` has been changed from `map[serviceId]url.URL` to `map[serviceId]*url.URL`. This means that the values in the map are now pointers to `url.URL` instead of the actual `url.URL` objects.

A new file named "errors.go" has been added to the "config" package. It defines error variables related to the RelayMiner configuration, covering cases such as unmarshaling YAML content, invalid URLs, and invalid configuration parameters.

The file `relayminer_config.yaml` has been added, containing various changes:
- `query_node_url` parameter has been added to specify the URL of a full pocket node for reading data and listening for on-chain events.
- `network_node_url` parameter has been added to specify the URL of a pocket node that gossips transactions throughout the network.
- `signing_key_name` parameter has been added to specify the name of the key in the keyring used for signing transactions.
- `proxied_service_endpoints` parameter has been added to specify the endpoints of the services that the relay miner proxies.
- `smt_store_path` parameter has been added to specify the path to the data backing SMT KV store on disk.

A new file called `yaml.go` has been added to the `testutil/yaml` directory. It defines a function `NormalizeYAMLIndentation` that normalizes the indentation of YAML content before parsing it, ensuring consistent indentation regardless of the original style.

The `jsonrpc.go` file in the `pkg/relayer/proxy` directory has been modified. It introduces a type `jsonRPCServer`, a function `NewJSONRPCServer`, and related modifications for implementing the `relayer.RelayServer` interface.

A new unit test file named `relayminer_configs_reader_test.go` has been added to the `pkg/relayer/config` package. It contains a comprehensive test suite for the `ParseRelayMinerConfigs` function, covering various scenarios and ensuring correct parsing and validation of RelayMiner configurations.

Lastly, the implementation for parsing and unmarshaling a RelayMiner configuration file has been added. It introduces structures `YAMLRelayMinerConfig` and `RelayMinerConfig` to represent the configuration in different formats and provides the `ParseRelayMinerConfigs` function for parsing and validating the configuration.

These changes collectively enhance the functionality and maintainability of the codebase for the RelayMiner project.
<!-- reviewpad:summarize:end -->

## Issue

- #205 

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updated documentation and left TODOs throughout the codebase
