### PR TITLE
[CI/E2E] e2e fixes for e2e fixes

### DIFF
--- a/.github/workflows-helpers/run-e2e-test-job-template.yaml
+++ b/.github/workflows-helpers/run-e2e-test-job-template.yaml
@@ -17,11 +17,11 @@ spec:
           args:
             - "-c"
             - |
-              poktrolld q gateway list-gateway --node=tcp://$POCKET_NODE && \
-              poktrolld q application list-application --node=tcp://$POCKET_NODE && \
-              poktrolld q supplier list-supplier --node=tcp://$POCKET_NODE && \
-              poktrolld tx supplier stake-supplier 1000upokt --config=/poktroll/localnet/poktrolld/config/supplier1_stake_config.yaml --keyring-backend=test --from=supplier1 --node=tcp://$POCKET_NODE --yes && \
-              poktrolld tx application stake-application 1000upokt --config=/poktroll/localnet/poktrolld/config/application1_stake_config.yaml --keyring-backend=test --from=app1 --node=tcp://$POCKET_NODE --yes && \
+              poktrolld q gateway list-gateway --node=tcp://$SEQUENCER_RPC_ENDPOINT && \
+              poktrolld q application list-application --node=tcp://$SEQUENCER_RPC_ENDPOINT && \
+              poktrolld q supplier list-supplier --node=tcp://$SEQUENCER_RPC_ENDPOINT && \
+              poktrolld tx supplier stake-supplier 1000upokt --config=/poktroll/localnet/poktrolld/config/supplier1_stake_config.yaml --keyring-backend=test --from=supplier1 --node=tcp://$SEQUENCER_RPC_ENDPOINT --yes && \
+              poktrolld tx application stake-application 1000upokt --config=/poktroll/localnet/poktrolld/config/application1_stake_config.yaml --keyring-backend=test --from=app1 --node=tcp://$SEQUENCER_RPC_ENDPOINT --yes && \
               go test -v ./e2e/tests/... -tags=e2e
           env:
             - name: AUTH_TOKEN

--- a/.github/workflows-helpers/run-e2e-test-job-template.yaml
+++ b/.github/workflows-helpers/run-e2e-test-job-template.yaml
@@ -17,11 +17,11 @@ spec:
           args:
             - "-c"
             - |
-              poktrolld q gateway list-gateway --node=http://$SEQUENCER_RPC_ENDPOINT && \
-              poktrolld q application list-application --node=http://$SEQUENCER_RPC_ENDPOINT && \
-              poktrolld q supplier list-supplier --node=http://$SEQUENCER_RPC_ENDPOINT && \
-              poktrolld tx supplier stake-supplier 1000upokt --config=/poktroll/localnet/poktrolld/config/supplier1_stake_config.yaml --keyring-backend=test --from=supplier1 --node=http://$SEQUENCER_RPC_ENDPOINT --yes && \
-              poktrolld tx application stake-application 1000upokt --config=/poktroll/localnet/poktrolld/config/application1_stake_config.yaml --keyring-backend=test --from=app1 --node=http://$SEQUENCER_RPC_ENDPOINT --yes && \
+              poktrolld q gateway list-gateway --node=$POCKET_NODE && \
+              poktrolld q application list-application --node=$POCKET_NODE && \
+              poktrolld q supplier list-supplier --node=$POCKET_NODE && \
+              poktrolld tx supplier stake-supplier 1000upokt --config=/poktroll/localnet/poktrolld/config/supplier1_stake_config.yaml --keyring-backend=test --from=supplier1 --node=$POCKET_NODE --yes && \
+              poktrolld tx application stake-application 1000upokt --config=/poktroll/localnet/poktrolld/config/application1_stake_config.yaml --keyring-backend=test --from=app1 --node=$POCKET_NODE --yes && \
               go test -v ./e2e/tests/... -tags=e2e
           env:
             - name: AUTH_TOKEN
@@ -29,6 +29,8 @@ spec:
                 secretKeyRef:
                   key: auth_token
                   name: celestia-secret
+            - name: POCKET_NODE
+              value: tcp://${NAMESPACE}-sequencer:36657
             - name: SEQUENCER_RPC_ENDPOINT
               value: ${NAMESPACE}-sequencer:36657
             - name: E2E_DEBUG_OUTPUT

