### PR TITLE
[Tooling] Act helpers to run github workflows locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -587,10 +587,26 @@ poktrolld_addr: ## Retrieve the address for an account by ACC_NAME
 ### Act Helpers ###
 ###################
 
+.PHONY: detect_arch
+# Internal helper to avoid the caller needing to specify the architecture
+detect_arch:
+	@ARCH=`uname -m`; \
+	case $$ARCH in \
+	x86_64) \
+		echo linux/amd64 ;; \
+	arm64) \
+		echo linux/arm64 ;; \
+	*) \
+		echo "Unsupported architecture: $$ARCH" >&2; \
+		exit 1 ;; \
+	esac
+
 .PHONY: act_list
 act_list: check_act ## List all github actions that can be executed locally with act
 	act --list
 
 .PHONY: act_reviewdog
 act_reviewdog: check_act check_gh ## Run the reviewdog workflow locally like so: `GITHUB_TOKEN=$(gh auth token) make act_reviewdog`
-	act -v -s GITHUB_TOKEN=$(GITHUB_TOKEN) -W .github/workflows/reviewdog.yml --container-architecture linux/arm64
+	$(eval CONTAINER_ARCH := $(shell make -s detect_arch))
+	@echo "Detected architecture: $(CONTAINER_ARCH)"
+	act -v -s GITHUB_TOKEN=$(GITHUB_TOKEN) -W .github/workflows/reviewdog.yml --container-architecture $(CONTAINER_ARCH)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,27 @@ check_go_version:
 		exit 1; \
 	fi
 
+.PHONY: check_act
+# Internal helper target - check if `act` is installed
+check_act:
+	{ \
+	if ( ! ( command -v act >/dev/null )); then \
+		echo "Seems like you don't have `act` installed. Please visit https://github.com/nektos/act before continuing"; \
+		exit 1; \
+	fi; \
+	}
+
+.PHONY: check_gh
+# Internal helper target - check if `gh` is installed
+check_gh:
+	{ \
+	if ( ! ( command -v gh >/dev/null )); then \
+		echo "Seems like you don't have `gh` installed. Please visit https://cli.github.com/ before continuing"; \
+		exit 1; \
+	fi; \
+	}
+
+
 .PHONY: check_docker
 # Internal helper target - check if docker is installed
 check_docker:
@@ -560,3 +581,16 @@ docusaurus_start: check_npm check_node ## Start the Docusaurus server
 .PHONY: poktrolld_addr
 poktrolld_addr: ## Retrieve the address for an account by ACC_NAME
 	@echo $(shell poktrolld --home=$(POKTROLLD_HOME) keys show -a $(ACC_NAME))
+
+
+###################
+### Act Helpers ###
+###################
+
+.PHONY: act_list
+act_list: check_act ## List all github actions that can be executed locally with act
+	act --list
+
+.PHONY: act_reviewdog
+act_reviewdog: check_act check_gh ## Run the reviewdog workflow locally like so: `GITHUB_TOKEN=$(gh auth token) make act_reviewdog`
+	act -v -s GITHUB_TOKEN=$(GITHUB_TOKEN) -W .github/workflows/reviewdog.yml --container-architecture linux/arm64


### PR DESCRIPTION
## Summary

Adding some makefile helpers to streamline the usage of [act](https://github.com/nektos/act) on the team.

@h5law shared it on our discord channel and does make it easier to verify things locally.

![Screenshot 2024-01-22 at 1 54 41 PM](https://github.com/pokt-network/poktroll/assets/1892194/58d8f958-abda-4eb5-b409-0a4845f4d72b)

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

```bash
GITHUB_TOKEN=$(gh auth token) make act_reviewdog
```

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code, updated documentation and left TODOs throughout the codebase
