### PR TITLE
fix: bad error check for session claiming

### DIFF
--- a/pkg/relayer/session/proof.go
+++ b/pkg/relayer/session/proof.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pokt-network/poktroll/pkg/observable/logging"
 	"github.com/pokt-network/poktroll/pkg/relayer"
 	"github.com/pokt-network/poktroll/pkg/relayer/protocol"
+	sessionkeeper "github.com/pokt-network/poktroll/x/session/keeper"
 )
 
 // submitProofs maps over the given claimedSessions observable.
@@ -67,7 +68,7 @@ func (rs *relayerSessionsManager) waitForEarliestSubmitProofHeight(
 	ctx context.Context,
 	createClaimHeight int64,
 ) {
-	submitProofWindowStartHeight := createClaimHeight
+	submitProofWindowStartHeight := createClaimHeight + sessionkeeper.GetSessionGracePeriodBlockCount()
 	// TODO_TECHDEBT: query the on-chain governance parameter once available.
 	// + claimproofparams.GovSubmitProofWindowStartHeightOffset
 

--- a/pkg/relayer/session/session.go
+++ b/pkg/relayer/session/session.go
@@ -181,7 +181,7 @@ func (rs *relayerSessionsManager) mapBlockToSessionsToClaim(
 				// against concurrent access by the sessionsTreesMu such that the first
 				// call that marks the session as claimed will be the only one to add the
 				// sessionTree to the list.
-				if err := sessionTree.StartClaiming(); err != nil {
+				if err := sessionTree.StartClaiming(); err == nil {
 					sessionTrees = append(sessionTrees, sessionTree)
 				}
 			}


### PR DESCRIPTION
## Summary

### Human Summary

A bad error check on session claim led to claiming sessions that were already marked as claimed. Resulting in multiple claim and proof submissions attempts. Which resulted in `session tree proof path mismatch` errors.

![image](https://github.com/pokt-network/poktroll/assets/231488/859b96f1-a132-439f-8de7-86f494318e9d)


### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 Jan 24 14:30 UTC
This pull request fixes a bad error check for session claiming. The patch modifies the `proof.go` and `session.go` files. In `proof.go`, the patch adds an import statement and modifies the `waitForEarliestSubmitProofHeight` function to correctly calculate `submitProofWindowStartHeight`. In `session.go`, the patch updates the error check in the `mapBlockToSessionsToClaim` function.
<!-- reviewpad:summarize:end -->

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_develop_and_test`
- [x] **Run E2E tests locally**: `make test_e2e`
- [ ] **Run E2E tests on DevNet**: Add the `devnet-test-e2e` label to the PR. This is VERY expensive, only do it after all the reviews are complete.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
