### PR TITLE
Make Relay{Request,Response}.GetSignableBytes return the signable hash

### DIFF
--- a/pkg/appgateserver/relay_verifier.go
+++ b/pkg/appgateserver/relay_verifier.go
@@ -29,13 +29,13 @@ func (app *appGateServer) verifyResponse(
 	supplierSignature := relayResponse.Meta.SupplierSignature
 
 	// Get the relay response signable bytes and hash them.
-	signableBz, err := relayResponse.GetSignableBytes()
+	responseSignableBz, err := relayResponse.GetSignableBytes()
 	if err != nil {
 		return err
 	}
 
 	// Verify the relay response signature.
-	if !supplierPubKey.VerifySignature(signableBz, supplierSignature) {
+	if !supplierPubKey.VerifySignature(responseSignableBz, supplierSignature) {
 		return ErrAppGateInvalidRelayResponseSignature
 	}
 

--- a/pkg/appgateserver/relay_verifier.go
+++ b/pkg/appgateserver/relay_verifier.go
@@ -3,7 +3,6 @@ package appgateserver
 import (
 	"context"
 
-	"github.com/cometbft/cometbft/crypto"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 
 	"github.com/pokt-network/poktroll/x/service/types"
@@ -30,14 +29,13 @@ func (app *appGateServer) verifyResponse(
 	supplierSignature := relayResponse.Meta.SupplierSignature
 
 	// Get the relay response signable bytes and hash them.
-	responseBz, err := relayResponse.GetSignableBytes()
+	signableBz, err := relayResponse.GetSignableBytes()
 	if err != nil {
 		return err
 	}
-	hash := crypto.Sha256(responseBz)
 
 	// Verify the relay response signature.
-	if !supplierPubKey.VerifySignature(hash, supplierSignature) {
+	if !supplierPubKey.VerifySignature(signableBz, supplierSignature) {
 		return ErrAppGateInvalidRelayResponseSignature
 	}
 

--- a/pkg/appgateserver/synchronous.go
+++ b/pkg/appgateserver/synchronous.go
@@ -7,8 +7,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/cometbft/cometbft/crypto"
-
 	"github.com/pokt-network/poktroll/pkg/partials"
 	"github.com/pokt-network/poktroll/pkg/signer"
 	"github.com/pokt-network/poktroll/x/service/types"
@@ -65,8 +63,7 @@ func (app *appGateServer) handleSynchronousRelay(
 		return ErrAppGateHandleRelay.Wrapf("getting signable bytes: %s", err)
 	}
 
-	hash := crypto.Sha256(signableBz)
-	signature, err := signer.Sign(hash)
+	signature, err := signer.Sign(signableBz)
 	if err != nil {
 		return ErrAppGateHandleRelay.Wrapf("signing relay: %s", err)
 	}

--- a/pkg/appgateserver/synchronous.go
+++ b/pkg/appgateserver/synchronous.go
@@ -63,11 +63,11 @@ func (app *appGateServer) handleSynchronousRelay(
 		return ErrAppGateHandleRelay.Wrapf("getting signable bytes: %s", err)
 	}
 
-	signature, err := signer.Sign(signableBz)
+	requestSig, err := signer.Sign(signableBz)
 	if err != nil {
 		return ErrAppGateHandleRelay.Wrapf("signing relay: %s", err)
 	}
-	relayRequest.Meta.Signature = signature
+	relayRequest.Meta.Signature = requestSig
 
 	// Marshal the relay request to bytes and create a reader to be used as an HTTP request body.
 	cdc := types.ModuleCdc

--- a/pkg/relayer/proxy/relay_signer.go
+++ b/pkg/relayer/proxy/relay_signer.go
@@ -23,12 +23,12 @@ func (rp *relayerProxy) SignRelayResponse(relayResponse *types.RelayResponse) er
 	}
 
 	// sign the relay response
-	sig, err := signer.Sign(signableBz)
+	responseSig, err := signer.Sign(signableBz)
 	if err != nil {
 		return sdkerrors.Wrapf(ErrRelayerProxyInvalidRelayResponse, "error signing relay response: %v", err)
 	}
 
 	// set the relay response's signature
-	relayResponse.Meta.SupplierSignature = sig
+	relayResponse.Meta.SupplierSignature = responseSig
 	return nil
 }

--- a/pkg/relayer/proxy/relay_signer.go
+++ b/pkg/relayer/proxy/relay_signer.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	sdkerrors "cosmossdk.io/errors"
-	"github.com/cometbft/cometbft/crypto"
 
 	"github.com/pokt-network/poktroll/pkg/signer"
 	"github.com/pokt-network/poktroll/x/service/types"
@@ -22,10 +21,9 @@ func (rp *relayerProxy) SignRelayResponse(relayResponse *types.RelayResponse) er
 	if err != nil {
 		return sdkerrors.Wrapf(ErrRelayerProxyInvalidRelayResponse, "error getting signable bytes: %v", err)
 	}
-	hash := crypto.Sha256(signableBz)
 
 	// sign the relay response
-	sig, err := signer.Sign(hash)
+	sig, err := signer.Sign(signableBz)
 	if err != nil {
 		return sdkerrors.Wrapf(ErrRelayerProxyInvalidRelayResponse, "error signing relay response: %v", err)
 	}

--- a/pkg/relayer/proxy/relay_verifier.go
+++ b/pkg/relayer/proxy/relay_verifier.go
@@ -61,13 +61,13 @@ func (rp *relayerProxy) VerifyRelayRequest(
 	}
 
 	// get and hash the signable bytes of the relay request
-	signableBz, err := relayRequest.GetSignableBytes()
+	requestSignableBz, err := relayRequest.GetSignableBytes()
 	if err != nil {
 		return sdkerrors.Wrapf(ErrRelayerProxyInvalidRelayRequest, "error getting signable bytes: %v", err)
 	}
 
 	var hash32 [32]byte
-	copy(hash32[:], signableBz)
+	copy(hash32[:], requestSignableBz)
 
 	// verify the relay request's signature
 	if valid := ringSig.Verify(hash32); !valid {

--- a/pkg/relayer/proxy/relay_verifier.go
+++ b/pkg/relayer/proxy/relay_verifier.go
@@ -6,7 +6,6 @@ import (
 
 	sdkerrors "cosmossdk.io/errors"
 	ring_secp256k1 "github.com/athanorlabs/go-dleq/secp256k1"
-	"github.com/cometbft/cometbft/crypto"
 	"github.com/noot/ring-go"
 
 	"github.com/pokt-network/poktroll/x/service/types"
@@ -67,9 +66,8 @@ func (rp *relayerProxy) VerifyRelayRequest(
 		return sdkerrors.Wrapf(ErrRelayerProxyInvalidRelayRequest, "error getting signable bytes: %v", err)
 	}
 
-	hash := crypto.Sha256(signableBz)
 	var hash32 [32]byte
-	copy(hash32[:], hash)
+	copy(hash32[:], signableBz)
 
 	// verify the relay request's signature
 	if valid := ringSig.Verify(hash32); !valid {

--- a/x/service/types/relay.go
+++ b/x/service/types/relay.go
@@ -3,7 +3,9 @@ package types
 import "github.com/cometbft/cometbft/crypto"
 
 // GetSignableBytes returns the signable bytes for the relay request
-// this involves setting the signature to nil and marshaling the message.
+// this involves setting the signature to nil and marshaling the message
+// then hashing it to guarantee that the signable bytes are always of a
+// constant and expected length.
 // A value receiver is used to avoid overwriting any pre-existing signature
 func (req RelayRequest) GetSignableBytes() ([]byte, error) {
 	// set signature to nil
@@ -15,13 +17,16 @@ func (req RelayRequest) GetSignableBytes() ([]byte, error) {
 		return nil, err
 	}
 
-	// return the marshaled request hash
+	// return the marshaled request hash to guarantee that the signable bytes are
+	// always of a constant and expected length
 	hash := crypto.Sha256(requestBz)
 	return hash, nil
 }
 
 // GetSignableBytes returns the signable bytes for the relay response
-// this involves setting the signature to nil and marshaling the message.
+// this involves setting the signature to nil and marshaling the message
+// then hashing it to guarantee that the signable bytes are always of a
+// constant and expected length.
 // A value receiver is used to avoid overwriting any pre-existing signature
 func (res RelayResponse) GetSignableBytes() ([]byte, error) {
 	// set signature to nil
@@ -32,7 +37,8 @@ func (res RelayResponse) GetSignableBytes() ([]byte, error) {
 		return nil, err
 	}
 
-	// return the marshaled response hash
+	// return the marshaled response hash to guarantee that the signable bytes are
+	// always of a constant and expected length
 	hash := crypto.Sha256(responseBz)
 	return hash, nil
 }

--- a/x/service/types/relay.go
+++ b/x/service/types/relay.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/cometbft/cometbft/crypto"
+
 // GetSignableBytes returns the signable bytes for the relay request
 // this involves setting the signature to nil and marshaling the message.
 // A value receiver is used to avoid overwriting any pre-existing signature
@@ -8,7 +10,14 @@ func (req RelayRequest) GetSignableBytes() ([]byte, error) {
 	req.Meta.Signature = nil
 
 	// return the marshaled message
-	return req.Marshal()
+	requestBz, err := req.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	// return the marshaled request hash
+	hash := crypto.Sha256(requestBz)
+	return hash, nil
 }
 
 // GetSignableBytes returns the signable bytes for the relay response
@@ -18,8 +27,14 @@ func (res RelayResponse) GetSignableBytes() ([]byte, error) {
 	// set signature to nil
 	res.Meta.SupplierSignature = nil
 
-	// return the marshaled message
-	return res.Marshal()
+	responseBz, err := res.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	// return the marshaled response hash
+	hash := crypto.Sha256(responseBz)
+	return hash, nil
 }
 
 func (res *RelayResponse) ValidateBasic() error {


### PR DESCRIPTION
## Summary

### Human Summary

In order to normalize data signing, `RelayRequest` and `RelayResponse` `.GetSignableBytes` now returns the hash of the unmarshaled structure instead of the hash itself, avoiding hashing to occur out side of the function.

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Dec 23 01:34 UTC
This pull request includes several changes across multiple files. 

In pkg/appgateserver/relay_verifier.go, the code has been updated to use the new API for obtaining the signable bytes of the relay response. The previous code used the crypto.Sha256 function to compute the hash of the response bytes, but it has been replaced with the correct function call supplierPubKey.VerifySignature. The function is now using the responseSignableBz variable instead of the old responseBz variable.

In pkg/appgateserver/synchronous.go, a similar change has been made. The code now uses the new API for obtaining the signable bytes of the relay request. The crypto.Sha256 function call has been replaced with the correct function call signer.Sign. The function is now using the requestSig variable instead of the old signature variable.

In pkg/relayer/proxy/relay_signer.go, the code has been updated to use the new API for obtaining the signable bytes of the relay response. The call to the crypto.Sha256 function has been removed, and the correct function call signer.Sign is used instead. The function is now using the responseSig variable instead of the old sig variable.

In pkg/relayer/proxy/relay_verifier.go, a similar change has been made. The code now uses the new API for obtaining the signable bytes of the relay request. The call to the crypto.Sha256 function has been removed, and the correct function call ringSig.Verify is used instead. The function is now using the requestSignableBz variable instead of the old signableBz variable.

In x/service/types/relay.go, the GetSignableBytes functions for both RelayRequest and RelayResponse have been updated to compute a hash of the marshaled message instead of returning the marshaled message directly. The crypto.Sha256 function is used to compute the hash. This change ensures that the signable bytes are always of a constant and expected length.

These changes improve the security and correctness of the code by using the correct functions for obtaining and verifying signatures and by properly hashing the signable bytes.
<!-- reviewpad:summarize:end -->

![image](https://github.com/pokt-network/poktroll/assets/231488/e4cb7a0e-1c17-408d-ad8b-68738aed3bb8)


## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
