### PR TITLE
[Supplier] refactor: proof store indices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/athanorlabs/go-dleq v0.1.0
 	github.com/cometbft/cometbft v0.37.2
 	github.com/cometbft/cometbft-db v0.8.0
-	github.com/cosmos/cosmos-proto v1.0.0-beta.2
 	github.com/cosmos/cosmos-sdk v0.47.3
 	github.com/cosmos/gogoproto v1.4.11
 	github.com/cosmos/ibc-go/v7 v7.1.0
@@ -48,7 +47,6 @@ require (
 	golang.org/x/crypto v0.15.0
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/sync v0.5.0
-	google.golang.org/genproto/googleapis/api v0.0.0-20230913181813-007df8e322eb
 	google.golang.org/grpc v1.59.0
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -92,6 +90,7 @@ require (
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
+	github.com/cosmos/cosmos-proto v1.0.0-beta.2 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/iavl v0.20.0 // indirect
@@ -286,6 +285,7 @@ require (
 	google.golang.org/api v0.143.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230913181813-007df8e322eb // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20230913181813-007df8e322eb // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230920204549-e6e6cdab5c13 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/proto/pocket/supplier/query.proto
+++ b/proto/pocket/supplier/query.proto
@@ -38,10 +38,9 @@ service Query {
     option (google.api.http).get = "/pocket/supplier/claims";
   }
 
-  // TODO_UPNEXT(@Olshansk): Update these endpoints after implementing proof persistence
   // Queries a list of Proof items.
   rpc Proof (QueryGetProofRequest) returns (QueryGetProofResponse) {
-    option (google.api.http).get = "/pocket/supplier/proof/{index}";
+    option (google.api.http).get = "/pocket/supplier/proof/{session_id}/{supplier_address}";
   }
   rpc AllProofs (QueryAllProofsRequest) returns (QueryAllProofsResponse) {
     option (google.api.http).get = "/pocket/supplier/proof";
@@ -99,7 +98,8 @@ message QueryAllClaimsResponse {
 }
 
 message QueryGetProofRequest {
-  string index = 1;
+  string session_id = 1;
+  string supplier_address = 2 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 }
 
 message QueryGetProofResponse {
@@ -108,6 +108,11 @@ message QueryGetProofResponse {
 
 message QueryAllProofsRequest {
   cosmos.base.query.v1beta1.PageRequest pagination = 1;
+  oneof filter {
+    string supplier_address = 2;
+    string session_id = 3;
+    uint64 session_end_height = 4;
+  }
 }
 
 message QueryAllProofsResponse {

--- a/x/supplier/client/cli/flags.go
+++ b/x/supplier/client/cli/flags.go
@@ -1,0 +1,7 @@
+package cli
+
+const (
+	FlagSessionEndHeight = "session-end-height"
+	FlagSessionId        = "session-id"
+	FlagSupplierAddress  = "supplier-address"
+)

--- a/x/supplier/client/cli/query_claim.go
+++ b/x/supplier/client/cli/query_claim.go
@@ -14,12 +14,6 @@ import (
 // Prevent strconv unused error
 var _ = strconv.IntSize
 
-const (
-	FlagSessionEndHeight = "session-end-height"
-	FlagSessionId        = "session-id"
-	FlagSupplierAddress  = "supplier-address"
-)
-
 // AddPaginationFlagsToCmd adds common pagination flags to cmd
 func AddClaimFilterFlags(cmd *cobra.Command) {
 	cmd.Flags().Uint64(FlagSessionEndHeight, 0, "claims whose session ends at this height will be returned")

--- a/x/supplier/client/cli/query_proof.go
+++ b/x/supplier/client/cli/query_proof.go
@@ -43,9 +43,9 @@ $ poktrolld --home=$(POKTROLLD_HOME) q proof list-proofs --supplier-address <sup
 			if err := updateProofsFilter(cmd, req); err != nil {
 				return err
 			}
-			//if err := req.ValidateBasic(); err != nil {
-			//	return err
-			//}
+			if err := req.ValidateBasic(); err != nil {
+				return err
+			}
 
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {

--- a/x/supplier/client/cli/query_proof.go
+++ b/x/supplier/client/cli/query_proof.go
@@ -11,7 +11,7 @@ import (
 )
 
 // AddPaginationFlagsToCmd adds common pagination flags to cmd
-func AddProofFilterFlags(cmd *cobra.Command) {
+func AddProofFilterFlagsToCmd(cmd *cobra.Command) {
 	cmd.Flags().Uint64(FlagSessionEndHeight, 0, "proofs whose session ends at this height will be returned")
 	cmd.Flags().String(FlagSessionId, "", "proofs matching this session id will be returned")
 	cmd.Flags().String(FlagSupplierAddress, "", "proofs submitted by suppliers matching this address will be returned")
@@ -62,7 +62,7 @@ $ poktrolld --home=$(POKTROLLD_HOME) q proof list-proofs --supplier-address <sup
 		},
 	}
 
-	AddProofFilterFlags(cmd)
+	AddProofFilterFlagsToCmd(cmd)
 	flags.AddPaginationFlagsToCmd(cmd, cmd.Use)
 	flags.AddQueryFlagsToCmd(cmd)
 
@@ -113,7 +113,7 @@ $ poktrolld --home=$(POKTROLLD_HOME) q proof show-proofs <session_id> <supplier_
 	return cmd
 }
 
-// updateClaimsFilter updates the claims filter request based on the flags set provided
+// updateClaimsFilter updates the proofs filter request based on the flags set provided
 func updateProofsFilter(cmd *cobra.Command, req *types.QueryAllProofsRequest) error {
 	sessionId, _ := cmd.Flags().GetString(FlagSessionId)
 	supplierAddr, _ := cmd.Flags().GetString(FlagSupplierAddress)

--- a/x/supplier/client/cli/query_proof.go
+++ b/x/supplier/client/cli/query_proof.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
@@ -8,28 +10,50 @@ import (
 	"github.com/pokt-network/poktroll/x/supplier/types"
 )
 
+// AddPaginationFlagsToCmd adds common pagination flags to cmd
+func AddProofFilterFlags(cmd *cobra.Command) {
+	cmd.Flags().Uint64(FlagSessionEndHeight, 0, "proofs whose session ends at this height will be returned")
+	cmd.Flags().String(FlagSessionId, "", "proofs matching this session id will be returned")
+	cmd.Flags().String(FlagSupplierAddress, "", "proofs submitted by suppliers matching this address will be returned")
+}
+
 func CmdListProof() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list-proofs",
 		Short: "list all proofs",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientQueryContext(cmd)
-			if err != nil {
-				return err
-			}
+		Long: `List all the proofs that the node being queried has in its state.
 
+The proofs can be optionally filtered by one of --session-end-height --session-id or --supplier-address flags
+
+Example:
+$ poktrolld --home=$(POKTROLLD_HOME) q proof list-proofs --node $(POCKET_NODE)
+$ poktrolld --home=$(POKTROLLD_HOME) q proof list-proofs --session-id <session_id> --node $(POCKET_NODE)
+$ poktrolld --home=$(POKTROLLD_HOME) q proof list-proofs --session-end-height <session_end_height> --node $(POCKET_NODE)
+$ poktrolld --home=$(POKTROLLD_HOME) q proof list-proofs --supplier-address <supplier_address> --node $(POCKET_NODE)`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
 			pageReq, err := client.ReadPageRequest(cmd.Flags())
 			if err != nil {
 				return err
 			}
 
-			queryClient := types.NewQueryClient(clientCtx)
-
-			params := &types.QueryAllProofsRequest{
+			req := &types.QueryAllProofsRequest{
 				Pagination: pageReq,
 			}
+			if err := updateProofsFilter(cmd, req); err != nil {
+				return err
+			}
+			//if err := req.ValidateBasic(); err != nil {
+			//	return err
+			//}
 
-			res, err := queryClient.AllProofs(cmd.Context(), params)
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := types.NewQueryClient(clientCtx)
+
+			res, err := queryClient.AllProofs(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -38,19 +62,36 @@ func CmdListProof() *cobra.Command {
 		},
 	}
 
+	AddProofFilterFlags(cmd)
 	flags.AddPaginationFlagsToCmd(cmd, cmd.Use)
 	flags.AddQueryFlagsToCmd(cmd)
 
 	return cmd
 }
 
-// TODO_UPNEXT(@Olshansk): Remove the dependency on index which was part of the default scaffolding behaviour
 func CmdShowProof() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show-proof <index>",
-		Short: "shows a proof",
-		Args:  cobra.ExactArgs(1),
+		Use:   "show-proof <session_id> <supplier_addr>",
+		Short: "shows a specific proof",
+		Long: `List a specific proof that the node being queried has access to.
+
+A unique proof can be defined via a session_id that a given supplier participated in.
+
+Example:
+$ poktrolld --home=$(POKTROLLD_HOME) q proof show-proofs <session_id> <supplier_address> --node $(POCKET_NODE)`,
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			sessionId := args[0]
+			supplierAddr := args[1]
+
+			getProofRequest := &types.QueryGetProofRequest{
+				SessionId:       sessionId,
+				SupplierAddress: supplierAddr,
+			}
+			if err := getProofRequest.ValidateBasic(); err != nil {
+				return err
+			}
+
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
 				return err
@@ -58,13 +99,7 @@ func CmdShowProof() *cobra.Command {
 
 			queryClient := types.NewQueryClient(clientCtx)
 
-			argIndex := args[0]
-
-			params := &types.QueryGetProofRequest{
-				Index: argIndex,
-			}
-
-			res, err := queryClient.Proof(cmd.Context(), params)
+			res, err := queryClient.Proof(cmd.Context(), getProofRequest)
 			if err != nil {
 				return err
 			}
@@ -76,4 +111,55 @@ func CmdShowProof() *cobra.Command {
 	flags.AddQueryFlagsToCmd(cmd)
 
 	return cmd
+}
+
+// updateClaimsFilter updates the claims filter request based on the flags set provided
+func updateProofsFilter(cmd *cobra.Command, req *types.QueryAllProofsRequest) error {
+	sessionId, _ := cmd.Flags().GetString(FlagSessionId)
+	supplierAddr, _ := cmd.Flags().GetString(FlagSupplierAddress)
+	sessionEndHeight, _ := cmd.Flags().GetUint64(FlagSessionEndHeight)
+
+	// Preparing a shared error in case more than one flag was set
+	err := fmt.Errorf("can only specify one flag filter but got sessionId (%s), supplierAddr (%s) and sessionEngHeight (%d)", sessionId, supplierAddr, sessionEndHeight)
+
+	// Use the session id as the filter
+	if sessionId != "" {
+		// If the session id is set, then the other flags must not be set
+		if supplierAddr != "" || sessionEndHeight > 0 {
+			return err
+		}
+		// Set the session id filter
+		req.Filter = &types.QueryAllProofsRequest_SessionId{
+			SessionId: sessionId,
+		}
+		return nil
+	}
+
+	// Use the supplier address as the filter
+	if supplierAddr != "" {
+		// If the supplier address is set, then the other flags must not be set
+		if sessionId != "" || sessionEndHeight > 0 {
+			return err
+		}
+		// Set the supplier address filter
+		req.Filter = &types.QueryAllProofsRequest_SupplierAddress{
+			SupplierAddress: supplierAddr,
+		}
+		return nil
+	}
+
+	// Use the session end height as the filter
+	if sessionEndHeight > 0 {
+		// If the session end height is set, then the other flags must not be set
+		if sessionId != "" || supplierAddr != "" {
+			return err
+		}
+		// Set the session end height filter
+		req.Filter = &types.QueryAllProofsRequest_SessionEndHeight{
+			SessionEndHeight: sessionEndHeight,
+		}
+		return nil
+	}
+
+	return nil
 }

--- a/x/supplier/client/cli/tx_submit_proof.go
+++ b/x/supplier/client/cli/tx_submit_proof.go
@@ -29,12 +29,12 @@ func CmdSubmitProof() *cobra.Command {
 			smstProofEncodedStr := args[1]
 
 			// Get the session header
-			cdc := codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
 			sessionHeaderBz, err := base64.StdEncoding.DecodeString(sessionHeaderEncodedStr)
 			if err != nil {
 				return err
 			}
 			sessionHeader := &sessiontypes.SessionHeader{}
+			cdc := codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
 			cdc.MustUnmarshalJSON(sessionHeaderBz, sessionHeader)
 
 			smstProof, err := base64.StdEncoding.DecodeString(smstProofEncodedStr)

--- a/x/supplier/client/cli/tx_submit_proof.go
+++ b/x/supplier/client/cli/tx_submit_proof.go
@@ -2,12 +2,13 @@ package cli
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"strconv"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/cosmos/cosmos-sdk/codec"
+	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/spf13/cobra"
 
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
@@ -24,12 +25,19 @@ func CmdSubmitProof() *cobra.Command {
 		Short: "Broadcast message submit-proof",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			argSessionHeader := new(sessiontypes.SessionHeader)
-			err = json.Unmarshal([]byte(args[0]), argSessionHeader)
+			sessionHeaderEncodedStr := args[0]
+			smstProofEncodedStr := args[1]
+
+			// Get the session header
+			cdc := codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
+			sessionHeaderBz, err := base64.StdEncoding.DecodeString(sessionHeaderEncodedStr)
 			if err != nil {
 				return err
 			}
-			argSmstProof, err := base64.StdEncoding.DecodeString(args[1])
+			sessionHeader := &sessiontypes.SessionHeader{}
+			cdc.MustUnmarshalJSON(sessionHeaderBz, sessionHeader)
+
+			smstProof, err := base64.StdEncoding.DecodeString(smstProofEncodedStr)
 			if err != nil {
 				return err
 			}
@@ -41,8 +49,8 @@ func CmdSubmitProof() *cobra.Command {
 
 			msg := types.NewMsgSubmitProof(
 				clientCtx.GetFromAddress().String(),
-				argSessionHeader,
-				argSmstProof,
+				sessionHeader,
+				smstProof,
 			)
 			if err := msg.ValidateBasic(); err != nil {
 				return err

--- a/x/supplier/keeper/msg_server_create_claim.go
+++ b/x/supplier/keeper/msg_server_create_claim.go
@@ -25,22 +25,6 @@ func (k msgServer) CreateClaim(goCtx context.Context, msg *suppliertypes.MsgCrea
 		return nil, err
 	}
 
-	var found bool
-	for _, supplier := range sessionRes.GetSession().GetSuppliers() {
-		if supplier.Address == msg.GetSupplierAddress() {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		return nil, suppliertypes.ErrSupplierNotFound.Wrapf(
-			"supplier address %q in session ID %q",
-			msg.GetSupplierAddress(),
-			sessionRes.GetSession().GetSessionId(),
-		)
-	}
-
 	logger.
 		With(
 			"session_id", sessionRes.GetSession().GetSessionId(),
@@ -67,6 +51,9 @@ func (k msgServer) CreateClaim(goCtx context.Context, msg *suppliertypes.MsgCrea
 		SessionHeader:   msg.GetSessionHeader(),
 		RootHash:        msg.RootHash,
 	}
+
+	// TODO_TECHDEBT: check if this claim already exists and return an appropriate error
+	// in any case where the supplier should no longer be able to update the given proof.
 	k.Keeper.UpsertClaim(ctx, claim)
 
 	logger.

--- a/x/supplier/keeper/msg_server_create_claim.go
+++ b/x/supplier/keeper/msg_server_create_claim.go
@@ -5,7 +5,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 	suppliertypes "github.com/pokt-network/poktroll/x/supplier/types"
 )
 
@@ -17,30 +16,13 @@ func (k msgServer) CreateClaim(goCtx context.Context, msg *suppliertypes.MsgCrea
 		return nil, err
 	}
 
-	sessionReq := &sessiontypes.QueryGetSessionRequest{
-		ApplicationAddress: msg.GetSessionHeader().GetApplicationAddress(),
-		Service:            msg.GetSessionHeader().GetService(),
-		BlockHeight:        msg.GetSessionHeader().GetSessionStartBlockHeight(),
-	}
-	sessionRes, err := k.Keeper.sessionKeeper.GetSession(goCtx, sessionReq)
+	sessionRes, err := k.ValidateSessionHeader(
+		goCtx,
+		msg.GetSessionHeader(),
+		msg.GetSupplierAddress(),
+	)
 	if err != nil {
 		return nil, err
-	}
-
-	logger.
-		With(
-			"session_id", sessionRes.GetSession().GetSessionId(),
-			"session_end_height", msg.GetSessionHeader().GetSessionEndBlockHeight(),
-			"supplier", msg.GetSupplierAddress(),
-		).
-		Debug("got sessionId for claim")
-
-	if sessionRes.Session.SessionId != msg.SessionHeader.SessionId {
-		return nil, suppliertypes.ErrSupplierInvalidSessionId.Wrapf(
-			"claimed sessionRes ID does not match on-chain sessionRes ID; expected %q, got %q",
-			sessionRes.Session.SessionId,
-			msg.SessionHeader.SessionId,
-		)
 	}
 
 	var found bool

--- a/x/supplier/keeper/msg_server_create_claim.go
+++ b/x/supplier/keeper/msg_server_create_claim.go
@@ -16,7 +16,7 @@ func (k msgServer) CreateClaim(goCtx context.Context, msg *suppliertypes.MsgCrea
 		return nil, err
 	}
 
-	sessionRes, err := k.ValidateSessionHeader(
+	session, err := k.queryAndValidateSessionHeader(
 		goCtx,
 		msg.GetSessionHeader(),
 		msg.GetSupplierAddress(),
@@ -27,7 +27,7 @@ func (k msgServer) CreateClaim(goCtx context.Context, msg *suppliertypes.MsgCrea
 
 	logger.
 		With(
-			"session_id", sessionRes.GetSession().GetSessionId(),
+			"session_id", session.GetSessionId(),
 			"session_end_height", msg.GetSessionHeader().GetSessionEndBlockHeight(),
 			"supplier", msg.GetSupplierAddress(),
 		).

--- a/x/supplier/keeper/proof.go
+++ b/x/supplier/keeper/proof.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -9,52 +11,51 @@ import (
 
 // UpsertProof inserts or updates a specific proof in the store by index.
 func (k Keeper) UpsertProof(ctx sdk.Context, proof types.Proof) {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.ProofKeyPrefix))
-	b := k.cdc.MustMarshal(&proof)
-	// TODO_NEXT(@bryanchriswhite #141): Refactor keys to support multiple indices.
-	store.Set(types.ProofKey(
-		proof.GetSessionHeader().GetSessionId(),
-	), b)
+	logger := k.Logger(ctx).With("method", "UpsertProof")
+
+	proofBz := k.cdc.MustMarshal(&proof)
+	parentStore := ctx.KVStore(k.storeKey)
+
+	primaryStore := prefix.NewStore(parentStore, types.KeyPrefix(types.ProofPrimaryKeyPrefix))
+	sessionId := proof.GetSessionHeader().GetSessionId()
+	primaryKey := types.ProofPrimaryKey(sessionId, proof.GetSupplierAddress())
+	primaryStore.Set(primaryKey, proofBz)
+
+	logger.Info(fmt.Sprintf("upserted proof for supplier %s with primaryKey %s", proof.GetSupplierAddress(), primaryKey))
+
+	// Update the address index: supplierAddress -> [ProofPrimaryKey]
+	addressStoreIndex := prefix.NewStore(parentStore, types.KeyPrefix(types.ProofSupplierAddressPrefix))
+	addressKey := types.ProofSupplierAddressKey(proof.GetSupplierAddress(), primaryKey)
+	addressStoreIndex.Set(addressKey, primaryKey)
+
+	logger.Info(fmt.Sprintf("indexed Proof for supplier %s with primaryKey %s", proof.GetSupplierAddress(), primaryKey))
+
+	// Update the session end height index: sessionEndHeight -> [ProofPrimaryKey]
+	sessionHeightStoreIndex := prefix.NewStore(parentStore, types.KeyPrefix(types.ProofSessionEndHeightPrefix))
+	sessionEndHeight := proof.GetSessionHeader().GetSessionEndBlockHeight()
+	heightKey := types.ProofSupplierEndSessionHeightKey(sessionEndHeight, primaryKey)
+	sessionHeightStoreIndex.Set(heightKey, primaryKey)
 }
 
 // GetProof returns a proof from its index
-func (k Keeper) GetProof(
-	ctx sdk.Context,
-	sessionId string,
-
-) (val types.Proof, found bool) {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.ProofKeyPrefix))
-
-	// TODO_NEXT(@bryanchriswhite #141): Refactor proof keys to support multiple indices.
-	b := store.Get(types.ProofKey(
-		sessionId,
-	))
-	if b == nil {
-		return val, false
-	}
-
-	k.cdc.MustUnmarshal(b, &val)
-	return val, true
+func (k Keeper) GetProof(ctx sdk.Context, sessionId, supplierAdd string) (val types.Proof, found bool) {
+	primaryKey := types.ProofPrimaryKey(sessionId, supplierAdd)
+	return k.getProofByPrimaryKey(ctx, primaryKey)
 }
 
 // RemoveProof removes a proof from the store
-func (k Keeper) RemoveProof(
-	ctx sdk.Context,
-	// TODO_NEXT(@bryanchriswhite #141): Refactor proof keys to support multiple indices.
-	index string,
-
-) {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.ProofKeyPrefix))
-	// TODO_NEXT(@bryanchriswhite #141): Refactor proof keys to support multiple indices.
-	store.Delete(types.ProofKey(
-		index,
-	))
+func (k Keeper) RemoveProof(ctx sdk.Context, sessionId, supplierAddr string) {
+	parentStore := ctx.KVStore(k.storeKey)
+	proofPrimaryStore := prefix.NewStore(parentStore, types.KeyPrefix(types.ProofPrimaryKeyPrefix))
+	proofPrimaryKey := types.ProofPrimaryKey(sessionId, supplierAddr)
+	proofPrimaryStore.Delete(proofPrimaryKey)
 }
 
 // GetAllProofs returns all proof
 func (k Keeper) GetAllProofs(ctx sdk.Context) (list []types.Proof) {
-	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.ProofKeyPrefix))
-	iterator := sdk.KVStorePrefixIterator(store, []byte{})
+	parentStore := ctx.KVStore(k.storeKey)
+	primaryStore := prefix.NewStore(parentStore, types.KeyPrefix(types.ProofPrimaryKeyPrefix))
+	iterator := sdk.KVStorePrefixIterator(primaryStore, []byte{})
 
 	defer iterator.Close()
 
@@ -65,4 +66,17 @@ func (k Keeper) GetAllProofs(ctx sdk.Context) (list []types.Proof) {
 	}
 
 	return
+}
+
+// getProofByPrimaryKey is a helper that retrieves, if exists, the Proof associated with the key provided
+func (k Keeper) getProofByPrimaryKey(ctx sdk.Context, primaryKey []byte) (val types.Proof, found bool) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.ProofPrimaryKeyPrefix))
+
+	proofBz := store.Get(primaryKey)
+	if proofBz == nil {
+		return val, false
+	}
+
+	k.cdc.MustUnmarshal(proofBz, &val)
+	return val, true
 }

--- a/x/supplier/keeper/proof.go
+++ b/x/supplier/keeper/proof.go
@@ -16,6 +16,7 @@ func (k Keeper) UpsertProof(ctx sdk.Context, proof types.Proof) {
 	proofBz := k.cdc.MustMarshal(&proof)
 	parentStore := ctx.KVStore(k.storeKey)
 
+	// Update the primary store containing the proof object.
 	primaryStore := prefix.NewStore(parentStore, types.KeyPrefix(types.ProofPrimaryKeyPrefix))
 	sessionId := proof.GetSessionHeader().GetSessionId()
 	primaryKey := types.ProofPrimaryKey(sessionId, proof.GetSupplierAddress())

--- a/x/supplier/keeper/proof_test.go
+++ b/x/supplier/keeper/proof_test.go
@@ -45,8 +45,10 @@ func TestProofGet(t *testing.T) {
 	keeper, ctx := keepertest.SupplierKeeper(t, nil)
 	proofs := createNProofs(keeper, ctx, 10)
 	for _, proof := range proofs {
-		rst, found := keeper.GetProof(ctx,
+		rst, found := keeper.GetProof(
+			ctx,
 			proof.GetSessionHeader().GetSessionId(),
+			proof.GetSupplierAddress(),
 		)
 		require.True(t, found)
 		require.Equal(t,
@@ -57,14 +59,11 @@ func TestProofGet(t *testing.T) {
 }
 func TestProofRemove(t *testing.T) {
 	keeper, ctx := keepertest.SupplierKeeper(t, nil)
-	items := createNProofs(keeper, ctx, 10)
-	for _, item := range items {
-		keeper.RemoveProof(ctx,
-			item.GetSessionHeader().GetSessionId(),
-		)
-		_, found := keeper.GetProof(ctx,
-			item.GetSessionHeader().GetSessionId(),
-		)
+	proofs := createNProofs(keeper, ctx, 10)
+	for _, proof := range proofs {
+		sessionId := proof.GetSessionHeader().GetSessionId()
+		keeper.RemoveProof(ctx, sessionId, proof.GetSupplierAddress())
+		_, found := keeper.GetProof(ctx, sessionId, proof.GetSupplierAddress())
 		require.False(t, found)
 	}
 }

--- a/x/supplier/keeper/query_proof.go
+++ b/x/supplier/keeper/query_proof.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -17,19 +18,57 @@ func (k Keeper) AllProofs(goCtx context.Context, req *types.QueryAllProofsReques
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
-	var proofs []types.Proof
+	if err := req.ValidateBasic(); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	ctx := sdk.UnwrapSDKContext(goCtx)
-
 	store := ctx.KVStore(k.storeKey)
-	proofStore := prefix.NewStore(store, types.KeyPrefix(types.ProofKeyPrefix))
 
+	var (
+		// isCustomIndex is used to determined if we'll be using the store that points
+		// to the actual Claim values, or a secondary index that points to the primary keys.
+		isCustomIndex bool
+		keyPrefix     []byte
+	)
+
+	switch filter := req.Filter.(type) {
+	case *types.QueryAllProofsRequest_SupplierAddress:
+		isCustomIndex = true
+		keyPrefix = types.KeyPrefix(types.ProofSupplierAddressPrefix)
+		keyPrefix = append(keyPrefix, []byte(filter.SupplierAddress)...)
+	case *types.QueryAllProofsRequest_SessionEndHeight:
+		isCustomIndex = true
+		keyPrefix = types.KeyPrefix(types.ProofSessionEndHeightPrefix)
+		keyPrefix = append(keyPrefix, []byte(fmt.Sprintf("%d", filter.SessionEndHeight))...)
+	case *types.QueryAllProofsRequest_SessionId:
+		isCustomIndex = false
+		keyPrefix = types.KeyPrefix(types.ProofPrimaryKeyPrefix)
+		keyPrefix = append(keyPrefix, []byte(filter.SessionId)...)
+	default:
+		isCustomIndex = false
+		keyPrefix = types.KeyPrefix(types.ProofPrimaryKeyPrefix)
+	}
+	proofStore := prefix.NewStore(store, keyPrefix)
+
+	var proofs []types.Proof
 	pageRes, err := query.Paginate(proofStore, req.Pagination, func(key []byte, value []byte) error {
-		var proof types.Proof
-		if err := k.cdc.Unmarshal(value, &proof); err != nil {
-			return err
+		if isCustomIndex {
+			// We retrieve the primaryKey, and need to query the actual proof before decoding it.
+			proof, proofFound := k.getProofByPrimaryKey(ctx, value)
+			if proofFound {
+				proofs = append(proofs, proof)
+			}
+		} else {
+			// The value is an encoded proof.
+			var proof types.Proof
+			if err := k.cdc.Unmarshal(value, &proof); err != nil {
+				return err
+			}
+
+			proofs = append(proofs, proof)
 		}
 
-		proofs = append(proofs, proof)
 		return nil
 	})
 
@@ -42,16 +81,20 @@ func (k Keeper) AllProofs(goCtx context.Context, req *types.QueryAllProofsReques
 
 func (k Keeper) Proof(goCtx context.Context, req *types.QueryGetProofRequest) (*types.QueryGetProofResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		err := types.ErrSupplierInvalidQueryRequest.Wrap("request cannot be nil")
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+
+	if err := req.ValidateBasic(); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	val, found := k.GetProof(
-		ctx,
-		req.Index,
-	)
+	val, found := k.GetProof(ctx, req.GetSessionId(), req.GetSupplierAddress())
 	if !found {
-		return nil, status.Error(codes.NotFound, "not found")
+		err := types.ErrSupplierProofNotFound.Wrapf("session ID %q and supplier %q", req.SessionId, req.SupplierAddress)
+		return nil, status.Error(codes.NotFound, err.Error())
 	}
 
 	return &types.QueryGetProofResponse{Proof: val}, nil

--- a/x/supplier/keeper/query_proof_test.go
+++ b/x/supplier/keeper/query_proof_test.go
@@ -12,6 +12,7 @@ import (
 
 	keepertest "github.com/pokt-network/poktroll/testutil/keeper"
 	"github.com/pokt-network/poktroll/testutil/nullify"
+	"github.com/pokt-network/poktroll/testutil/sample"
 	"github.com/pokt-network/poktroll/x/supplier/types"
 )
 
@@ -21,44 +22,117 @@ var _ = strconv.IntSize
 func TestProofQuerySingle(t *testing.T) {
 	keeper, ctx := keepertest.SupplierKeeper(t, nil)
 	wctx := sdk.WrapSDKContext(ctx)
-	msgs := createNProofs(keeper, ctx, 2)
+	proofs := createNProofs(keeper, ctx, 2)
+
+	var randSupplierAddr = sample.AccAddress()
 	tests := []struct {
-		desc     string
-		request  *types.QueryGetProofRequest
-		response *types.QueryGetProofResponse
-		err      error
+		desc string
+
+		request *types.QueryGetProofRequest
+
+		response    *types.QueryGetProofResponse
+		expectedErr error
 	}{
 		{
 			desc: "First",
 			request: &types.QueryGetProofRequest{
-				Index: msgs[0].GetSessionHeader().GetSessionId(),
+				SessionId:       proofs[0].GetSessionHeader().GetSessionId(),
+				SupplierAddress: proofs[0].SupplierAddress,
 			},
-			response: &types.QueryGetProofResponse{Proof: msgs[0]},
+			response: &types.QueryGetProofResponse{Proof: proofs[0]},
 		},
 		{
 			desc: "Second",
 			request: &types.QueryGetProofRequest{
-				Index: msgs[1].GetSessionHeader().GetSessionId(),
+				SessionId:       proofs[1].GetSessionHeader().GetSessionId(),
+				SupplierAddress: proofs[1].SupplierAddress,
 			},
-			response: &types.QueryGetProofResponse{Proof: msgs[1]},
+			response: &types.QueryGetProofResponse{Proof: proofs[1]},
 		},
 		{
-			desc: "KeyNotFound",
+			desc: "Proof Not Found - Random SessionId",
+
 			request: &types.QueryGetProofRequest{
-				Index: strconv.Itoa(100000),
+				SessionId:       "not a real session id",
+				SupplierAddress: proofs[0].GetSupplierAddress(),
 			},
-			err: status.Error(codes.NotFound, "not found"),
+
+			expectedErr: status.Error(
+				codes.NotFound,
+				types.ErrSupplierProofNotFound.Wrapf(
+					"session ID %q and supplier %q",
+					"not a real session id",
+					proofs[0].GetSupplierAddress(),
+				).Error(),
+			),
 		},
 		{
-			desc: "InvalidRequest",
-			err:  status.Error(codes.InvalidArgument, "invalid request"),
+			desc: "Proof Not Found - Random Supplier Address",
+
+			request: &types.QueryGetProofRequest{
+				SessionId:       proofs[0].GetSessionHeader().GetSessionId(),
+				SupplierAddress: randSupplierAddr,
+			},
+
+			expectedErr: status.Error(
+				codes.NotFound,
+				types.ErrSupplierProofNotFound.Wrapf(
+					"session ID %q and supplier %q",
+					proofs[0].GetSessionHeader().GetSessionId(),
+					randSupplierAddr,
+				).Error(),
+			),
+		},
+		{
+			desc: "InvalidRequest - Missing SessionId",
+			request: &types.QueryGetProofRequest{
+				// SessionId:       Intentionally Omitted
+				SupplierAddress: proofs[0].GetSupplierAddress(),
+			},
+
+			expectedErr: status.Error(
+				codes.InvalidArgument,
+				types.ErrSupplierInvalidSessionId.Wrapf(
+					"invalid session ID for proof being retrieved %s",
+					"",
+				).Error(),
+			),
+		},
+		{
+			desc: "InvalidRequest - Missing SupplierAddress",
+			request: &types.QueryGetProofRequest{
+				SessionId: proofs[0].GetSessionHeader().GetSessionId(),
+				// SupplierAddress: Intentionally Omitted,
+			},
+
+			expectedErr: status.Error(
+				codes.InvalidArgument,
+				types.ErrSupplierInvalidAddress.Wrap(
+					"invalid supplier address for proof being retrieved ; (empty address string is not allowed)",
+				).Error(),
+			),
+		},
+		{
+			desc:    "InvalidRequest - nil QueryGetProofRequest",
+			request: nil,
+
+			expectedErr: status.Error(
+				codes.InvalidArgument,
+				types.ErrSupplierInvalidQueryRequest.Wrap(
+					"request cannot be nil",
+				).Error(),
+			),
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			response, err := keeper.Proof(wctx, tc.request)
-			if tc.err != nil {
-				require.ErrorIs(t, err, tc.err)
+			if tc.expectedErr != nil {
+				actualStatus, ok := status.FromError(err)
+				require.True(t, ok)
+
+				require.ErrorIs(t, actualStatus.Err(), tc.expectedErr)
+				require.ErrorContains(t, err, tc.expectedErr.Error())
 			} else {
 				require.NoError(t, err)
 				require.Equal(t,

--- a/x/supplier/keeper/session.go
+++ b/x/supplier/keeper/session.go
@@ -9,6 +9,8 @@ import (
 	suppliertypes "github.com/pokt-network/poktroll/x/supplier/types"
 )
 
+// ValidateSessionHeader ensures that a session with the sessionID of the given session
+// header exists and that this session includes the supplier with the given address.
 func (k msgServer) ValidateSessionHeader(
 	goCtx context.Context,
 	sessionHeader *sessiontypes.SessionHeader,
@@ -42,5 +44,22 @@ func (k msgServer) ValidateSessionHeader(
 			sessionHeader.SessionId,
 		)
 	}
+
+	var found bool
+	for _, supplier := range sessionRes.GetSession().GetSuppliers() {
+		if supplier.Address == supplierAddr {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return nil, suppliertypes.ErrSupplierNotFound.Wrapf(
+			"supplier address %q in session ID %q",
+			supplierAddr,
+			sessionRes.GetSession().GetSessionId(),
+		)
+	}
+
 	return sessionRes, nil
 }

--- a/x/supplier/keeper/session.go
+++ b/x/supplier/keeper/session.go
@@ -44,11 +44,17 @@ func (k msgServer) queryAndValidateSessionHeader(
 	// Ensure that the given session header's session ID matches the on-chain onChainSession ID.
 	if sessionHeader.GetSessionId() != onChainSession.GetSessionId() {
 		return nil, suppliertypes.ErrSupplierInvalidSessionId.Wrapf(
-			"claimed onChainSession ID does not match on-chain onChainSession ID; expected %q, got %q",
+			"session ID does not match on-chain session ID; expected %q, got %q",
 			onChainSession.GetSessionId(),
 			sessionHeader.GetSessionId(),
 		)
 	}
+
+	// NB: it is redundant to assert that the service ID in the request matches the
+	// on-chain session service ID because the session is queried using the service
+	// ID as a parameter. Either a different session (i.e. different session ID)
+	// or an error would be returned depending on whether an application/supplier
+	// pair exists for the given service ID or not, respectively.
 
 	// Ensure the given supplier is in the onChainSession supplier list.
 	var found bool
@@ -60,9 +66,9 @@ func (k msgServer) queryAndValidateSessionHeader(
 	}
 	if !found {
 		return nil, suppliertypes.ErrSupplierNotFound.Wrapf(
-			"supplier address %q in onChainSession ID %q",
+			"supplier address %q not found in session ID %q",
 			supplierAddr,
-			onChainSession.GetSessionId(),
+			sessionHeader.GetSessionId(),
 		)
 	}
 	return onChainSession, nil

--- a/x/supplier/keeper/session.go
+++ b/x/supplier/keeper/session.go
@@ -1,0 +1,46 @@
+package keeper
+
+import (
+	"context"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
+	suppliertypes "github.com/pokt-network/poktroll/x/supplier/types"
+)
+
+func (k msgServer) ValidateSessionHeader(
+	goCtx context.Context,
+	sessionHeader *sessiontypes.SessionHeader,
+	supplierAddr string,
+) (*sessiontypes.QueryGetSessionResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	logger := k.Logger(ctx).With("method", "SubmitProof")
+
+	sessionReq := &sessiontypes.QueryGetSessionRequest{
+		ApplicationAddress: sessionHeader.GetApplicationAddress(),
+		Service:            sessionHeader.GetService(),
+		BlockHeight:        sessionHeader.GetSessionStartBlockHeight(),
+	}
+
+	sessionRes, err := k.Keeper.sessionKeeper.GetSession(goCtx, sessionReq)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.
+		With(
+			"session_id", sessionRes.GetSession().GetSessionId(),
+			"session_end_height", sessionHeader.GetSessionEndBlockHeight(),
+			"supplier", supplierAddr,
+		).
+		Debug("got sessionId for proof")
+	if sessionRes.Session.SessionId != sessionHeader.SessionId {
+		return nil, suppliertypes.ErrSupplierInvalidSessionId.Wrapf(
+			"claimed sessionRes ID does not match on-chain sessionRes ID; expected %q, got %q",
+			sessionRes.Session.SessionId,
+			sessionHeader.SessionId,
+		)
+	}
+	return sessionRes, nil
+}

--- a/x/supplier/types/key_proof.go
+++ b/x/supplier/types/key_proof.go
@@ -5,20 +5,32 @@ import "encoding/binary"
 var _ binary.ByteOrder
 
 const (
-	// ProofKeyPrefix is the prefix to retrieve all Proof
-	ProofKeyPrefix = "Proof/value/"
+	// ProofPrimaryKeyPrefix is the prefix to retrieve the entire Proof object (the primary store)
+	ProofPrimaryKeyPrefix = "Proof/value/"
+
+	// ProofSupplierAddressPrefix is the key to retrieve a Proof's Primary Key from the Address index
+	ProofSupplierAddressPrefix = "Proof/address/"
+
+	// ProofSessionEndHeightPrefix is the key to retrieve a Proof's Primary Key from the Height index
+	ProofSessionEndHeightPrefix = "Proof/height/"
 )
 
-// ProofKey returns the store key to retrieve a Proof from the index fields
-// TODO_UPNEXT(@Olshansk): Implement a similar indexing strategy for Proofs as we do for Claims
-func ProofKey(
-	index string,
-) []byte {
-	var key []byte
+// ProofPrimaryKey returns the primary store key used to retrieve a Proof by creating a composite key of the sessionId and supplierAddr.
+func ProofPrimaryKey(sessionId, supplierAddr string) []byte {
+	// We are guaranteed uniqueness of the primary key if it's a composite of the (sessionId, supplierAddr).
+	// because every supplier can only have one Proof per session.
+	return KeyComposite([]byte(sessionId), []byte(supplierAddr))
+}
 
-	indexBytes := []byte(index)
-	key = append(key, indexBytes...)
-	key = append(key, []byte("/")...)
+// ProofSupplierAddressKey returns the key used to iterate through Proofs given a supplier Address.
+func ProofSupplierAddressKey(supplierAddr string, primaryKey []byte) []byte {
+	return KeyComposite([]byte(supplierAddr), primaryKey)
+}
 
-	return key
+// ProofSupplierEndSessionHeightKey returns the key used to iterate through Proofs given a session end height.
+func ProofSupplierEndSessionHeightKey(sessionEndHeight int64, primaryKey []byte) []byte {
+	heightBz := make([]byte, 8)
+	binary.BigEndian.PutUint64(heightBz, uint64(sessionEndHeight))
+
+	return KeyComposite(heightBz, primaryKey)
 }

--- a/x/supplier/types/query_validation.go
+++ b/x/supplier/types/query_validation.go
@@ -47,7 +47,43 @@ func (query *QueryAllClaimsRequest) ValidateBasic() error {
 		if filter.SessionEndHeight < 0 {
 			return ErrSupplierInvalidSessionEndHeight.Wrapf("invalid session end height for claims being retrieved %d", filter.SessionEndHeight)
 		}
+	}
+	return nil
+}
 
+func (query *QueryGetProofRequest) ValidateBasic() error {
+	// Validate the supplier address
+	if _, err := sdk.AccAddressFromBech32(query.SupplierAddress); err != nil {
+		return ErrSupplierInvalidAddress.Wrapf("invalid supplier address for proof being retrieved %s; (%v)", query.SupplierAddress, err)
+	}
+
+	// TODO_TECHDEBT: Validate the session ID once we have a deterministic way to generate it
+	if query.SessionId == "" {
+		return ErrSupplierInvalidSessionId.Wrapf("invalid session ID for proof being retrieved %s", query.SessionId)
+	}
+	return nil
+}
+
+func (query *QueryAllProofsRequest) ValidateBasic() error {
+	// TODO_TECHDEBT: update function signature to receive a context.
+	logger := polylog.Ctx(context.TODO())
+
+	switch filter := query.Filter.(type) {
+	case *QueryAllProofsRequest_SupplierAddress:
+		if _, err := sdk.AccAddressFromBech32(filter.SupplierAddress); err != nil {
+			return ErrSupplierInvalidAddress.Wrapf("invalid supplier address for proofs being retrieved %s; (%v)", filter.SupplierAddress, err)
+		}
+
+	case *QueryAllProofsRequest_SessionId:
+		// TODO_TECHDEBT: Validate the session ID once we have a deterministic way to generate it
+		logger.Warn().
+			Str("session_id", filter.SessionId).
+			Msg("TODO: SessionID check is currently a noop")
+
+	case *QueryAllProofsRequest_SessionEndHeight:
+		if filter.SessionEndHeight < 0 {
+			return ErrSupplierInvalidSessionEndHeight.Wrapf("invalid session end height for proofs being retrieved %d", filter.SessionEndHeight)
+		}
 	default:
 		// No filter is set
 		logger.Debug().Msg("No specific filter set when requesting claims")


### PR DESCRIPTION
## Summary

### Human Summary

Refactors on-chain proof store to support multiple indices/stores in the multistore (similar to claims): "primary key", "supplier address", and "session end block height".

## Issue

- #141 
- #263
- #264
- #265 
- #289
- #290 
- #285
- :point_right: THIS PR :point_left: 
- #250

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Run E2E tests locally**: `make test_e2e`
- [ ] **Run E2E tests on DevNet**: Add the `devnet-test-e2e` label to the PR. This is VERY expensive, o only do it after all the reviews are complete.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updated documentation and left TODOs throughout the codebase
