### PR TITLE
[🪲Off-chain, Polylog] fix: broken localnet output 🙄

### DIFF
--- a/pkg/deps/config/suppliers.go
+++ b/pkg/deps/config/suppliers.go
@@ -15,6 +15,7 @@ import (
 	querytypes "github.com/pokt-network/poktroll/pkg/client/query/types"
 	txtypes "github.com/pokt-network/poktroll/pkg/client/tx/types"
 	"github.com/pokt-network/poktroll/pkg/crypto/rings"
+	"github.com/pokt-network/poktroll/pkg/polylog"
 )
 
 // hostToWebsocketURL converts the provided host into a websocket URL that can
@@ -42,6 +43,18 @@ func SupplyConfig(
 		}
 	}
 	return deps, nil
+}
+
+// NewSupplyLoggerFromCtx supplies a depinject config with a polylog.Logger instance
+// populated from the given context.
+func NewSupplyLoggerFromCtx(ctx context.Context) SupplierFn {
+	return func(
+		_ context.Context,
+		deps depinject.Config,
+		_ *cobra.Command,
+	) (depinject.Config, error) {
+		return depinject.Configs(deps, depinject.Supply(polylog.Ctx(ctx))), nil
+	}
 }
 
 // NewSupplyEventsQueryClientFn returns a new function which constructs an

--- a/pkg/polylog/polyzero/logger.go
+++ b/pkg/polylog/polyzero/logger.go
@@ -2,6 +2,7 @@ package polyzero
 
 import (
 	"context"
+	"os"
 
 	"github.com/rs/zerolog"
 
@@ -17,11 +18,20 @@ type zerologLogger struct {
 }
 
 // NewLogger constructs a new zerolog-backed logger which conforms to the
-// polylog.Logger interface.
+// polylog.Logger interface. By default, the logger is configured to write to
+// os.Stderr and log at the Debug level.
+//
+// TODO_IMPROVE/TODO_COMMUNITY: Add `NewProductionLogger`, `NewDevelopmentLogger`,
+// and `NewExampleLogger` functions with reasonable defaults the their respective
+// environments; conceptually similar to the respective analogues in zap.
+// See: https://pkg.go.dev/github.com/uber-go/zap#hdr-Configuring_Zap.
 func NewLogger(
 	opts ...polylog.LoggerOption,
 ) polylog.Logger {
-	ze := &zerologLogger{}
+	ze := &zerologLogger{
+		level:  zerolog.DebugLevel,
+		Logger: zerolog.New(os.Stderr),
+	}
 
 	for _, opt := range opts {
 		opt(ze)


### PR DESCRIPTION
## Summary

### Human Summary

Although unit tests were passing, I failed to double-check localnet output before merging #219. Apparently I assumed that the zero value zerolog logger (feel free to re-read carefully as many times as necessary :stuck_out_tongue_closed_eyes:) used `os.Stderr` as the output; however, it seems not to be the case. I've also ruled out level misconfiguration, it's definitely the output configuration.

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 06 Dec 23 08:43 UTC
This pull request contains changes to multiple files in the repository. Here is a summary of the changes:

- In `pkg/appgateserver/cmd/cmd.go`, there are some changes related to configuring the logger for the command context.
- In `pkg/deps/config/suppliers.go`, a new function `NewSupplyLoggerFromCtx` is added to supply a `polylog.Logger` instance from the given context.
- In `pkg/polylog/polyzero/logger.go`, there are changes related to configuring the logger, including the addition of default settings for logger output and log level.
- In `pkg/relayer/cmd/cmd.go`, there are similar changes to what was done in `pkg/appgateserver/cmd/cmd.go` for configuring the logger. The `NewSupplyLoggerFromCtx` function is also added here.

These changes seem to be related to fixing issues with the localnet output and improving the logging functionality.
<!-- reviewpad:summarize:end -->

## Issue

- #181 
- #219


## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [x] **Verify Localnet manually**: See the instructions [here](TODO: add link to instructions)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
