### PR TITLE
Update README.md (fix broken link - the blog moved) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The godocs for this repository can be found at [pkg.go.dev/github.com/pokt-netwo
 
 ### Pocket V1 (Shannon) Docs
 
-It is the result of a research spike conducted by the Core [Pocket Network](https://pokt.network/) Protocol Team at [GROVE](https://grove.city/) documented [here](https://www.pokt.network/why-pokt-network-is-rolling-with-rollkit-a-technical-deep-dive/) (deep dive) and [here](https://www.pokt.network/a-sovereign-rollup-and-a-modular-future/) (summary).
+It is the result of a research spike conducted by the Core [Pocket Network](https://pokt.network/) Protocol Team at [GROVE](https://grove.city/) documented [here](https://www.pokt.network/why-pokt-network-is-rolling-with-rollkit-a-technical-deep-dive/) (deep dive) and [here](https://www.pokt.network/blog/pokt-network-rolling-into-the-modular-future-of-the-protocol-a-technical-deep-dive) (summary).
 
 For now, we recommend visiting the links in [pokt-network/pocket/README.md](https://github.com/pokt-network/pocket/blob/main/README.md) as a starting point.
 


### PR DESCRIPTION
Updated broken link to the new blog site: https://www.pokt.network/blog/pokt-network-rolling-into-the-modular-future-of-the-protocol-a-technical-deep-dive



## Summary

Fixed broken link

### Human Summary

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 28 Nov 23 15:21 UTC
This pull request updates the README.md file. It fixes a broken link to the new blog site and replaces it with the correct link: [https://www.pokt.network/blog/pokt-network-rolling-into-the-modular-future-of-the-protocol-a-technical-deep-dive](https://www.pokt.network/blog/pokt-network-rolling-into-the-modular-future-of-the-protocol-a-technical-deep-dive).
<!-- reviewpad:summarize:end -->

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
