### PR TITLE
[SDK] feat: Have distinct JSON-RPC and gRPC urls

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -152,7 +152,7 @@ k8s_resource(
     "sequencer",
     labels=["blockchains"],
     resource_deps=["celestia-rollkit"],
-    port_forwards=["36657", "40004"],
+    port_forwards=["36657", "36658", "40004"],
 )
 k8s_resource(
     "relayminers",

--- a/pkg/client/query/codec.go
+++ b/pkg/client/query/codec.go
@@ -3,6 +3,7 @@ package query
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	accounttypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
@@ -14,5 +15,6 @@ var queryCodec *codec.ProtoCodec
 func init() {
 	reg := codectypes.NewInterfaceRegistry()
 	accounttypes.RegisterInterfaces(reg)
+	cryptocodec.RegisterInterfaces(reg)
 	queryCodec = codec.NewProtoCodec(reg)
 }

--- a/pkg/client/query/supplierquerier.go
+++ b/pkg/client/query/supplierquerier.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"cosmossdk.io/depinject"
-
 	"github.com/cosmos/gogoproto/grpc"
+
 	"github.com/pokt-network/poktroll/pkg/client"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 	suppliertypes "github.com/pokt-network/poktroll/x/supplier/types"

--- a/pkg/client/query/supplierquerier.go
+++ b/pkg/client/query/supplierquerier.go
@@ -4,10 +4,9 @@ import (
 	"context"
 
 	"cosmossdk.io/depinject"
-	cosmosclient "github.com/cosmos/cosmos-sdk/client"
 
+	"github.com/cosmos/gogoproto/grpc"
 	"github.com/pokt-network/poktroll/pkg/client"
-	"github.com/pokt-network/poktroll/pkg/client/query/types"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 	suppliertypes "github.com/pokt-network/poktroll/x/supplier/types"
 )
@@ -16,7 +15,7 @@ import (
 // querying of on-chain supplier information through a single exposed method
 // which returns an sharedtypes.Supplier struct
 type supplierQuerier struct {
-	clientCtx       types.Context
+	clientConn      grpc.ClientConn
 	supplierQuerier suppliertypes.QueryClient
 }
 
@@ -30,12 +29,12 @@ func NewSupplierQuerier(deps depinject.Config) (client.SupplierQueryClient, erro
 
 	if err := depinject.Inject(
 		deps,
-		&supq.clientCtx,
+		&supq.clientConn,
 	); err != nil {
 		return nil, err
 	}
 
-	supq.supplierQuerier = suppliertypes.NewQueryClient(cosmosclient.Context(supq.clientCtx))
+	supq.supplierQuerier = suppliertypes.NewQueryClient(supq.clientConn)
 
 	return supq, nil
 }

--- a/pkg/deps/config/suppliers.go
+++ b/pkg/deps/config/suppliers.go
@@ -309,9 +309,8 @@ func NewSupplyPOKTRollSDKFn(
 		}
 
 		config := &sdk.POKTRollSDKConfig{
-			PrivateKey:    privateKey,
-			PocketNodeUrl: queryNodeURL,
-			Deps:          deps,
+			PrivateKey: privateKey,
+			Deps:       deps,
 		}
 
 		poktrollSDK, err := sdk.NewPOKTRollSDK(ctx, config)

--- a/pkg/sdk/deps_builder.go
+++ b/pkg/sdk/deps_builder.go
@@ -44,7 +44,7 @@ func (sdk *poktrollSDK) buildDeps(
 	deps = depinject.Configs(deps, depinject.Supply(blockClient))
 
 	// Create and supply the grpc client used by the queriers
-	// TODO_TECHDEBT: Configure the grpc client options from the config
+	// TODO_TECHDEBT: Configure the grpc client options from the config.
 	var grpcClient grpctypes.ClientConn
 	grpcClient, err = grpc.Dial(
 		config.QueryNodeGRPCUrl.Host,

--- a/pkg/sdk/deps_builder.go
+++ b/pkg/sdk/deps_builder.go
@@ -3,6 +3,7 @@ package sdk
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"cosmossdk.io/depinject"
 	grpctypes "github.com/cosmos/gogoproto/grpc"
@@ -23,7 +24,7 @@ func (sdk *poktrollSDK) buildDeps(
 	ctx context.Context,
 	config *POKTRollSDKConfig,
 ) (depinject.Config, error) {
-	pocketNodeWebsocketURL := fmt.Sprintf("ws://%s/websocket", config.PocketNodeUrl.Host)
+	pocketNodeWebsocketURL := queryNodeToWebsocketURL(config.QueryNodeUrl)
 
 	// Have a new depinject config
 	deps := depinject.Configs()
@@ -46,7 +47,7 @@ func (sdk *poktrollSDK) buildDeps(
 	// TODO_TECHDEBT: Configure the grpc client options from the config
 	var grpcClient grpctypes.ClientConn
 	grpcClient, err = grpc.Dial(
-		config.PocketNodeUrl.Host,
+		config.QueryNodeGRPCUrl.Host,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {
@@ -83,4 +84,11 @@ func (sdk *poktrollSDK) buildDeps(
 	deps = depinject.Configs(deps, depinject.Supply(ringCache))
 
 	return deps, nil
+}
+
+// hostToWebsocketURL converts the provided host into a websocket URL that can
+// be used to subscribe to onchain events and query the chain via a client
+// context or send transactions via a tx client context.
+func queryNodeToWebsocketURL(queryNode *url.URL) string {
+	return fmt.Sprintf("ws://%s/websocket", queryNode.Host)
 }

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -24,9 +24,10 @@ var _ POKTRollSDK = (*poktrollSDK)(nil)
 // Deps is an optional field that can be used to provide the needed dependencies
 // for the SDK. If it is not provided, the SDK will build the dependencies itself.
 type POKTRollSDKConfig struct {
-	PocketNodeUrl *url.URL
-	PrivateKey    cryptotypes.PrivKey
-	Deps          depinject.Config
+	QueryNodeGRPCUrl *url.URL
+	QueryNodeUrl     *url.URL
+	PrivateKey       cryptotypes.PrivKey
+	Deps             depinject.Config
 }
 
 // poktrollSDK is the implementation of the POKTRollSDK.


### PR DESCRIPTION
## Summary

### Human Summary

Make `POKTRollSDK` have different query node URLs so it can be used outside of `cosmosclient.Context` and be imported from external codebases that do not depend on `CosmosSDK`

Have distinct query node urls:
* JSON-RPC `QueryNodeUrl`  for event subscriptions
* gRPC `QueryNodeGRPCUrl` for query client usage

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Dec 23 14:56 UTC
This pull request includes three patches:

1. The first patch adds distinct JSON-RPC and gRPC URLs in the `Tiltfile` and updates the port forwards accordingly.

2. The second patch triggers e2e tests in the `deps_builder.go` file.

3. The third patch fixes the import groups in the `supplierquerier.go` file.
<!-- reviewpad:summarize:end -->

## Issue

- #259 

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_develop_and_test`
- [x] **Run E2E tests locally**: `make test_e2e`
- [ ] **Run E2E tests on DevNet`: Add the `devnet-test-e2e` label to the PR. This is VERY expensive, o only do it after all the reviews are complete.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
