### PR TITLE
[Testing, Code Health] refactor: `NewMinedRelay` to shared testutil

### DIFF
--- a/testutil/testrelayer/relays.go
+++ b/testutil/testrelayer/relays.go
@@ -1,0 +1,44 @@
+package testrelayer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/poktroll/pkg/relayer"
+	"github.com/pokt-network/poktroll/pkg/relayer/miner"
+	servicetypes "github.com/pokt-network/poktroll/x/service/types"
+	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
+)
+
+// NewMinedRelay returns a new mined relay with the given session start and end
+// heights on the session header, and the bytes and hash fields populated.
+func NewMinedRelay(
+	t *testing.T,
+	sessionStartHeight int64,
+	sessionEndHeight int64,
+) *relayer.MinedRelay {
+	relay := servicetypes.Relay{
+		Req: &servicetypes.RelayRequest{
+			Meta: &servicetypes.RelayRequestMetadata{
+				SessionHeader: &sessiontypes.SessionHeader{
+					SessionStartBlockHeight: sessionStartHeight,
+					SessionEndBlockHeight:   sessionEndHeight,
+				},
+			},
+		},
+		Res: &servicetypes.RelayResponse{},
+	}
+
+	// TODO_BLOCKER: use canonical codec to serialize the relay
+	relayBz, err := relay.Marshal()
+	require.NoError(t, err)
+
+	relayHash := HashBytes(t, miner.DefaultRelayHasher, relayBz)
+
+	return &relayer.MinedRelay{
+		Relay: relay,
+		Bytes: relayBz,
+		Hash:  relayHash,
+	}
+}


### PR DESCRIPTION
## Summary

### Human Summary

Moves and exports `NewMinedRelay()` test helper to  a `testrelayer` package.

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 13 Dec 23 14:00 UTC
This pull request refactors `NewMinedRelay` to the shared `testutil` package. It moves the function from `pkg/relayer/session/session_test.go` to `testutil/testrelayer/relays.go`. This change simplifies the code structure and promotes code reuse.
<!-- reviewpad:summarize:end -->

## Issue

- #141 
- #250 

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Run E2E tests locally**: `make test_e2e`
- [ ] **Run E2E tests on DevNet`: Add the `devnet-test-e2e` label to the PR. This is VERY expensive, o only do it after all the reviews are complete.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updated documentation and left TODOs throughout the codebase