--- a/.github/workflows-helpers/run-e2e-test-job-template.yaml
+++ b/.github/workflows-helpers/run-e2e-test-job-template.yaml
@@ -17,11 +17,11 @@ spec:
           args:
             - "-c"
             - |
-              poktrolld q gateway list-gateway --node=tcp://$SEQUENCER_RPC_ENDPOINT && \
-              poktrolld q application list-application --node=tcp://$SEQUENCER_RPC_ENDPOINT && \
-              poktrolld q supplier list-supplier --node=tcp://$SEQUENCER_RPC_ENDPOINT && \
-              poktrolld tx supplier stake-supplier 1000upokt --config=/poktroll/localnet/poktrolld/config/supplier1_stake_config.yaml --keyring-backend=test --from=supplier1 --node=tcp://$SEQUENCER_RPC_ENDPOINT --yes && \
-              poktrolld tx application stake-application 1000upokt --config=/poktroll/localnet/poktrolld/config/application1_stake_config.yaml --keyring-backend=test --from=app1 --node=tcp://$SEQUENCER_RPC_ENDPOINT --yes && \
+              poktrolld q gateway list-gateway --node=http://$SEQUENCER_RPC_ENDPOINT && \
+              poktrolld q application list-application --node=http://$SEQUENCER_RPC_ENDPOINT && \
+              poktrolld q supplier list-supplier --node=http://$SEQUENCER_RPC_ENDPOINT && \
+              poktrolld tx supplier stake-supplier 1000upokt --config=/poktroll/localnet/poktrolld/config/supplier1_stake_config.yaml --keyring-backend=test --from=supplier1 --node=http://$SEQUENCER_RPC_ENDPOINT --yes && \
+              poktrolld tx application stake-application 1000upokt --config=/poktroll/localnet/poktrolld/config/application1_stake_config.yaml --keyring-backend=test --from=app1 --node=http://$SEQUENCER_RPC_ENDPOINT --yes && \
               go test -v ./e2e/tests/... -tags=e2e
           env:
             - name: AUTH_TOKEN

--- a/.github/workflows-helpers/run-e2e-test-job-template.yaml
+++ b/.github/workflows-helpers/run-e2e-test-job-template.yaml
@@ -17,11 +17,11 @@ spec:
           args:
             - "-c"
             - |
-              poktrolld q gateway list-gateway --node=$POCKET_NODE && \
-              poktrolld q application list-application --node=$POCKET_NODE && \
-              poktrolld q supplier list-supplier --node=$POCKET_NODE && \
-              poktrolld tx supplier stake-supplier 1000upokt --config=/poktroll/localnet/poktrolld/config/supplier1_stake_config.yaml --keyring-backend=test --from=supplier1 --node=$POCKET_NODE --yes && \
-              poktrolld tx application stake-application 1000upokt --config=/poktroll/localnet/poktrolld/config/application1_stake_config.yaml --keyring-backend=test --from=app1 --node=$POCKET_NODE --yes && \
+              poktrolld q gateway list-gateway --node=tcp://$POCKET_NODE && \
+              poktrolld q application list-application --node=tcp://$POCKET_NODE && \
+              poktrolld q supplier list-supplier --node=tcp://$POCKET_NODE && \
+              poktrolld tx supplier stake-supplier 1000upokt --config=/poktroll/localnet/poktrolld/config/supplier1_stake_config.yaml --keyring-backend=test --from=supplier1 --node=tcp://$POCKET_NODE --yes && \
+              poktrolld tx application stake-application 1000upokt --config=/poktroll/localnet/poktrolld/config/application1_stake_config.yaml --keyring-backend=test --from=app1 --node=tcp://$POCKET_NODE --yes && \
               go test -v ./e2e/tests/... -tags=e2e
           env:
             - name: AUTH_TOKEN
@@ -29,8 +29,8 @@ spec:
                 secretKeyRef:
                   key: auth_token
                   name: celestia-secret
