### PR TITLE
[Testing, Tooling] test: run pkg integration tests

### DIFF
--- a/.github/workflows-helpers/run-e2e-test-job-template.yaml
+++ b/.github/workflows-helpers/run-e2e-test-job-template.yaml
@@ -22,7 +22,8 @@ spec:
               poktrolld q supplier list-supplier --node=$POCKET_NODE && \
               poktrolld tx supplier stake-supplier 1000upokt --config=/poktroll/localnet/poktrolld/config/supplier1_stake_config.yaml --keyring-backend=test --from=supplier1 --node=$POCKET_NODE --yes && \
               poktrolld tx application stake-application 1000upokt --config=/poktroll/localnet/poktrolld/config/application1_stake_config.yaml --keyring-backend=test --from=app1 --node=$POCKET_NODE --yes && \
-              go test -v ./e2e/tests/... -tags=e2e
+              go test -v ./e2e/tests/... -tags=e2e; \
+              go test -v ./pkg/... -tags=e2e
           env:
             - name: AUTH_TOKEN
               valueFrom:

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ test_e2e: ## Run all E2E tests
 	export APPGATE_SERVER=$(APPGATE_SERVER) && \
 	POKTROLLD_HOME=../../$(POKTROLLD_HOME) && \
 	go test -v ./e2e/tests/... -tags=e2e
+	go test -v ./e2e/pkg/... -tags=e2e
 
 .PHONY: go_test_verbose
 go_test_verbose: check_go_version ## Run all go tests verbosely

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ test_e2e: ## Run all E2E tests
 	export APPGATE_SERVER=$(APPGATE_SERVER) && \
 	POKTROLLD_HOME=../../$(POKTROLLD_HOME) && \
 	go test -v ./e2e/tests/... -tags=e2e
-	go test -v ./e2e/pkg/... -tags=e2e
+	go test -v ./pkg/... -tags=e2e
 
 .PHONY: go_test_verbose
 go_test_verbose: check_go_version ## Run all go tests verbosely

--- a/testutil/testclient/localnet.go
+++ b/testutil/testclient/localnet.go
@@ -59,7 +59,9 @@ func NewLocalnetClientCtx(t *testing.T, flagSet *pflag.FlagSet) *client.Context 
 // - A flag set populated with flags tailored for localnet environments.
 func NewLocalnetFlagSet(t *testing.T) *pflag.FlagSet {
 	mockFlagSet := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	mockFlagSet.String(flags.FlagNode, "tcp://127.0.0.1:36657", "use localnet poktrolld node")
+	// TODO_IMPROVE: It would be nice if the value could be set correctly based
+	// on whether the test using it is running in tilt or not.
+	mockFlagSet.String(flags.FlagNode, "tcp://poktroll-sequencer:36657", "use localnet poktrolld node")
 	mockFlagSet.String(flags.FlagHome, "", "use localnet poktrolld node")
 	mockFlagSet.String(flags.FlagKeyringBackend, "test", "use test keyring")
 	err := mockFlagSet.Parse([]string{})

--- a/testutil/testclient/localnet.go
+++ b/testutil/testclient/localnet.go
@@ -14,7 +14,10 @@ import (
 )
 
 // CometLocalWebsocketURL provides a default URL pointing to the localnet websocket endpoint.
-const CometLocalWebsocketURL = "ws://localhost:36657/websocket"
+//
+// TODO_IMPROVE: It would be nice if the value could be set correctly based
+// on whether the test using it is running in tilt or not.
+const CometLocalWebsocketURL = "ws://poktroll-sequencer:36657/websocket"
 
 // EncodingConfig encapsulates encoding configurations for the Pocket application.
 var EncodingConfig = app.MakeEncodingConfig()


### PR DESCRIPTION
## Summary

### Human Summary

- [x] Add step to `run-e2e-test-job-template.yaml`
- [x] Add step to `test_e2e` makefile target
- [x] Update testutil hostnames to use in-tilt hostnames
- [ ] Ensure mocks are generated before running E2E tests in CI

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Dec 23 13:10 UTC
This pull request includes several changes:

1. The patch updates the Makefile to include e2e tests in the `test_e2e` make target. It adds a new line of code to run e2e tests in the `./e2e/pkg/...` directory.

2. The patch modifies the `localnet.go` file by updating the mock node flag with the in-tilt host. It changes the value of the `FlagNode` flag to `"tcp://poktroll-sequencer:36657"`.

3. The patch updates the `CometLocalWebsocketURL` constant in the `localnet.go` file to use the in-tilt host. It changes the value of the constant to `"ws://poktroll-sequencer:36657/websocket"`.

4. The patch fixes a typo in the Makefile. It changes the path from `./e2e/pkg/...` to `./pkg/...` in the `test_e2e` target.

5. The patch updates the CI workflow file to run e2e tests on the `./pkg/...` directory. It adds a new line of code to run e2e tests in the `./pkg/...` directory.

Overall, these changes aim to include the e2e tests in the `test_e2e` make target and update the necessary flags and URLs to use the in-tilt host.
<!-- reviewpad:summarize:end -->

## Issue

- N/A

I'm recalling that some end-to-end tests currently exist inside of some of the packages in the pkg directory.

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
