### PR TITLE
[Test] Replace time waiting with message submission waiting

### DIFF
--- a/e2e/tests/session.feature
+++ b/e2e/tests/session.feature
@@ -9,7 +9,7 @@ Feature: Session Namespace
     # The timeout for when a claim can be submitted on-chain depends on `createClaimWindowStartHeight`, which
     # is a function of `SessionGracePeriod`. The higher this value, the higher this timeout needs to be. Since
     # this test is not dependant on the grace period, setting it to 0 and having a lower grace period will simplify it.
-    And the user should wait for "7" seconds
+    And the user should wait for the "proof" "CreateClaim" Message to be submited
     Then the claim created by supplier "supplier1" for service "svc1" for application "app1" should be persisted on-chain
     # TODO_IMPROVE: And an event should be emitted...
     And after the supplier submits a proof for the session for service "svc1" for application "app1"

--- a/e2e/tests/session.feature
+++ b/e2e/tests/session.feature
@@ -5,10 +5,6 @@ Feature: Session Namespace
   Scenario: Supplier completes claim/proof lifecycle for a valid session
     Given the user has the pocketd binary installed
     When the supplier "supplier1" has serviced a session with "5" relays for service "svc1" for application "app1"
-    # TODO_TECHDEBT: Once the session grace period is configurable, set it to 0 at the beginning of this test.
-    # The timeout for when a claim can be submitted on-chain depends on `createClaimWindowStartHeight`, which
-    # is a function of `SessionGracePeriod`. The higher this value, the higher this timeout needs to be. Since
-    # this test is not dependant on the grace period, setting it to 0 and having a lower grace period will simplify it.
     And the user should wait for the "proof" "CreateClaim" Message to be submited
     Then the claim created by supplier "supplier1" for service "svc1" for application "app1" should be persisted on-chain
     # TODO_IMPROVE: And an event should be emitted...

--- a/e2e/tests/session_steps_test.go
+++ b/e2e/tests/session_steps_test.go
@@ -42,6 +42,7 @@ const (
 	preExistingProofsKey = "preExistingProofsKey"
 )
 
+// TODO_TECHDEBT: Evaluate if/where/how this function should be reused in other tests
 func (s *suite) TheUserShouldWaitForTheMessageToBeSubmited(module, message string) {
 	s.waitForMessageAction(fmt.Sprintf("/poktroll.%s.Msg%s", module, message))
 }

--- a/e2e/tests/session_steps_test.go
+++ b/e2e/tests/session_steps_test.go
@@ -42,6 +42,10 @@ const (
 	preExistingProofsKey = "preExistingProofsKey"
 )
 
+func (s *suite) TheUserShouldWaitForTheMessageToBeSubmited(module, message string) {
+	s.waitForMessageAction(fmt.Sprintf("/poktroll.%s.Msg%s", module, message))
+}
+
 func (s *suite) AfterTheSupplierCreatesAClaimForTheSessionForServiceForApplication(serviceId, appName string) {
 	s.waitForMessageAction("/poktroll.proof.MsgCreateClaim")
 }


### PR DESCRIPTION
## Summary

### Human Summary

Waiting for a claim to be submitted is subject to gov. params, and e2e tests leveraging timing to wait for transactions to be submitted make them coupled to these params and potentially flaky due to CPU load.

![image](https://github.com/pokt-network/poktroll/assets/231488/8edf5dbf-ee01-49a6-878d-937fa5ced6cb)

This PR makes `session.feature` e2e test switching from: Waiting for a number of seconds then check for tx submission to: Subscribing to target transactions and waiting until they are effectively submitted and observed on-chain.

With this change, we should no longer see these failures:
![image](https://github.com/pokt-network/poktroll/assets/231488/728d909d-d184-447e-9e2e-d602e058d5c9)

### AI Summary

reviewpad:summary

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_develop_and_test`
- [x] **Run E2E tests locally**: `make test_e2e`
- [ ] **Run E2E tests on DevNet**: Add the `devnet-test-e2e` label to the PR. This is VERY expensive, only do it after all the reviews are complete.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
