### PR TITLE
[Load Testing] docs: add k6 plugins & how to build

### DIFF
--- a/docusaurus/docs/infrastructure/testing/load_testing.md
+++ b/docusaurus/docs/infrastructure/testing/load_testing.md
@@ -26,7 +26,20 @@ We use [k6](https://k6.io/) for load testing. For detailed information about k6 
 ## Dependencies
 
 - [k6](https://grafana.com/docs/k6/latest/get-started/installation/)
+- [xk6-read plugin](https://github.com/acuenca-facephi/xk6-read) (must be built with k6s)
+- [xk6-file plugin](https://github.com/avitalique/xk6-file) (must be built with k6s)
 - (For local suite execution) [LocalNet](../localnet.md)
+
+Since we depend on k6s extensions, it is necessary to build k6 with these extensions.
+This is done via another tool called `xk6`, which can be invoked inside a docker container:
+
+```bash
+docker run --rm -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" grafana/xk6 build \
+  --with github.com/acuenca-facephi/xk6-read@v1.0.0-rc1 \
+  --with github.com/avitalique/xk6-file@v1.4.0
+```
+
+This will build a k6 binary with the necessary extensions and **output it into the current directory**.
 
 ## How to run tests
 


### PR DESCRIPTION
## Summary

1. Add `xk6-read` and `xk6-file` k6 plugins to dependencies list
2. Add instructions for how to build k6 with plugins.

## Issue

- ?

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR. **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
- [ ] **Documentation changes**: `make docusaurus_start`

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and referenced any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
