### PR TITLE
[Docs] Remove session-mismatch error workaround

### DIFF
--- a/docusaurus/docs/quickstart.md
+++ b/docusaurus/docs/quickstart.md
@@ -221,12 +221,6 @@ If everything worked as expected, you should see output similar to the following
 
 ### Send a relay a shannon
 
-:::danger
-TODO(#275): The E2E relay is unlikely to work as of writing this so please see
-[this comment](https://github.com/pokt-network/poktroll/issues/275#issuecomment-1863519333)
-for details and a workaround.
-:::
-
 However, the appgate server above is not configured to sign relays on behalf of `SHANNON_ADDRESS`.
 
 To do so, you'll need to create a similar configuration like so:


### PR DESCRIPTION
## Summary

### Human Summary

Remove `session-mismatch` workaround section in the `quickstart` documentation page.

This workaround is no longer needed as per #326  

### AI Summary

reviewpad:summary

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
