### PR TITLE
[Config, Docs] Add application staking config documentation

### DIFF
--- a/docusaurus/docs/configs/app_staking_config.md
+++ b/docusaurus/docs/configs/app_staking_config.md
@@ -1,0 +1,67 @@
+---
+title: Application staking config
+sidebar_position: 4
+---
+
+# Application staking config
+
+_This document describes the configuration file used by the `Application` actor
+to submit a stake transaction required to allow it to use the Pocket Network's
+RPC services._
+
+- [Application staking config](#application-staking-config)
+- [Usage](#usage)
+- [Configuration](#configuration)
+  - [`stake_amount`](#stake_amount)
+  - [`service_ids`](#service_ids)
+- [Example](#example)
+
+# Usage
+
+The `stake-application` transaction submission command accepts a `--config` flag
+that points to a `yaml` configuration file that defines the `stake_amount` and
+`service_ids` which the `Application` is allowed to use.
+
+```bash
+poktrolld tx application stake-application \
+  --home=./poktroll \
+  --config ./stake_config.yaml \
+  --keyring-backend test \
+  --from application1 \
+  --node tcp://poktroll-node:36657
+```
+
+# Configuration
+
+The configuration file consists of a `stake_amount` entry denominated in `upokt`
+and a `service_ids` list defining the services the `Application` is willing to
+consume.
+
+## `stake_amount`
+_`Required`_
+
+```yaml
+stake_amount: <number>upokt
+```
+
+Defines the amount of `upokt` to stake from the `Application` to be able to
+consume the services defined in the `service_ids` list.
+
+## `service_ids`
+_`Required`_, _`Non-empty`_
+
+```yaml
+service_ids:
+  - <string>
+```
+
+Defines the list of services the `Application` is willing to consume on the
+Pocket network. Each entry in the list is a `service_id` that identifies a service
+that is available on the Pocket network.
+
+It MUST be a string of at most 8 characters or less allowing only alphanumeric
+characters, underscores, and dashes (i.e. matching the regex `^[a-zA-Z0-9_-]{1,8}$`).
+
+# Example
+
+A full example of the configuration file could be found at [application_staking_config.yaml](https://github.com/pokt-network/poktroll/tree/main/localnet/poktrolld/config/application1_stake_config.yaml)

--- a/docusaurus/docs/configs/app_staking_config.md
+++ b/docusaurus/docs/configs/app_staking_config.md
@@ -3,24 +3,30 @@ title: Application staking config
 sidebar_position: 4
 ---
 
-# Application staking config
+# Application staking config <!-- omit in toc -->
 
-_This document describes the configuration file used by the `Application` actor
-to submit a stake transaction required to allow it to use the Pocket Network's
-RPC services._
+This document describes the configuration file used by the `Application` actor
+to submit a `stake`` transaction required to allow it to use the Pocket Network's
+RPC services.
 
-- [Application staking config](#application-staking-config)
 - [Usage](#usage)
 - [Configuration](#configuration)
   - [`stake_amount`](#stake_amount)
   - [`service_ids`](#service_ids)
 - [Example](#example)
 
-# Usage
+## Usage
 
 The `stake-application` transaction submission command accepts a `--config` flag
 that points to a `yaml` configuration file that defines the `stake_amount` and
 `service_ids` which the `Application` is allowed to use.
+
+:::warning
+
+TestNet is not ready as of writing this documentation so you may
+need to adjust the command below appropriately.
+
+:::
 
 ```bash
 poktrolld tx application stake-application \
@@ -31,13 +37,14 @@ poktrolld tx application stake-application \
   --node tcp://poktroll-node:36657
 ```
 
-# Configuration
+## Configuration
 
 The configuration file consists of a `stake_amount` entry denominated in `upokt`
 and a `service_ids` list defining the services the `Application` is willing to
 consume.
 
-## `stake_amount`
+### `stake_amount`
+
 _`Required`_
 
 ```yaml
@@ -45,9 +52,12 @@ stake_amount: <number>upokt
 ```
 
 Defines the amount of `upokt` to stake from the `Application` to be able to
-consume the services defined in the `service_ids` list.
+consume the services. This amount will be transferred from the Application's
+account balance and locked. It will be deducted at the end of every session
+based on the Application's usage.
 
-## `service_ids`
+### `service_ids`
+
 _`Required`_, _`Non-empty`_
 
 ```yaml
@@ -62,6 +72,6 @@ that is available on the Pocket network.
 It MUST be a string of at most 8 characters or less allowing only alphanumeric
 characters, underscores, and dashes (i.e. matching the regex `^[a-zA-Z0-9_-]{1,8}$`).
 
-# Example
+## Example
 
 A full example of the configuration file could be found at [application_staking_config.yaml](https://github.com/pokt-network/poktroll/tree/main/localnet/poktrolld/config/application1_stake_config.yaml)


### PR DESCRIPTION
## Summary

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 18 Jan 24 20:29 UTC
This pull request adds documentation for the application staking configuration. It includes information on how to use and configure the staking settings, such as the stake amount and service IDs. Additionally, there are edits made to improve the clarity and accuracy of the documentation. Overall, this patch enhances the understanding and usage of the application staking configuration.
<!-- reviewpad:summarize:end -->

## Issue

- #274 
- #159 

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
