### PR TITLE
[SMT] Path Bump to v0.8.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2
 	github.com/noot/ring-go v0.0.0-20231019173746-6c4b33bcf03f
-	github.com/pokt-network/smt v0.8.1
+	github.com/pokt-network/smt v0.8.2
 	github.com/pokt-network/smt/kvstore/badger v0.0.0-20240104123447-abb5c71c14ce
 	github.com/regen-network/gocuke v0.6.2
 	github.com/rs/zerolog v1.29.1

--- a/go.sum
+++ b/go.sum
@@ -1598,8 +1598,8 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pokt-network/smt v0.8.1 h1:3oKyg1J8d2Eqy6PldmFQyone5OQriHLb474He8iOQbo=
-github.com/pokt-network/smt v0.8.1/go.mod h1:jZAEO+btrzRHXxHImbf38GH+ZstHlOuFxSS54RNEK4Y=
+github.com/pokt-network/smt v0.8.2 h1:pCuIuSrEiSZEc6fhjjUXM9395Jqduzx6fZI8MheSJLA=
+github.com/pokt-network/smt v0.8.2/go.mod h1:S4Ho4OPkK2v2vUCHNtA49XDjqUC/OFYpBbynRVYmxvA=
 github.com/pokt-network/smt/kvstore/badger v0.0.0-20240104123447-abb5c71c14ce h1:JCpmaD35pHq9VWbePNuysIVOX5ybmVzThNY2BcurjVE=
 github.com/pokt-network/smt/kvstore/badger v0.0.0-20240104123447-abb5c71c14ce/go.mod h1:VG/uGRf6wmiDnSxee8rmVtmtLXrVM2SK4/xXtrBFeZ0=
 github.com/polydawn/refmt v0.89.0 h1:ADJTApkvkeBZsN0tBTx8QjpD9JkmxbKp0cxfr9qszm4=


### PR DESCRIPTION
## Summary

- Dependabot caught a vulnerability in an indirect dependency and thus once fixed I released SMT v0.8.2 this PR bumps to that version

### Human Summary

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 08 Jan 24 17:15 UTC
This pull request updates the smt package to version 0.8.2. It modifies the go.mod and go.sum files, bumping the smt version from 0.8.1 to 0.8.2. The changes include 3 insertions and 3 deletions.
<!-- reviewpad:summarize:end -->

## Issue

- Fixes N/A

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_develop_and_test`
- [x] **Run E2E tests locally**: `make test_e2e`
- [ ] **Run E2E tests on DevNet**: Add the `devnet-test-e2e` label to the PR. This is VERY expensive, only do it after all the reviews are complete.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
