### PR TITLE
wip: use viper as SoT for overridable config values & add select bound flags

### DIFF
--- a/cmd/flags/bind.go
+++ b/cmd/flags/bind.go
@@ -1,0 +1,34 @@
+package flags
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type FlagDescriptor struct {
+	FlagName    string
+	ConfigKey   string
+	Description string
+}
+
+func BindFlags(cmd *cobra.Command, flagDescriptors ...FlagDescriptor) error {
+	v := viper.GetViper()
+
+	for _, flagDesc := range flagDescriptors {
+		// Register a persistent flag on the command.
+		cmd.PersistentFlags().String(
+			flagDesc.FlagName,
+			v.GetString(flagDesc.ConfigKey),
+			flagDesc.Description,
+		)
+
+		// Bind the flag to the respective config key in viper.
+		if err := v.BindPFlag(
+			flagDesc.ConfigKey,
+			cmd.PersistentFlags().Lookup(flagDesc.FlagName),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/relayer/cmd/flags.go
+++ b/pkg/relayer/cmd/flags.go
@@ -1,0 +1,9 @@
+package cmd
+
+const (
+	FlagRelayMinerConfigPath = "config"
+	FlagQueryNodeUrl         = "query-node"
+	FlagNetworkNodeUrl       = "network-node"
+	FlagSigningKeyName       = "signing-key"
+	FlagSmtStorePath         = "store-path"
+)

--- a/pkg/relayer/config/config.go
+++ b/pkg/relayer/config/config.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
+const (
+	KeyRelayMinerConfigPath = "relay_miner_config_path"
+	KeyQueryNodeUrl         = "query_node_url"
+	KeyNetworkNodeUrl       = "network_node_url"
+	KeySigningKeyName       = "signing_key_name"
+	KeySmtStorePath         = "smt_store_path"
+)
+
+func ReadConfig(configPath string) {
+	if configPath != "" {
+		viper.SetConfigFile(configPath)
+	} else {
+		//// TODO_IN_THIS_COMMIT: what exactly does this do?
+		//viper.SetConfigName("config")
+		//viper.AddConfigPath(".")
+
+		// TODO_IN_THIS_COMMIT: establish a default...
+		panic("config path is required")
+	}
+
+	viper.AutomaticEnv() // read in environment variables that match
+
+	if err := viper.ReadInConfig(); err != nil {
+		fmt.Printf("Error reading config file, %s", err)
+	}
+}

--- a/pkg/relayer/config/relayminer_configs_reader.go
+++ b/pkg/relayer/config/relayminer_configs_reader.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 )
 
@@ -37,24 +38,40 @@ func ParseRelayMinerConfigs(configContent []byte) (*RelayMinerConfig, error) {
 		return nil, ErrRelayMinerConfigUnmarshalYAML.Wrapf("%s", err)
 	}
 
+	// TODO_IN_THIS_COMMIT: fix comment...
+	// Check if the --query-node flag was set and use it if so.
 	// Check that the query node URL is provided
-	if yamlRelayMinerConfig.QueryNodeUrl == "" {
+	queryNodeUrlString := viper.GetString(KeyQueryNodeUrl)
+	switch {
+	case queryNodeUrlString != "":
+		yamlRelayMinerConfig.QueryNodeUrl = queryNodeUrlString
+	case yamlRelayMinerConfig.QueryNodeUrl != "":
+		queryNodeUrlString = yamlRelayMinerConfig.QueryNodeUrl
+	default:
 		return nil, ErrRelayMinerConfigInvalidQueryNodeUrl.Wrapf("query node url is required")
 	}
 
 	// Parse the query node URL
-	queryNodeUrl, err := url.Parse(yamlRelayMinerConfig.QueryNodeUrl)
+	queryNodeUrl, err := url.Parse(queryNodeUrlString)
 	if err != nil {
 		return nil, ErrRelayMinerConfigInvalidQueryNodeUrl.Wrapf("%s", err)
 	}
 
+	// TODO_IN_THIS_COMMIT: fix comment...
+	// Check if the --network-node flag was set and use it if so.
 	// Check that the network node URL is provided
-	if yamlRelayMinerConfig.NetworkNodeUrl == "" {
+	networkNodeUrlString := viper.GetString(KeyNetworkNodeUrl)
+	switch {
+	case networkNodeUrlString != "":
+		yamlRelayMinerConfig.NetworkNodeUrl = networkNodeUrlString
+	case yamlRelayMinerConfig.NetworkNodeUrl != "":
+		networkNodeUrlString = yamlRelayMinerConfig.NetworkNodeUrl
+	default:
 		return nil, ErrRelayMinerConfigInvalidNetworkNodeUrl.Wrapf("network node url is required")
 	}
 
 	// Parse the network node URL
-	networkNodeUrl, err := url.Parse(yamlRelayMinerConfig.NetworkNodeUrl)
+	networkNodeUrl, err := url.Parse(networkNodeUrlString)
 	if err != nil {
 		return nil, ErrRelayMinerConfigInvalidNetworkNodeUrl.Wrapf("%s", err)
 	}
@@ -62,12 +79,25 @@ func ParseRelayMinerConfigs(configContent []byte) (*RelayMinerConfig, error) {
 	// Parse the websocket URL of the Pocket Node to connect to for subscribing to on-chain events.
 	pocketNodeWebsocketUrl := fmt.Sprintf("ws://%s/websocket", queryNodeUrl.Host)
 
-	if yamlRelayMinerConfig.SigningKeyName == "" {
+	signingKeyName := viper.GetString(KeySigningKeyName)
+	switch {
+	case signingKeyName != "":
+		yamlRelayMinerConfig.SigningKeyName = signingKeyName
+	case yamlRelayMinerConfig.SigningKeyName != "":
+		signingKeyName = yamlRelayMinerConfig.SigningKeyName
+	default:
 		return nil, ErrRelayMinerConfigInvalidSigningKeyName
 	}
 
-	if yamlRelayMinerConfig.SmtStorePath == "" {
+	smtStorePath := viper.GetString(KeySmtStorePath)
+	switch {
+	case smtStorePath != "":
+		yamlRelayMinerConfig.SmtStorePath = smtStorePath
+	case yamlRelayMinerConfig.SmtStorePath != "":
+		smtStorePath = yamlRelayMinerConfig.SmtStorePath
+	default:
 		return nil, ErrRelayMinerConfigInvalidSmtStorePath
+
 	}
 
 	if yamlRelayMinerConfig.ProxiedServiceEndpoints == nil {


### PR DESCRIPTION



## Summary

### Human Summary

- Integrates viper into the relayminer subcommand for use with the relayminer config.
- Adds viper-bound flags for overriding specified config fields.

### AI Summary

reviewpad:summary

## Issue

- #205 
- #206 

![image](https://github.com/pokt-network/poktroll/assets/600733/f422b8c5-cdb3-430f-8ed9-5a1f107ffb06)

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
