### PR TITLE
[Tooling] fix: PR template typo 2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,7 +45,7 @@ Select one or more:
 
 - [ ] **Run all unit tests**: `make go_develop_and_test`
 - [ ] **Run E2E tests locally**: `make test_e2e`
-- [ ] **Run E2E tests on DevNet**: Add the `devnet-test-e2e` label to the PR. This is VERY expensive, o only do it after all the reviews are complete.
+- [ ] **Run E2E tests on DevNet**: Add the `devnet-test-e2e` label to the PR. This is VERY expensive, only do it after all the reviews are complete.
 
 ## Sanity Checklist
 


### PR DESCRIPTION

## Summary

### Human Summary

One more typo in the PR template.

## Issue

N/A

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Run E2E tests locally**: `make test_e2e`
- [ ] **Run E2E tests on DevNet**: Add the `devnet-test-e2e` label to the PR. This is VERY expensive, o only do it after all the reviews are complete.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
