### PR TITLE
[CI] build images on migration/base branch

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -2,7 +2,7 @@ name: Main build
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "migration/base"]
   pull_request:
 
 concurrency:
@@ -41,11 +41,11 @@ jobs:
         run: ignite chain build -v --debug --skip-proto
 
       - name: Set up Docker Buildx
-        if: (github.ref == 'refs/heads/main') || (contains(github.event.pull_request.labels.*.name, 'push-image'))
+        if: (github.ref == 'refs/heads/main') || (github.ref == 'refs/heads/migration/base') || (contains(github.event.pull_request.labels.*.name, 'push-image'))
         uses: docker/setup-buildx-action@v3
 
       - name: Docker Metadata action
-        if: (github.ref == 'refs/heads/main') || (contains(github.event.pull_request.labels.*.name, 'push-image'))
+        if: (github.ref == 'refs/heads/main') || (github.ref == 'refs/heads/migration/base') || (contains(github.event.pull_request.labels.*.name, 'push-image'))
         id: meta
         uses: docker/metadata-action@v5
         env:
@@ -60,7 +60,7 @@ jobs:
             type=sha,format=long
 
       - name: Login to GitHub Container Registry
-        if: (github.ref == 'refs/heads/main') || (contains(github.event.pull_request.labels.*.name, 'push-image'))
+        if: (github.ref == 'refs/heads/main') || (github.ref == 'refs/heads/migration/base') || (contains(github.event.pull_request.labels.*.name, 'push-image'))
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -68,7 +68,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Copy binaries to inside of the Docker context
-        if: (github.ref == 'refs/heads/main') || (contains(github.event.pull_request.labels.*.name, 'push-image'))
+        if: (github.ref == 'refs/heads/main') || (github.ref == 'refs/heads/migration/base') || (contains(github.event.pull_request.labels.*.name, 'push-image'))
         run: |
           mkdir -p ./bin # Make sure the bin directory exists
           cp $(which ignite) ./bin # Copy ignite binary to the repo's bin directory
@@ -76,7 +76,7 @@ jobs:
           ls -la ./bin
 
       - name: Build and push Docker image
-        if: (github.ref == 'refs/heads/main') || (contains(github.event.pull_request.labels.*.name, 'push-image'))
+        if: (github.ref == 'refs/heads/main') || (github.ref == 'refs/heads/migration/base') || (contains(github.event.pull_request.labels.*.name, 'push-image'))
         uses: docker/build-push-action@v5
         with:
           push: true

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,89 @@
+name: Release artifacts
+
+on:
+  push:
+    tags: ["*"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  go-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: install ignite
+        # TODO_TECHDEBT: upgrade to the latest Ignite (the latest at the moment of creating a note is 0.28). Need to downgrade to fix CI pipelines. Might be done in scope of #240.
+        run: |
+          # curl https://get.ignite.com/cli! | bash
+          wget https://github.com/ignite/cli/releases/download/v28.2.0/ignite_28.2.0_linux_amd64.tar.gz
+          tar -xzf ignite_28.2.0_linux_amd64.tar.gz
+          sudo mv ignite /usr/local/bin/ignite
+          ignite version
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0" # Per https://github.com/ignite/cli/issues/1674#issuecomment-1144619147
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21.6"
+
+      - name: Install CI dependencies
+        run: make install_ci_deps
+
+      - name: Generate protobufs
+        run: make proto_regen
+
+      - name: Generate mocks
+        run: make go_mockgen
+
+      - name: Build binaries
+        run: ignite chain build --release -t=linux:amd64 -t=linux:arm64 -t=windows:amd64 -t=windows:arm64 -t=darwin:arm64 -t=darwin:amd64 --debug
+
+      - name: Unarchive linux binaries for Docker to consume
+        run: |
+          mkdir -p release_linux_amd64 && tar -zxvf release/poktroll_linux_amd64.tar.gz -C $_
+          mkdir -p release_linux_arm64 && tar -zxvf release/poktroll_linux_arm64.tar.gz -C $_
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Metadata action
+        id: meta
+        uses: docker/metadata-action@v5
+        env:
+          DOCKER_METADATA_PR_HEAD_SHA: "true"
+        with:
+          images: |
+            ghcr.io/pokt-network/poktrolld
+          tags: |
+            type=ref,event=tag
+            type=sha
+            type=sha,format=long
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          file: Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+
+      - name: Add release and publish binaries
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            release/*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,10 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
-env:
-  GKE_CLUSTER: protocol-us-central1
-  GKE_ZONE: us-central1
-
 jobs:
   go-test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ localnet_config.yaml
 localnet_config.yaml-e
 
 # Relase artifacts produced by `ignite chain build --release`
-release
+/release*
 
 # Only keep one go module in our codebase
 go.work.sum

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:latest
+
+ARG TARGETARCH
+
+COPY release_linux_$TARGETARCH/poktrolld /usr/local/bin/poktrolld
+
+RUN chmod +x /usr/local/bin/poktrolld
+
+CMD ["/usr/local/bin/poktrolld"]


### PR DESCRIPTION
1. Allows us to use container images from `migration/base` branch - will be useful for community members who wish to deploy Full Node;
2. Adds a job to build and release binaries. Also, would build container images for us using the same binaries. Currently no way of testing this job.