### PR TITLE
[RingCache] Add `EventDelegateeChange` event emission and cache invalidation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/athanorlabs/go-dleq v0.1.0
 	github.com/cometbft/cometbft v0.37.2
 	github.com/cometbft/cometbft-db v0.8.0
+	github.com/cosmos/cosmos-proto v1.0.0-beta.2
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/cosmos/gogoproto v1.4.10
 	github.com/cosmos/ibc-go/v7 v7.1.0
@@ -30,6 +31,7 @@ require (
 	go.uber.org/multierr v1.11.0
 	golang.org/x/crypto v0.12.0
 	golang.org/x/sync v0.3.0
+	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	google.golang.org/grpc v1.56.1
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -73,7 +75,6 @@ require (
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
-	github.com/cosmos/cosmos-proto v1.0.0-beta.2 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/iavl v0.20.0 // indirect
@@ -269,7 +270,6 @@ require (
 	gonum.org/v1/gonum v0.11.0 // indirect
 	google.golang.org/api v0.122.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/proto/pocket/application/event.proto
+++ b/proto/pocket/application/event.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package pocket.application;
+
+option go_package = "github.com/pokt-network/poktroll/x/application/types";
+
+import "cosmos_proto/cosmos.proto";
+
+// EventDelegateeChange is an event emitted whenever an application changes its
+// delegatee gateways on chain. This is in response to both a DelegateToGateway
+// and UndelegateFromGateway message.
+message EventDelegateeChange {
+  string app_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"]; // The Bech32 address of the application using cosmos' ScalarDescriptor to ensure deterministic encoding
+}

--- a/x/application/keeper/msg_server_delegate_to_gateway.go
+++ b/x/application/keeper/msg_server_delegate_to_gateway.go
@@ -3,10 +3,10 @@ package keeper
 import (
 	"context"
 
-	"github.com/pokt-network/poktroll/x/application/types"
-
 	sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/pokt-network/poktroll/x/application/types"
 )
 
 func (k msgServer) DelegateToGateway(goCtx context.Context, msg *types.MsgDelegateToGateway) (*types.MsgDelegateToGatewayResponse, error) {
@@ -56,6 +56,9 @@ func (k msgServer) DelegateToGateway(goCtx context.Context, msg *types.MsgDelega
 	// Update the application store with the new delegation
 	k.SetApplication(ctx, app)
 	logger.Info("Successfully delegated application to gateway for app: %+v", app)
+
+	// Emit the application delegation change event
+	ctx.EventManager().EmitTypedEvent(msg.NewDelegateeChangeEvent())
 
 	return &types.MsgDelegateToGatewayResponse{}, nil
 }

--- a/x/application/keeper/msg_server_delegate_to_gateway_test.go
+++ b/x/application/keeper/msg_server_delegate_to_gateway_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"fmt"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -56,6 +57,11 @@ func TestMsgServer_DelegateToGateway_SuccessfullyDelegate(t *testing.T) {
 	// Delegate the application to the gateway
 	_, err = srv.DelegateToGateway(wctx, delegateMsg)
 	require.NoError(t, err)
+	events := ctx.EventManager().Events()
+	require.Equal(t, 1, len(events))
+	require.Equal(t, "pocket.application.EventDelegateeChange", events[0].Type)
+	require.Equal(t, "app_address", events[0].Attributes[0].Key)
+	require.Equal(t, fmt.Sprintf("\"%s\"", appAddr), events[0].Attributes[0].Value)
 
 	// Verify that the application exists
 	foundApp, isAppFound := k.GetApplication(ctx, appAddr)
@@ -73,6 +79,11 @@ func TestMsgServer_DelegateToGateway_SuccessfullyDelegate(t *testing.T) {
 	// Delegate the application to the second gateway
 	_, err = srv.DelegateToGateway(wctx, delegateMsg2)
 	require.NoError(t, err)
+	events = ctx.EventManager().Events()
+	require.Equal(t, 2, len(events))
+	require.Equal(t, "pocket.application.EventDelegateeChange", events[1].Type)
+	require.Equal(t, "app_address", events[1].Attributes[0].Key)
+	require.Equal(t, fmt.Sprintf("\"%s\"", appAddr), events[1].Attributes[0].Value)
 	foundApp, isAppFound = k.GetApplication(ctx, appAddr)
 	require.True(t, isAppFound)
 	require.Equal(t, 2, len(foundApp.DelegateeGatewayAddresses))
@@ -120,6 +131,11 @@ func TestMsgServer_DelegateToGateway_FailDuplicate(t *testing.T) {
 	// Delegate the application to the gateway
 	_, err = srv.DelegateToGateway(wctx, delegateMsg)
 	require.NoError(t, err)
+	events := ctx.EventManager().Events()
+	require.Equal(t, 1, len(events))
+	require.Equal(t, "pocket.application.EventDelegateeChange", events[0].Type)
+	require.Equal(t, "app_address", events[0].Attributes[0].Key)
+	require.Equal(t, fmt.Sprintf("\"%s\"", appAddr), events[0].Attributes[0].Value)
 
 	// Verify that the application exists
 	foundApp, isAppFound := k.GetApplication(ctx, appAddr)
@@ -137,6 +153,8 @@ func TestMsgServer_DelegateToGateway_FailDuplicate(t *testing.T) {
 	// Attempt to delegate the application to the gateway again
 	_, err = srv.DelegateToGateway(wctx, delegateMsg2)
 	require.ErrorIs(t, err, types.ErrAppAlreadyDelegated)
+	events = ctx.EventManager().Events()
+	require.Equal(t, 1, len(events))
 	foundApp, isAppFound = k.GetApplication(ctx, appAddr)
 	require.True(t, isAppFound)
 	require.Equal(t, 1, len(foundApp.DelegateeGatewayAddresses))
@@ -242,10 +260,19 @@ func TestMsgServer_DelegateToGateway_FailMaxReached(t *testing.T) {
 		require.True(t, isAppFound)
 		require.Equal(t, int(i+1), len(foundApp.DelegateeGatewayAddresses))
 	}
+	events := ctx.EventManager().Events()
+	require.Equal(t, int(maxDelegatedParam), len(events))
+	for _, event := range events {
+		require.Equal(t, "pocket.application.EventDelegateeChange", event.Type)
+		require.Equal(t, "app_address", event.Attributes[0].Key)
+		require.Equal(t, fmt.Sprintf("\"%s\"", appAddr), event.Attributes[0].Value)
+	}
 
 	// Attempt to delegate the application when the max is already reached
 	_, err = srv.DelegateToGateway(wctx, delegateMsg)
 	require.ErrorIs(t, err, types.ErrAppMaxDelegatedGateways)
+	events = ctx.EventManager().Events()
+	require.Equal(t, int(maxDelegatedParam), len(events))
 	foundApp, isAppFound := k.GetApplication(ctx, appAddr)
 	require.True(t, isAppFound)
 	require.Equal(t, maxDelegatedParam, int64(len(foundApp.DelegateeGatewayAddresses)))

--- a/x/application/keeper/msg_server_delegate_to_gateway_test.go
+++ b/x/application/keeper/msg_server_delegate_to_gateway_test.go
@@ -24,12 +24,8 @@ func TestMsgServer_DelegateToGateway_SuccessfullyDelegate(t *testing.T) {
 	gatewayAddr1 := sample.AccAddress()
 	gatewayAddr2 := sample.AccAddress()
 	// Mock the gateway being staked via the staked gateway map
-	keepertest.StakedGatewayMap[gatewayAddr1] = struct{}{}
-	keepertest.StakedGatewayMap[gatewayAddr2] = struct{}{}
-	t.Cleanup(func() {
-		delete(keepertest.StakedGatewayMap, gatewayAddr1)
-		delete(keepertest.StakedGatewayMap, gatewayAddr2)
-	})
+	keepertest.AddGatewayToStakedGatewayMap(t, gatewayAddr1)
+	keepertest.AddGatewayToStakedGatewayMap(t, gatewayAddr2)
 
 	// Prepare the application
 	stakeMsg := &types.MsgStakeApplication{
@@ -100,10 +96,7 @@ func TestMsgServer_DelegateToGateway_FailDuplicate(t *testing.T) {
 	appAddr := sample.AccAddress()
 	gatewayAddr := sample.AccAddress()
 	// Mock the gateway being staked via the staked gateway map
-	keepertest.StakedGatewayMap[gatewayAddr] = struct{}{}
-	t.Cleanup(func() {
-		delete(keepertest.StakedGatewayMap, gatewayAddr)
-	})
+	keepertest.AddGatewayToStakedGatewayMap(t, gatewayAddr)
 
 	// Prepare the application
 	stakeMsg := &types.MsgStakeApplication{
@@ -210,10 +203,7 @@ func TestMsgServer_DelegateToGateway_FailMaxReached(t *testing.T) {
 	appAddr := sample.AccAddress()
 	gatewayAddr := sample.AccAddress()
 	// Mock the gateway being staked via the staked gateway map
-	keepertest.StakedGatewayMap[gatewayAddr] = struct{}{}
-	t.Cleanup(func() {
-		delete(keepertest.StakedGatewayMap, gatewayAddr)
-	})
+	keepertest.AddGatewayToStakedGatewayMap(t, gatewayAddr)
 
 	// Prepare the application
 	stakeMsg := &types.MsgStakeApplication{
@@ -244,10 +234,7 @@ func TestMsgServer_DelegateToGateway_FailMaxReached(t *testing.T) {
 		// Prepare the delegation message
 		gatewayAddr := sample.AccAddress()
 		// Mock the gateway being staked via the staked gateway map
-		keepertest.StakedGatewayMap[gatewayAddr] = struct{}{}
-		t.Cleanup(func() {
-			delete(keepertest.StakedGatewayMap, gatewayAddr)
-		})
+		keepertest.AddGatewayToStakedGatewayMap(t, gatewayAddr)
 		delegateMsg := &types.MsgDelegateToGateway{
 			AppAddress:     appAddr,
 			GatewayAddress: gatewayAddr,

--- a/x/application/keeper/msg_server_undelegate_from_gateway.go
+++ b/x/application/keeper/msg_server_undelegate_from_gateway.go
@@ -9,7 +9,10 @@ import (
 	"github.com/pokt-network/poktroll/x/application/types"
 )
 
-func (k msgServer) UndelegateFromGateway(goCtx context.Context, msg *types.MsgUndelegateFromGateway) (*types.MsgUndelegateFromGatewayResponse, error) {
+func (k msgServer) UndelegateFromGateway(
+	goCtx context.Context,
+	msg *types.MsgUndelegateFromGateway,
+) (*types.MsgUndelegateFromGatewayResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	logger := k.Logger(ctx).With("method", "UndelegateFromGateway")
@@ -46,6 +49,9 @@ func (k msgServer) UndelegateFromGateway(goCtx context.Context, msg *types.MsgUn
 	// Update the application store with the new delegation
 	k.SetApplication(ctx, app)
 	logger.Info("Successfully undelegated application from gateway for app: %+v", app)
+
+	// Emit the application delegation change event
+	ctx.EventManager().EmitTypedEvent(msg.NewDelegateeChangeEvent())
 
 	return &types.MsgUndelegateFromGatewayResponse{}, nil
 }

--- a/x/application/keeper/msg_server_undelegate_from_gateway_test.go
+++ b/x/application/keeper/msg_server_undelegate_from_gateway_test.go
@@ -179,7 +179,7 @@ func TestMsgServer_UndelegateFromGateway_SuccessfullyUndelegateFromUnstakedGatew
 	appAddr := sample.AccAddress()
 	gatewayAddr := sample.AccAddress()
 	// Mock the gateway being staked via the staked gateway map
-	keepertest.RemoveGatewayFromStakedGatewayMap(t, gatewayAddr)
+	keepertest.AddGatewayToStakedGatewayMap(t, gatewayAddr)
 
 	// Prepare the application
 	stakeMsg := &types.MsgStakeApplication{
@@ -220,7 +220,7 @@ func TestMsgServer_UndelegateFromGateway_SuccessfullyUndelegateFromUnstakedGatew
 	require.Equal(t, gatewayAddr, foundApp.DelegateeGatewayAddresses[0])
 
 	// Mock unstaking the gateway
-	keepertest.AddGatewayToStakedGatewayMap(t, gatewayAddr)
+	keepertest.RemoveGatewayFromStakedGatewayMap(t, gatewayAddr)
 
 	// Prepare an undelegation message
 	undelegateMsg := &types.MsgUndelegateFromGateway{

--- a/x/application/keeper/msg_server_undelegate_from_gateway_test.go
+++ b/x/application/keeper/msg_server_undelegate_from_gateway_test.go
@@ -26,14 +26,9 @@ func TestMsgServer_UndelegateFromGateway_SuccessfullyUndelegate(t *testing.T) {
 	for i := 0; i < len(gatewayAddresses); i++ {
 		gatewayAddr := sample.AccAddress()
 		// Mock the gateway being staked via the staked gateway map
-		keepertest.StakedGatewayMap[gatewayAddr] = struct{}{}
+		keepertest.AddGatewayToStakedGatewayMap(t, gatewayAddr)
 		gatewayAddresses[i] = gatewayAddr
 	}
-	t.Cleanup(func() {
-		for _, gatewayAddr := range gatewayAddresses {
-			delete(keepertest.StakedGatewayMap, gatewayAddr)
-		}
-	})
 
 	// Prepare the application
 	stakeMsg := &types.MsgStakeApplication{
@@ -113,12 +108,8 @@ func TestMsgServer_UndelegateFromGateway_FailNotDelegated(t *testing.T) {
 	gatewayAddr1 := sample.AccAddress()
 	gatewayAddr2 := sample.AccAddress()
 	// Mock the gateway being staked via the staked gateway map
-	keepertest.StakedGatewayMap[gatewayAddr1] = struct{}{}
-	keepertest.StakedGatewayMap[gatewayAddr2] = struct{}{}
-	t.Cleanup(func() {
-		delete(keepertest.StakedGatewayMap, gatewayAddr1)
-		delete(keepertest.StakedGatewayMap, gatewayAddr2)
-	})
+	keepertest.AddGatewayToStakedGatewayMap(t, gatewayAddr1)
+	keepertest.AddGatewayToStakedGatewayMap(t, gatewayAddr2)
 
 	// Prepare the application
 	stakeMsg := &types.MsgStakeApplication{
@@ -188,7 +179,7 @@ func TestMsgServer_UndelegateFromGateway_SuccessfullyUndelegateFromUnstakedGatew
 	appAddr := sample.AccAddress()
 	gatewayAddr := sample.AccAddress()
 	// Mock the gateway being staked via the staked gateway map
-	keepertest.StakedGatewayMap[gatewayAddr] = struct{}{}
+	keepertest.RemoveGatewayFromStakedGatewayMap(t, gatewayAddr)
 
 	// Prepare the application
 	stakeMsg := &types.MsgStakeApplication{
@@ -229,7 +220,7 @@ func TestMsgServer_UndelegateFromGateway_SuccessfullyUndelegateFromUnstakedGatew
 	require.Equal(t, gatewayAddr, foundApp.DelegateeGatewayAddresses[0])
 
 	// Mock unstaking the gateway
-	delete(keepertest.StakedGatewayMap, gatewayAddr)
+	keepertest.AddGatewayToStakedGatewayMap(t, gatewayAddr)
 
 	// Prepare an undelegation message
 	undelegateMsg := &types.MsgUndelegateFromGateway{

--- a/x/application/types/message_delegate_to_gateway.go
+++ b/x/application/types/message_delegate_to_gateway.go
@@ -37,6 +37,12 @@ func (msg *MsgDelegateToGateway) GetSignBytes() []byte {
 	return sdk.MustSortJSON(bz)
 }
 
+func (msg *MsgDelegateToGateway) NewDelegateeChangeEvent() *EventDelegateeChange {
+	return &EventDelegateeChange{
+		AppAddress: msg.AppAddress,
+	}
+}
+
 func (msg *MsgDelegateToGateway) ValidateBasic() error {
 	// Validate the application address
 	if _, err := sdk.AccAddressFromBech32(msg.AppAddress); err != nil {

--- a/x/application/types/message_undelegate_from_gateway.go
+++ b/x/application/types/message_undelegate_from_gateway.go
@@ -37,6 +37,12 @@ func (msg *MsgUndelegateFromGateway) GetSignBytes() []byte {
 	return sdk.MustSortJSON(bz)
 }
 
+func (msg *MsgUndelegateFromGateway) NewDelegateeChangeEvent() *EventDelegateeChange {
+	return &EventDelegateeChange{
+		AppAddress: msg.AppAddress,
+	}
+}
+
 func (msg *MsgUndelegateFromGateway) ValidateBasic() error {
 	// Validate the application address
 	if _, err := sdk.AccAddressFromBech32(msg.AppAddress); err != nil {


### PR DESCRIPTION
## Summary

### Human Summary

This PR adds the `EventDelegateeChange` typed event and emits it on a successfull application delegation or undelegation to/from a gateway. This is listened for by the `RingCache` and used to invalidate cache entries for rings that need to be reloaded.

### AI Summary

reviewpad:summary

## Issue

- Fixes N/A

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_develop_and_test`
- [x] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updated documentation and left TODOs throughout the codebase
