### PR TITLE
[Configs] feat: Add stake amount in the app stake config

### DIFF
--- a/.github/workflows-helpers/run-e2e-test-job-template.yaml
+++ b/.github/workflows-helpers/run-e2e-test-job-template.yaml
@@ -21,7 +21,7 @@ spec:
               poktrolld q application list-application --node=$POCKET_NODE && \
               poktrolld q supplier list-supplier --node=$POCKET_NODE && \
               poktrolld tx supplier stake-supplier 1000upokt --config=/poktroll/localnet/poktrolld/config/supplier1_stake_config.yaml --keyring-backend=test --from=supplier1 --node=$POCKET_NODE --yes && \
-              poktrolld tx application stake-application 1000upokt --config=/poktroll/localnet/poktrolld/config/application1_stake_config.yaml --keyring-backend=test --from=app1 --node=$POCKET_NODE --yes && \
+              poktrolld tx application stake-application --config=/poktroll/localnet/poktrolld/config/application1_stake_config.yaml --keyring-backend=test --from=app1 --node=$POCKET_NODE --yes && \
               go test -v ./e2e/tests/... -tags=e2e
           env:
             - name: AUTH_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,7 @@ app_list: ## List all the staked applications
 
 .PHONY: app_stake
 app_stake: ## Stake tokens for the application specified (must specify the APP and SERVICES env vars)
-	poktrolld --home=$(POKTROLLD_HOME) tx application stake-application 1000upokt --config $(POKTROLLD_HOME)/config/$(SERVICES) --keyring-backend test --from $(APP) --node $(POCKET_NODE)
+	poktrolld --home=$(POKTROLLD_HOME) tx application stake-application --config $(POKTROLLD_HOME)/config/$(SERVICES) --keyring-backend test --from $(APP) --node $(POCKET_NODE)
 
 # TODO_IMPROVE(#180): Make sure genesis-staked actors are available via AccountKeeper
 .PHONY: app1_stake

--- a/localnet/poktrolld/config/application1_stake_config.yaml
+++ b/localnet/poktrolld/config/application1_stake_config.yaml
@@ -1,3 +1,4 @@
+stake_amount: 1000upokt
 service_ids:
  - anvil
  - svc1

--- a/localnet/poktrolld/config/application2_stake_config.yaml
+++ b/localnet/poktrolld/config/application2_stake_config.yaml
@@ -1,3 +1,4 @@
+stake_amount: 1000upokt
 service_ids:
  - anvil
  - svc2

--- a/localnet/poktrolld/config/application3_stake_config.yaml
+++ b/localnet/poktrolld/config/application3_stake_config.yaml
@@ -1,3 +1,4 @@
+stake_amount: 1000upokt
 service_ids:
  - anvil
  - svc3

--- a/x/application/client/cli/tx_stake_application.go
+++ b/x/application/client/cli/tx_stake_application.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
 
 	"github.com/pokt-network/poktroll/x/application/client/config"
