### PR TITLE
feat: goimports-reviser script

### DIFF
--- a/pkg/appgateserver/config/errors.go
+++ b/pkg/appgateserver/config/errors.go
@@ -1,6 +1,8 @@
 package config
 
-import sdkerrors "cosmossdk.io/errors"
+import (
+	sdkerrors "cosmossdk.io/errors"
+)
 
 var (
 	codespace                                = "appgate_config"

--- a/pkg/appgateserver/errors.go
+++ b/pkg/appgateserver/errors.go
@@ -1,6 +1,8 @@
 package appgateserver
 
-import sdkerrors "cosmossdk.io/errors"
+import (
+	sdkerrors "cosmossdk.io/errors"
+)
 
 var (
 	codespace                           = "appgateserver"

--- a/pkg/client/keyring/errors.go
+++ b/pkg/client/keyring/errors.go
@@ -1,6 +1,8 @@
 package keyring
 
-import "cosmossdk.io/errors"
+import (
+	"cosmossdk.io/errors"
+)
 
 var (
 	// ErrEmptySigningKeyName represents an error which indicates that the

--- a/pkg/client/tx/errors.go
+++ b/pkg/client/tx/errors.go
@@ -1,6 +1,8 @@
 package tx
 
-import errorsmod "cosmossdk.io/errors"
+import (
+	errorsmod "cosmossdk.io/errors"
+)
 
 var (
 	// ErrInvalidMsg signifies that there was an issue in validating the

--- a/pkg/observable/errors.go
+++ b/pkg/observable/errors.go
@@ -1,6 +1,8 @@
 package observable
 
-import errorsmod "cosmossdk.io/errors"
+import (
+	errorsmod "cosmossdk.io/errors"
+)
 
 var (
 	ErrObserverClosed = errorsmod.Register(codespace, 1, "observer is closed")

--- a/pkg/observable/interface.go
+++ b/pkg/observable/interface.go
@@ -1,6 +1,8 @@
 package observable
 
-import "context"
+import (
+	"context"
+)
 
 // NOTE: We explicitly decided to write a small and custom notifications package
 // to keep logic simple and minimal. If the needs & requirements of this library ever

--- a/pkg/polylog/context.go
+++ b/pkg/polylog/context.go
@@ -1,6 +1,8 @@
 package polylog
 
-import "context"
+import (
+	"context"
+)
 
 // CtxKey is the key used to store the polylog.Logger in a context.Context. This
 // is **independant** of any logger-implementation-specific context key that may

--- a/pkg/relayer/config/errors.go
+++ b/pkg/relayer/config/errors.go
@@ -1,6 +1,8 @@
 package config
 
-import sdkerrors "cosmossdk.io/errors"
+import (
+	sdkerrors "cosmossdk.io/errors"
+)
 
 var (
 	codespace                                 = "relayminer_config"

--- a/pkg/relayer/miner/gen/template.go
+++ b/pkg/relayer/miner/gen/template.go
@@ -1,6 +1,8 @@
 package main
 
-import "text/template"
+import (
+	"text/template"
+)
 
 var (
 	relayFixtureLineFmt   = "\t\t\"%x\","

--- a/pkg/relayer/protocol/errors.go
+++ b/pkg/relayer/protocol/errors.go
@@ -1,6 +1,8 @@
 package protocol
 
-import errorsmod "cosmossdk.io/errors"
+import (
+	errorsmod "cosmossdk.io/errors"
+)
 
 var (
 	ErrDifficulty = errorsmod.New(codespace, 1, "difficulty error")

--- a/pkg/relayer/session/errors.go
+++ b/pkg/relayer/session/errors.go
@@ -1,6 +1,8 @@
 package session
 
-import sdkerrors "cosmossdk.io/errors"
+import (
+	sdkerrors "cosmossdk.io/errors"
+)
 
 var (
 	codespace                              = "relayer_session"

--- a/pkg/sdk/errors.go
+++ b/pkg/sdk/errors.go
@@ -1,6 +1,8 @@
 package sdk
 
-import sdkerrors "cosmossdk.io/errors"
+import (
+	sdkerrors "cosmossdk.io/errors"
+)
 
 var (
 	codespace                           = "poktrollsdk"

--- a/pkg/sdk/urls.go
+++ b/pkg/sdk/urls.go
@@ -1,6 +1,8 @@
 package sdk
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // HostToWebsocketURL converts the provided host into a websocket URL that can
 // be used to subscribe to onchain events and query the chain via a client

--- a/pkg/signer/simple_signer.go
+++ b/pkg/signer/simple_signer.go
@@ -1,6 +1,8 @@
 package signer
 
-import "github.com/cosmos/cosmos-sdk/crypto/keyring"
+import (
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+)
 
 var _ Signer = (*SimpleSigner)(nil)
 

--- a/testutil/testerrors/require.go
+++ b/testutil/testerrors/require.go
@@ -1,6 +1,8 @@
 package testerrors
 
-import errorsmod "cosmossdk.io/errors"
+import (
+	errorsmod "cosmossdk.io/errors"
+)
 
 var (
 	// ErrAsync is returned when a test assertion fails in a goroutine other than

--- a/testutil/testkeyring/gen_accounts/template.go
+++ b/testutil/testkeyring/gen_accounts/template.go
@@ -2,7 +2,9 @@
 
 package main
 
-import "text/template"
+import (
+	"text/template"
+)
 
 var (
 	preGeneratedAccountLineFmt = "\t\tmustParsePreGeneratedAccount(%q),"

--- a/testutil/yaml/yaml.go
+++ b/testutil/yaml/yaml.go
@@ -1,6 +1,8 @@
 package yaml
 
-import "strings"
+import (
+	"strings"
+)
 
 // YAML is indentation sensitive, so we need to remove the extra indentation from the test cases and make sure
 // it is space-indented instead of tab-indented, otherwise the YAML parser will fail

--- a/tools/scripts/goimports-revisor.sh
+++ b/tools/scripts/goimports-revisor.sh
@@ -4,23 +4,15 @@ FLAGS=(
     -rm-unused
     -use-cache
     -imports-order "std,general,company,project,blanked,dotted"
-    -project-name "github.com/pokt-network/poktroll"
+    -project-name "github.com/pokt-network/poktrolld"
 )
 
-# String to check within the import block
-EXCLUDE_STRING="this line is used by starport scaffolding"
-
-# Define a function to check for the exclusion comment within the import block and run goimports-reviser
+# Define a function to check for the exclusion comment and run goimports-reviser
 process_file() {
     local file=$1
-    echo "Checking $file"
-
-    # Extract the import block and check if it contains the exclude string
-    if ! awk '/import \(/{flag=1;next}/\)/{flag=0}flag' "$file" | grep -q "$EXCLUDE_STRING"; then
+    if ! grep -q "//go:build ignore" "$file"; then
         echo "Processing $file"
         goimports-reviser "${FLAGS[@]}" "$file"
-    else
-        echo "Skipping $file due to exclusion string within import block"
     fi
 }
 

--- a/tools/scripts/goimports-revisor.sh
+++ b/tools/scripts/goimports-revisor.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+FLAGS=(
+    -rm-unused
+    -use-cache
+    -imports-order "std,general,company,project,blanked,dotted"
+    -project-name "github.com/pokt-network/poktroll"
+)
+
+# String to check within the import block
+EXCLUDE_STRING="this line is used by starport scaffolding"
+
+# Define a function to check for the exclusion comment within the import block and run goimports-reviser
+process_file() {
+    local file=$1
+    echo "Checking $file"
+
+    # Extract the import block and check if it contains the exclude string
+    if ! awk '/import \(/{flag=1;next}/\)/{flag=0}flag' "$file" | grep -q "$EXCLUDE_STRING"; then
+        echo "Processing $file"
+        goimports-reviser "${FLAGS[@]}" "$file"
+    else
+        echo "Skipping $file due to exclusion string within import block"
+    fi
+}
+
+export -f process_file
+
+# Find all .go files, excluding specified patterns, and process them
+find . -type f -name '*.go' \
+    ! -path "./vendors/*" \
+    ! -path "./ts-client/*" \
+    ! -path "./.git/*" \
+    ! -path "./.github/*" \
+    ! -path "./bin/*" \
+    ! -path "./docs/*" \
+    ! -path "./localnet/*" \
+    ! -path "./proto/*" \
+    ! -path "./tools/*" \
+    ! -name "*mock.go" \
+    ! -name "*pb.go" \
+    -exec bash -c 'process_file "$0"' {} \;

--- a/tools/scripts/restore-scaffold-lines.sh
+++ b/tools/scripts/restore-scaffold-lines.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# The line to be restored
+RESTORE_LINE="// this line is used by starport scaffolding # root/moduleImport"
+
+# The pattern after which the line should be restored (modify this as needed)
+PATTERN="import ("
+
+# Function to restore the line in a file
+restore_line() {
+    local file=$1
+    local temp_file=$(mktemp)
+
+    # Flag to indicate if the line has been restored
+    local restored=0
+
+    # Read the file line by line
+    while IFS= read -r line; do
+        echo "$line" >> "$temp_file"
+        # Check if the line matches the pattern
+        if [[ $line == *"$PATTERN"* ]]; then
+            # Add the RESTORE_LINE after the pattern
+            echo "$RESTORE_LINE" >> "$temp_file"
+            restored=1
+        fi
+    done < "$file"
+
+    # Replace the original file with the temp file
+    mv "$temp_file" "$file"
+}
+
+# Process each file changed in the git diff
+git diff --name-only | while IFS= read -r file; do
+    # Check if the file is a .go file and the specific line was deleted
+    if [[ $file == *.go ]] && git diff "$file" | grep -q "^\-.*$RESTORE_LINE"; then
+        echo "Restoring line in $file"
+        restore_line "$file"
+    fi
+done

--- a/x/application/client/config/errors.go
+++ b/x/application/client/config/errors.go
@@ -1,6 +1,8 @@
 package config
 
-import sdkerrors "cosmossdk.io/errors"
+import (
+	sdkerrors "cosmossdk.io/errors"
+)
 
 var (
 	codespace                            = "applicationconfig"

--- a/x/application/types/key_application.go
+++ b/x/application/types/key_application.go
@@ -1,6 +1,8 @@
 package types
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+)
 
 var _ binary.ByteOrder
 

--- a/x/gateway/types/key_gateway.go
+++ b/x/gateway/types/key_gateway.go
@@ -1,6 +1,8 @@
 package types
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+)
 
 var _ binary.ByteOrder
 

--- a/x/service/types/relay.go
+++ b/x/service/types/relay.go
@@ -1,6 +1,8 @@
 package types
 
-import "crypto/sha256"
+import (
+	"crypto/sha256"
+)
 
 // getSignableBytes returns the bytes resulting from marshaling the relay request
 // A value receiver is used to avoid overwriting any pre-existing signature

--- a/x/supplier/client/config/errors.go
+++ b/x/supplier/client/config/errors.go
@@ -1,6 +1,8 @@
 package config
 
-import sdkerrors "cosmossdk.io/errors"
+import (
+	sdkerrors "cosmossdk.io/errors"
+)
 
 var (
 	codespace                              = "supplierconfig"

--- a/x/supplier/types/key_proof.go
+++ b/x/supplier/types/key_proof.go
@@ -1,6 +1,8 @@
 package types
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+)
 
 var _ binary.ByteOrder
 

--- a/x/supplier/types/key_supplier.go
+++ b/x/supplier/types/key_supplier.go
@@ -1,6 +1,8 @@
 package types
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+)
 
 var _ binary.ByteOrder
 


### PR DESCRIPTION
## Summary

<!-- README: DELETE THIS COMMENT BLOCK after
      - Provide a quick summary of the changes yourself
      - Let reviewpad summarize your PR under AI summary
      - You can leave a `/reviewpad summarize` comment at any time to trigger it manually.
-->

### Human Summary

Add bash script to add goimports-reviser import grouping excluding files where scaffolding comments are in the import area. This may need to be improved upon in fututre but its a start at least.

I also include all the changes it makes.

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 17 Dec 23 01:52 UTC
This pull request includes the following changes:

1. The file `relay.go`:
- The import statement for `"crypto/sha256"` has been updated to be imported within parentheses.
- The function `getSignableBytes` has not been modified.

2. The file `pkg/relayer/session/errors.go`:
- A new import block has been added that includes the package `cosmossdk.io/errors`.
- The variable `codespace` now has the value `"relayer_session"`.

3. The file `require.go` in the `testutil/testerrors` package:
- The package `errorsmod` from the import statement `cosmossdk.io/errors` has been imported.
- The import statements have been slightly modified to use parentheses for multiple imports.

4. The file `template.go` in the `testutil/testkeyring/gen_accounts` package:
- An import statement for `text/template` was added.
- The import statements are now surrounded by parentheses.
- The variable `preGeneratedAccountLineFmt` was not modified.

5. The file `errors.go`:
- The import statement for the package `cosmossdk.io/errors` has been modified to be imported in a separate block using parentheses.
- The changes have been made in the `config`, `pkg/sdk`, `appgateserver`, `pkg/appgateserver/config`, `pkg/client/keyring/errors.go`, `x/supplier/types/key_proof.go`, `pkg/client/tx`, `x/supplier/client/config`, `pkg/client/keyring/errors.go`, `pkg/client/tx`, `urls.go`, and `pkg/signer` packages.

6. The file `yaml.go`:
- The import statement for the "strings" package has been updated to use parentheses for multiple imports.
- The code comment has been modified to provide additional explanation about the YAML format and the need for proper indentation.

7. The file `x/supplier/token_supplier.go`:
- Added imports for `encoding/binary`.
- Updated import formatting to use parentheses for multiple imports.

8. The file `errors.go` in the `pkg/sdk` package:
- An import statement has been added for the package `cosmossdk.io/errors`.
- The import statement has been formatted to use parentheses for multiple imports.

9. The file `key_supplier.go`:
- Added import for `encoding/binary`.
- Updated import formatting to use parentheses for multiple imports.

10. The file `errors.go`:
- Import statement for `sdkerrors "cosmossdk.io/errors"` has been modified to be imported in a separate block using parentheses.
- The changes have been made in the `config` and `pkg/appgateserver/config` packages.

11. The file `pkg/observable/interface.go`:
- Importing the `context` package and adding parentheses to the import statement.

12. The file `errors.go` in the `pkg/client/keyring` package:
- Import statement for the package `cosmossdk.io/errors` has been modified to be a multiline import statement.
- The variable `ErrEmptySigningKeyName` has not been changed.

13. The file `errors.go` in the `x/supplier` package:
- Import statement for the package `cosmossdk.io/errors` has been modified to be a multiline import statement.

14. The file `x/supplier/keeper/supplier_keeper.go`:
- Importing the package `context` and adding parentheses to the import statement.

15. The file `template.go` in the `exported` package:
- The import "text/template" has been modified to use multi-line import syntax.
- A new import statement for the text/template package has been added.
- The variable `relayFixtureLineFmt` has not been modified.

16. The file `errors.go`:
- The changes include importing the "cosmossdk.io/errors" package and adding parentheses for multiple imports.
- Additionally, a new error variable "ErrObserverClosed" is defined using the imported package.

17. The file `pkg/client/keyring/errors.go`:
- Import statement for the package `cosmossdk.io/errors` has been modified to be a multiline import statement.
- The variable `ErrEmptySigningKeyName` has not been changed.

18. The file `errors.go` in the `appgateserver` package:
- An import statement has been updated to import the `sdkerrors` package from the `cosmossdk.io/errors` module.
- The import has been formatted using parentheses and each import is now placed on a new line.

19. The file `x/supplier/types/key_proof.go`:
- Added import block for `encoding/binary` package.

20. The file `errors.go`:
- Changes in the import section, importing the package `cosmossdk.io/errors` with updated formatting using parentheses.

21. The file `errors.go` in the `pkg/appgateserver/config` package:
- Imported the `sdkerrors` package from `cosmossdk.io/errors`.
- Reformatted the import using parentheses.
- The content of the `codespace` variable remains the same.

22. The file `errors.go` in the `x/supplier/client/config` package:
- Imported the package `cosmossdk.io/errors` using the single import statement format.
- Updated the `import` section to use parentheses for multiple imports.

23. The file `urls.go` in the `sdk` package:
- An import statement for the package `fmt` has been added.

24. The file `simple_signer.go` in the `pkg/signer` package:
- Imported package `github.com/cosmos/cosmos-sdk/crypto/keyring` has been moved inside a separate import block.
- No other changes have been made to the file.

25. The file `context.go` in the `polylog` package:
- The import statement for `context` has been changed to be imported within parentheses.
- The `CtxKey` constant has been defined as the key used to store the `polylog.Logger` in a `context.Context`.

26. The file `restore-scaffold-lines.sh`:
- This file introduces a new bash script named "goimports-revisor.sh" that will be used to run the "goimports-reviser" tool.
- The script defines an array of flags to be passed to the tool and a function named "process_file" to check for exclusion comments and run the tool on the file.
- The script then uses the "find" command to search for ".go" files, excluding certain patterns and filenames, and executes the "process_file" function on each file.

27. The file `key_gateway.go`:
- The diff of the file includes adding an import for `encoding/binary`.
- Updated import formatting to use parentheses for multiple imports.

Please review these changes and ensure that they align with the intended functionality of the files.
<!-- reviewpad:summarize:end -->

## Issue

In part (https://github.com/pokt-network/poktroll/issues/270#issuecomment-1858982731)

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [ ] **Run E2E tests locally**: `make test_e2e`
- [ ] **Run E2E tests on DevNet**: Add the `devnet-test-e2e` label to the PR. This is VERY expensive, only do it after all the reviews are complete.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
