### PR TITLE
[Miner, Testing] chore: omitted improvments to #191

### DIFF
--- a/pkg/observable/channel/collect.go
+++ b/pkg/observable/channel/collect.go
@@ -16,6 +16,7 @@ func Collect[V any](
 	srcObservable observable.Observable[V],
 ) (dstCollection []V) {
 	var dstCollectionMu sync.Mutex
+	// Defer unlocking as lock is acquired immediately before returning.
 	defer dstCollectionMu.Unlock()
 
 	ForEach(ctx, srcObservable, func(ctx context.Context, src V) {
@@ -27,6 +28,7 @@ func Collect[V any](
 	// Wait for context to be done before returning.
 	<-ctx.Done()
 
+	// Lock to read from dstCollection in return.
 	dstCollectionMu.Lock()
 	return dstCollection
 }

--- a/pkg/relayer/miner/gen/template.go
+++ b/pkg/relayer/miner/gen/template.go
@@ -24,7 +24,7 @@ var (
 
 	// marshaledUnminableRelaysHex are the hex encoded strings of serialized
 	// relayer.MinedRelays which have been pre-mined to **exclude** relays with
-	// difficulty 2 (or greater). Like marshaledMinableRelaysHex, this is done
+	// difficulty {{.difficultyBitsThreshold}} (or greater). Like marshaledMinableRelaysHex, this is done
 	// by populating the signature with random bytes. It is intended for use in
 	// tests.
 	marshaledUnminableRelaysHex = []string{

--- a/pkg/relayer/miner/relay_fixtures_test.go
+++ b/pkg/relayer/miner/relay_fixtures_test.go
@@ -20,7 +20,7 @@ var (
 
 	// marshaledUnminableRelaysHex are the hex encoded strings of serialized
 	// relayer.MinedRelays which have been pre-mined to **exclude** relays with
-	// difficulty 2 (or greater). Like marshaledMinableRelaysHex, this is done
+	// difficulty 16 (or greater). Like marshaledMinableRelaysHex, this is done
 	// by populating the signature with random bytes. It is intended for use in
 	// tests.
 	marshaledUnminableRelaysHex = []string{


### PR DESCRIPTION
## Summary

### Human Summary

Commit mistakenly omitted changes from #191.

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 22 Nov 23 21:24 UTC
This pull request includes some chore improvements to #191. It adds some code to handle locking and unlocking of a mutex in the `Collect` function in `pkg/observable/channel/collect.go` file. It also updates a comment in the `template.go` file in the `pkg/relayer/miner/gen` package to reflect changes in the difficulty threshold. 
<!-- reviewpad:summarize:end -->

## Issue

<!-- DELETE THIS COMMENT BLOCK
     Specify the ticket number below if there is a relevant issue. Keep the `-` so the full issue is referenced.
-->

- #126 
- #191

I walked away from an ssh key passphrase prompt, mistakenly thinking that my `git push ...`  worked.

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
