### PR TITLE
[Logging] Enforce polylog usage after #219 for new logs added

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -7,10 +7,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
-  
+
 jobs:
-  # Makes sure that comments like TODO_IN_THIS_PR or TODO_IN_THIS_COMMIT block merging to main
-  # More info: https://github.com/pokt-network/action-fail-on-found
+  # Makes sure that comments like TODO_IN_THIS_PR or TODO_IN_THIS_COMMIT block
+  # merging to main. See https://github.com/pokt-network/action-fail-on-found
   check_todo_in_this:
     name: Check TODO_IN_THIS_
     runs-on: ubuntu-latest
@@ -24,6 +24,23 @@ jobs:
           fail_on_error: true
           pattern: TODO_IN_THIS_
 
+  # Makes sure that comments like TODO_IN_THIS_PR or TODO_IN_THIS_COMMIT block
+  # merging to main. See https://github.com/pokt-network/action-fail-on-found
+  check_polylog_in_off_chain_package:
+    name: Check polylog in off-chain source code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pokt-network/action-fail-on-found@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          level: error
+          fail_on_error: true
+          pattern: log\..*
+
+  # There are multiple ways to validate (at compile time) that a struct
+  # implements a certain interface. This check enforces a common practice.
   check_non_standard_interface_implementations:
     name: Check for non-standard interface implementation statements
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add a reviewdog workflow to make sure we do not use `log.*` for logging purposes anymore.

### Human Summary

### AI Summary

reviewpad:summary

## Issue
- Follow up to PR #219


## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
