### PR TITLE
[Cleanup] Wrap errors by type not by `sdkerrors` import's `Wrapf` method.

### DIFF
--- a/pkg/relayer/proxy/relay_verifier.go
+++ b/pkg/relayer/proxy/relay_verifier.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"context"
 
-	sdkerrors "cosmossdk.io/errors"
 	ring_secp256k1 "github.com/athanorlabs/go-dleq/secp256k1"
 	ring "github.com/noot/ring-go"
 
@@ -34,23 +33,20 @@ func (rp *relayerProxy) VerifyRelayRequest(
 	}
 	signature := relayRequest.Meta.Signature
 	if signature == nil {
-		return sdkerrors.Wrapf(
-			ErrRelayerProxyInvalidRelayRequest,
+		return ErrRelayerProxyInvalidRelayRequest.Wrapf(
 			"missing signature from relay request: %v", relayRequest,
 		)
 	}
 
 	ringSig := new(ring.RingSig)
 	if err := ringSig.Deserialize(ring_secp256k1.NewCurve(), signature); err != nil {
-		return sdkerrors.Wrapf(
-			ErrRelayerProxyInvalidRelayRequestSignature,
+		return ErrRelayerProxyInvalidRelayRequestSignature.Wrapf(
 			"error deserializing ring signature: %v", err,
 		)
 	}
 
 	if relayRequest.Meta.SessionHeader.ApplicationAddress == "" {
-		return sdkerrors.Wrap(
-			ErrRelayerProxyInvalidRelayRequest,
+		return ErrRelayerProxyInvalidRelayRequest.Wrap(
 			"missing application address from relay request",
 		)
 	}
@@ -59,16 +55,14 @@ func (rp *relayerProxy) VerifyRelayRequest(
 	appAddress := relayRequest.Meta.SessionHeader.ApplicationAddress
 	appRing, err := rp.ringCache.GetRingForAddress(ctx, appAddress)
 	if err != nil {
-		return sdkerrors.Wrapf(
-			ErrRelayerProxyInvalidRelayRequest,
+		return ErrRelayerProxyInvalidRelayRequest.Wrapf(
 			"error getting ring for application address %s: %v", appAddress, err,
 		)
 	}
 
 	// verify the ring signature against the ring
 	if !ringSig.Ring().Equals(appRing) {
-		return sdkerrors.Wrapf(
-			ErrRelayerProxyInvalidRelayRequestSignature,
+		return ErrRelayerProxyInvalidRelayRequestSignature.Wrapf(
 			"ring signature does not match ring for application address %s", appAddress,
 		)
 	}
@@ -81,8 +75,7 @@ func (rp *relayerProxy) VerifyRelayRequest(
 
 	// verify the relay request's signature
 	if valid := ringSig.Verify(requestSignableBz); !valid {
-		return sdkerrors.Wrapf(
-			ErrRelayerProxyInvalidRelayRequestSignature,
+		return ErrRelayerProxyInvalidRelayRequestSignature.Wrapf(
 			"invalid ring signature",
 		)
 	}
@@ -107,7 +100,6 @@ func (rp *relayerProxy) VerifyRelayRequest(
 		service.Id,
 		sessionBlockHeight,
 	)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/relayer/proxy/synchronous.go
+++ b/pkg/relayer/proxy/synchronous.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"time"
 
-	sdkerrors "cosmossdk.io/errors"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -177,8 +176,7 @@ func (sync *synchronousRPCServer) ServeHTTP(writer http.ResponseWriter, request 
 	}
 
 	if relayRequest.Meta == nil {
-		err = sdkerrors.Wrapf(
-			ErrRelayerProxyInvalidRelayRequest,
+		err = ErrRelayerProxyInvalidRelayRequest.Wrapf(
 			"missing meta from relay request: %v", relayRequest,
 		)
 		sync.replyWithError(ctx, relayRequest.Payload, writer, sync.proxyConfig.ProxyName, supplierService.Id, err)

--- a/x/service/types/params.go
+++ b/x/service/types/params.go
@@ -3,7 +3,6 @@ package types
 import (
 	"fmt"
 
-	sdkerrors "cosmossdk.io/errors"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
@@ -48,8 +47,7 @@ func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 func (p Params) Validate() error {
 	// TODO(@h5law): Look into better validation
 	if p.AddServiceFee < DefaultAddServiceFee {
-		return sdkerrors.Wrapf(
-			ErrServiceInvalidServiceFee,
+		return ErrServiceInvalidServiceFee.Wrapf(
 			"AddServiceFee param %d uPOKT: got %d",
 			DefaultAddServiceFee,
 			p.AddServiceFee,

--- a/x/session/keeper/session_hydrator.go
+++ b/x/session/keeper/session_hydrator.go
@@ -8,10 +8,9 @@ import (
 	"fmt"
 	"math/rand"
 
-	sdkerrors "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	_ "golang.org/x/crypto/sha3"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/pokt-network/poktroll/x/session/types"
 	sharedhelpers "github.com/pokt-network/poktroll/x/shared/helpers"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
@@ -98,8 +97,7 @@ func (k Keeper) hydrateSessionMetadata(ctx context.Context, sh *sessionHydrator)
 
 	lastCommittedBlockHeight := sdk.UnwrapSDKContext(ctx).BlockHeight()
 	if sh.blockHeight > lastCommittedBlockHeight {
-		return sdkerrors.Wrapf(
-			types.ErrSessionHydration,
+		return types.ErrSessionHydration.Wrapf(
 			"block height %d is ahead of the last committed block height %d",
 			sh.blockHeight, lastCommittedBlockHeight,
 		)
@@ -212,7 +210,11 @@ func (k Keeper) hydrateSessionSuppliers(ctx context.Context, sh *sessionHydrator
 // TODO_INVESTIGATE: We are using a `Go` native implementation for a pseudo-random number generator. In order
 // for it to be language agnostic, a general purpose algorithm MUST be used.
 // pseudoRandomSelection returns a random subset of the candidates.
-func pseudoRandomSelection(candidates []*sharedtypes.Supplier, numTarget int, sessionIDBz []byte) []*sharedtypes.Supplier {
+func pseudoRandomSelection(
+	candidates []*sharedtypes.Supplier,
+	numTarget int,
+	sessionIDBz []byte,
+) []*sharedtypes.Supplier {
 	// Take the first 8 bytes of sessionId to use as the seed
 	// NB: There is specific reason why `BigEndian` was chosen over `LittleEndian` in this specific context.
 	seed := int64(binary.BigEndian.Uint64(sha3Hash(sessionIDBz)[:8]))


### PR DESCRIPTION
## Summary

As per https://github.com/pokt-network/poktroll/issues/347#issuecomment-1910838720 some sed magic to make a few adjustments.

```
:%s/sdkerrors\(\.Wrap[f?](\)\n*\s*\(.\+\),/\2\1/ge
```

### Human Summary

Conform to wrapping errors the same everywhere.

### AI Summary

reviewpad:summary

## Issue

- N/A

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make go_develop_and_test`
- [x] **Run E2E tests locally**: `make test_e2e`
- [ ] **Run E2E tests on DevNet**: Add the `devnet-test-e2e` label to the PR. This is VERY expensive, only do it after all the reviews are complete.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, updated documentation and left TODOs throughout the codebase
