### PR TITLE
[Infra] fix: relayminer config

### DIFF
--- a/localnet/poktrolld/config/relayminer_config.yaml
+++ b/localnet/poktrolld/config/relayminer_config.yaml
@@ -16,7 +16,7 @@ suppliers:
     proxy_names:
       - http-proxy
     hosts:
-      - tcp://relayminers:8545
+      - http://relayminers:8545
 metrics:
   enabled: true
   addr: :9090


### PR DESCRIPTION
## Summary

1. Fix inconsistency between supplier state and relayminer configuration which was preventing relayminer from starting
2. Fix `make localnet_regenesis` so that it no longer creates an extra, nested `config` directory.

## Issue

- N/A

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR. **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
- [ ] **Documentation changes**: `make docusaurus_start`

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and referenced any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