@@ -22,29 +21,21 @@ var (
 func CmdStakeApplication() *cobra.Command {
 	// fromAddress & signature is retrieved via `flags.FlagFrom` in the `clientCtx`
 	cmd := &cobra.Command{
-		// This needs to be expand to specify the full ApplicationServiceConfig. Furthermore, providing a flag to
-		// a file where ApplicationServiceConfig specifying full service configurations in the CLI by providing a flag that accepts a JSON string
-		Use:   "stake-application <upokt_amount> --config <config_file.yaml>",
+		Use:   "stake-application --config <config_file.yaml>",
 		Short: "Stake an application",
 		Long: `Stake an application with the provided parameters. This is a broadcast operation that
 will stake the tokens and serviceIds and associate them with the application specified by the 'from' address.
 
 Example:
-$ poktrolld --home=$(POKTROLLD_HOME) tx application stake-application 1000upokt --config stake_config.yaml --keyring-backend test --from $(APP) --node $(POCKET_NODE)`,
-		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			stakeString := args[0]
+$ poktrolld --home=$(POKTROLLD_HOME) tx application stake-application --config stake_config.yaml --keyring-backend test --from $(APP) --node $(POCKET_NODE)`,
+		Args: cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, _ []string) (err error) {
 			configContent, err := os.ReadFile(flagStakeConfig)
 			if err != nil {
 				return err
 			}
 
 			clientCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
-
-			stake, err := sdk.ParseCoinNormalized(stakeString)
 			if err != nil {
 				return err
 			}
@@ -56,8 +47,8 @@ $ poktrolld --home=$(POKTROLLD_HOME) tx application stake-application 1000upokt 
 
 			msg := types.NewMsgStakeApplication(
 				clientCtx.GetFromAddress().String(),
-				stake,
-				appStakeConfigs,
+				appStakeConfigs.StakeAmount,
+				appStakeConfigs.Services,
 			)
 
 			if err := msg.ValidateBasic(); err != nil {

--- a/x/application/client/config/application_configs_reader.go
+++ b/x/application/client/config/application_configs_reader.go
@@ -36,7 +36,7 @@ func ParseApplicationConfigs(configContent []byte) (*ApplicationStakeConfig, err
 		return nil, ErrApplicationConfigUnmarshalYAML.Wrapf("%s", err)
 	}
 
-	if len(parsedAppConfig.ServiceIds) == 0 {
+	if len(parsedAppConfig.ServiceIds) == 0 || parsedAppConfig.ServiceIds == nil {
 		return nil, ErrApplicationConfigInvalidServiceId.Wrap("serviceIds cannot be empty")
 	}
 

--- a/x/application/client/config/application_configs_reader.go
+++ b/x/application/client/config/application_configs_reader.go
@@ -3,6 +3,8 @@ package config
 import (
 	"gopkg.in/yaml.v2"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	sharedhelpers "github.com/pokt-network/poktroll/x/shared/helpers"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
@@ -10,12 +12,24 @@ import (
 // YAMLApplicationConfig is the structure describing a single service stake entry in the stake config file
 // TODO_DOCUMENT(@red-0ne): Add additional documentation on app config files.
 type YAMLApplicationConfig struct {
-	ServiceIds []string `yaml:"service_ids"`
+	StakeAmount string   `yaml:"stake_amount"`
+	ServiceIds  []string `yaml:"service_ids"`
+}
+
+type ApplicationStakeConfig struct {
+	// StakeAmount is the amount of upokt tokens that the application is willing to stake
+	StakeAmount sdk.Coin
+	// Services is the list of services that the application is willing to stake for
+	Services []*sharedtypes.ApplicationServiceConfig
 }
 
 // ParseApplicationConfig parses the stake config file and returns a slice of ApplicationServiceConfig
-func ParseApplicationConfigs(configContent []byte) ([]*sharedtypes.ApplicationServiceConfig, error) {
+func ParseApplicationConfigs(configContent []byte) (*ApplicationStakeConfig, error) {
 	var parsedAppConfig YAMLApplicationConfig
+
+	if len(configContent) == 0 {
+		return nil, ErrApplicationConfigEmptyContent
+	}
 
 	// Unmarshal the stake config file into a applicationServiceConfig
 	if err := yaml.Unmarshal(configContent, &parsedAppConfig); err != nil {
@@ -23,7 +37,31 @@ func ParseApplicationConfigs(configContent []byte) ([]*sharedtypes.ApplicationSe
 	}
 
 	if len(parsedAppConfig.ServiceIds) == 0 {
-		return nil, ErrApplicationConfigEmptyContent
+		return nil, ErrApplicationConfigInvalidServiceId.Wrap("serviceIds cannot be empty")
+	}
+
+	if parsedAppConfig.StakeAmount == "" {
+		return nil, ErrApplicationConfigInvalidStake.Wrap("stake amount cannot be empty")
+	}
+
+	stakeAmount, err := sdk.ParseCoinNormalized(parsedAppConfig.StakeAmount)
+	if err != nil {
+		return nil, ErrApplicationConfigInvalidStake.Wrap(err.Error())
+	}
+
+	if err := stakeAmount.Validate(); err != nil {
+		return nil, ErrApplicationConfigInvalidStake.Wrap(err.Error())
+	}
+
+	if stakeAmount.IsZero() {
+		return nil, ErrApplicationConfigInvalidStake.Wrap("stake amount cannot be zero")
+	}
+
+	if stakeAmount.Denom != "upokt" {
+		return nil, ErrApplicationConfigInvalidStake.Wrapf(
+			"invalid stake denom, expecting: upokt, got: %s",
+			stakeAmount.Denom,
+		)
 	}
 
 	// Prepare the applicationServiceConfig
@@ -46,5 +84,8 @@ func ParseApplicationConfigs(configContent []byte) ([]*sharedtypes.ApplicationSe
 		applicationServiceConfig = append(applicationServiceConfig, appServiceConfig)
 	}
 
-	return applicationServiceConfig, nil
+	return &ApplicationStakeConfig{
+		StakeAmount: stakeAmount,
+		Services:    applicationServiceConfig,
+	}, nil
 }

--- a/x/application/client/config/application_configs_reader_test.go
+++ b/x/application/client/config/application_configs_reader_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	sdkerrors "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/gogo/status"
 	"github.com/stretchr/testify/require"
 
@@ -20,25 +21,29 @@ func Test_ParseApplicationConfigs(t *testing.T) {
 		inputConfig string
 
 		expectedError  *sdkerrors.Error
-		expectedConfig []*sharedtypes.ApplicationServiceConfig
+		expectedConfig *config.ApplicationStakeConfig
 	}{
 		// Valid Configs
 		{
 			desc: "valid: service staking config",
 
 			inputConfig: `
+				stake_amount: 1000upokt
 				service_ids:
 				  - svc1
 				  - svc2
 				`,
 
 			expectedError: nil,
-			expectedConfig: []*sharedtypes.ApplicationServiceConfig{
-				{
-					Service: &sharedtypes.Service{Id: "svc1"},
-				},
-				{
-					Service: &sharedtypes.Service{Id: "svc2"},
+			expectedConfig: &config.ApplicationStakeConfig{
+				StakeAmount: sdk.NewCoin("upokt", sdk.NewInt(1000)),
+				Services: []*sharedtypes.ApplicationServiceConfig{
+					{
+						Service: &sharedtypes.Service{Id: "svc1"},
+					},
+					{
+						Service: &sharedtypes.Service{Id: "svc2"},
+					},
 				},
 			},
 		},
@@ -48,13 +53,14 @@ func Test_ParseApplicationConfigs(t *testing.T) {
 
 			inputConfig: ``,
 
-			expectedError: config.ErrApplicationConfigUnmarshalYAML,
+			expectedError: config.ErrApplicationConfigEmptyContent,
 		},
 		{
 			desc: "invalid: no service ids",
 
 			inputConfig: `
-				service_ids:
+				stake_amount: 1000upokt
+				service_ids: # explicitly omitting service ids
 				`,
 
 			expectedError: config.ErrApplicationConfigInvalidServiceId,
@@ -63,11 +69,48 @@ func Test_ParseApplicationConfigs(t *testing.T) {
 			desc: "invalid: invalid serviceId",
 
 			inputConfig: `
+				stake_amount: 1000upokt
 				service_ids:
 				  - sv c1
 				`,
 
 			expectedError: config.ErrApplicationConfigInvalidServiceId,
+		},
+		{
+			desc: "invalid: no stake amount",
+
+			inputConfig: `
+				stake_amount: # explicitly omitting stake amount
+				service_ids:
+				  - svc1
+				  - svc2
+				`,
+
+			expectedError: config.ErrApplicationConfigInvalidStake,
+		},
+		{
+			desc: "invalid: non-positive stake amount",
+
+			inputConfig: `
+				stake_amount: 0upokt
+				service_ids:
+				  - svc1
+				  - svc2
+				`,
+
+			expectedError: config.ErrApplicationConfigInvalidStake,
+		},
+		{
+			desc: "invalid: unsupported stake denom",
+
+			inputConfig: `
+				stake_amount: 1000npokt
+				service_ids:
+				  - svc1
+				  - svc2
+				`,
+
+			expectedError: config.ErrApplicationConfigInvalidStake,
 		},
 	}
 
@@ -78,7 +121,7 @@ func Test_ParseApplicationConfigs(t *testing.T) {
 
 			if tt.expectedError != nil {
 				require.Error(t, err)
-				require.Nil(t, appServiceConfig)
+				require.ErrorIs(t, err, tt.expectedError)
 				stat, ok := status.FromError(tt.expectedError)
 				require.True(t, ok)
 				require.Contains(t, stat.Message(), tt.expectedError.Error())
@@ -88,10 +131,13 @@ func Test_ParseApplicationConfigs(t *testing.T) {
 
 			require.NoError(t, err)
 
+			require.Equal(t, tt.expectedConfig.StakeAmount.Amount, appServiceConfig.StakeAmount.Amount)
+			require.Equal(t, tt.expectedConfig.StakeAmount.Denom, appServiceConfig.StakeAmount.Denom)
+
 			log.Printf("serviceIds: %v", appServiceConfig)
-			require.Equal(t, len(tt.expectedConfig), len(appServiceConfig))
-			for i, expected := range tt.expectedConfig {
-				require.Equal(t, expected.Service.Id, appServiceConfig[i].Service.Id)
+			require.Equal(t, len(tt.expectedConfig.Services), len(appServiceConfig.Services))
+			for i, expected := range tt.expectedConfig.Services {
+				require.Equal(t, expected.Service.Id, appServiceConfig.Services[i].Service.Id)
 			}
 		})
 	}

--- a/x/application/client/config/errors.go
+++ b/x/application/client/config/errors.go
@@ -6,5 +6,6 @@ var (
 	codespace                            = "applicationconfig"
 	ErrApplicationConfigUnmarshalYAML    = sdkerrors.Register(codespace, 1, "config reader cannot unmarshal yaml content")
 	ErrApplicationConfigInvalidServiceId = sdkerrors.Register(codespace, 2, "invalid serviceId in application config")
-	ErrApplicationConfigEmptyContent     = sdkerrors.Register(codespace, 4, "empty application config content")
+	ErrApplicationConfigEmptyContent     = sdkerrors.Register(codespace, 3, "empty application config content")
+	ErrApplicationConfigInvalidStake     = sdkerrors.Register(codespace, 4, "invalid stake amount in application config")
 )


### PR DESCRIPTION
## Summary

### Human Summary

Add staking amount to the config file used by the application stake cmd

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Jan 24 16:01 UTC
This pull request includes the following changes:

- In the `.github/workflows-helpers/run-e2e-test-job-template.yaml` file, the command `poktrolld tx application stake-application` was modified. The amount `1000upokt` was removed and the flag `--config=/poktroll/localnet/poktrolld/config/application1_stake_config.yaml` was added.

- In the `Makefile` file, the `app_stake` target was modified. The argument `1000upokt` was removed from the command `poktrolld --home=$(POKTROLLD_HOME) tx application stake-application 1000upokt`.

- In the `errors.go` file, the error codes `ErrApplicationConfigEmptyContent` and `ErrApplicationConfigInvalidStake` were updated.

- The `tx_stake_application.go` file in the `x/application/client/cli` package underwent several changes, including the removal of an import statement, modifications to the `CmdStakeApplication` command, and updates to the `Args` field and `RunE` function.

- The `application2_stake_config.yaml` file was modified by adding a stake amount and service IDs.

- A file diff included changes that added a stake amount and service ID.

- The `tx_stake_application_test.go` file underwent modifications, including adding an import statement and making changes to variables and test functions.

- Changes were made to the `application_configs_reader_test.go` file, including adding an import statement, modifying the expected configuration type, and adding new test cases.

- The `application_configs_reader.go` file saw changes related to the `ParseApplicationConfigs` function, including importing a package, adding structs, modifying existing structs, and changing the return type.

- The `application3_stake_config.yaml` file had changes made to its contents.

Let me know if you need more information or assistance.
<!-- reviewpad:summarize:end -->

## Issue

- #293 

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Run all unit tests**: `make go_develop_and_test`
- [x] **Run E2E tests locally**: `make test_e2e`
- [ ] **Run E2E tests on DevNet**: Add the `devnet-test-e2e` label to the PR. This is VERY expensive, only do it after all the reviews are complete.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