-            - name: POCKET_NODE
-              value: tcp://${NAMESPACE}-sequencer:36657
+            - name: SEQUENCER_RPC_ENDPOINT
+              value: ${NAMESPACE}-sequencer:36657
             - name: E2E_DEBUG_OUTPUT
               value: "false" # Flip to true to see the command and result of the execution
             - name: POKTROLLD_HOME

--- a/e2e/tests/node.go
+++ b/e2e/tests/node.go
@@ -118,9 +118,9 @@ func (p *pocketdBin) runCurlPostCmd(rpcUrl string, service string, data string, 
 	dataStr := fmt.Sprintf("%s", data)
 	urlStr := fmt.Sprintf("%s/%s", rpcUrl, service)
 	base := []string{
-		"-v",                                   // verbose output
-		"-sS",                                  // silent with error
-		"POST",                                 // HTTP method
+		"-v",         // verbose output
+		"-sS",        // silent with error
+		"-X", "POST", // HTTP method
 		"-H", "Content-Type: application/json", // HTTP headers
 		"--data", dataStr, urlStr, // POST data
 	}

--- a/testutil/testclient/localnet.go
+++ b/testutil/testclient/localnet.go
@@ -1,6 +1,9 @@
 package testclient
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -11,26 +14,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
+var (
 	// CometLocalTCPURL provides a default URL pointing to the localnet TCP endpoint.
-	//
-	// TODO_IMPROVE: It would be nice if the value could be set correctly based
-	// on whether the test using it is running in tilt or not.
 	CometLocalTCPURL = "tcp://localhost:36657"
 
 	// CometLocalWebsocketURL provides a default URL pointing to the localnet websocket endpoint.
-	//
-	// TODO_IMPROVE: It would be nice if the value could be set correctly based
-	// on whether the test using it is running in tilt or not.
 	CometLocalWebsocketURL = "ws://localhost:36657/websocket"
-)
 
-// EncodingConfig encapsulates encoding configurations for the Pocket application.
-var EncodingConfig = app.MakeEncodingConfig()
+	// EncodingConfig encapsulates encoding configurations for the Pocket application.
+	EncodingConfig = app.MakeEncodingConfig()
+)
 
 // init initializes the SDK configuration upon package import.
 func init() {
 	cmd.InitSDKConfig()
+
+	// If SEQUENCER_RPC_ENDPOINT environment variable is set, use it to override the default localnet endpoint.
+	if endpoint := os.Getenv("SEQUENCER_RPC_ENDPOINT"); endpoint != "" {
+		CometLocalTCPURL = fmt.Sprintf("tcp://%s", endpoint)
+		CometLocalWebsocketURL = fmt.Sprintf("ws://%s/websocket")
+	}
 }
 
 // NewLocalnetClientCtx creates a client context specifically tailored for localnet

--- a/testutil/testclient/localnet.go
+++ b/testutil/testclient/localnet.go
@@ -32,7 +32,7 @@ func init() {
 	// If SEQUENCER_RPC_ENDPOINT environment variable is set, use it to override the default localnet endpoint.
 	if endpoint := os.Getenv("SEQUENCER_RPC_ENDPOINT"); endpoint != "" {
 		CometLocalTCPURL = fmt.Sprintf("tcp://%s", endpoint)
-		CometLocalWebsocketURL = fmt.Sprintf("ws://%s/websocket")
+		CometLocalWebsocketURL = fmt.Sprintf("ws://%s/websocket", endpoint)
 	}
 }
 


### PR DESCRIPTION
## Summary

### Human Summary

Add an ability to override an RPC endpoint for e2e tests, so they can run locally and remotely.

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 11 Dec 23 23:40 UTC
This pull request includes the following changes:

1. In the file `.github/workflows-helpers/run-e2e-test-job-template.yaml`, a new environment variable `SEQUENCER_RPC_ENDPOINT` is added with the value `${NAMESPACE}-sequencer:36657`.
2. In the file `e2e/tests/node.go`, the HTTP method option is changed from `POST` to `-X POST`.
3. In the file `testutil/testclient/localnet.go`, a new import statement for `fmt` and `os` is added. Additionally, the default values for `CometLocalTCPURL` and `CometLocalWebsocketURL` are modified based on the value of the `SEQUENCER_RPC_ENDPOINT` environment variable.

Please review these changes.
<!-- reviewpad:summarize:end -->
