### PR TITLE
[Quick change] Bump default gas limit

### DIFF
--- a/pkg/client/tx/client.go
+++ b/pkg/client/tx/client.go
@@ -233,7 +233,7 @@ func (txnClient *txClient) SignAndBroadcast(
 		Height() + txnClient.commitTimeoutHeightOffset
 
 	// TODO_TECHDEBT: this should be configurable
-	txBuilder.SetGasLimit(200000)
+	txBuilder.SetGasLimit(1000000)
 	txBuilder.SetTimeoutHeight(uint64(timeoutHeight))
 
 	// sign transactions

--- a/pkg/client/tx/client.go
+++ b/pkg/client/tx/client.go
@@ -233,7 +233,7 @@ func (txnClient *txClient) SignAndBroadcast(
 		Height() + txnClient.commitTimeoutHeightOffset
 
 	// TODO_TECHDEBT: this should be configurable
-	txBuilder.SetGasLimit(1000000)
+	txBuilder.SetGasLimit(690000042)
 	txBuilder.SetTimeoutHeight(uint64(timeoutHeight))
 
 	// sign transactions


### PR DESCRIPTION
Increasing default gas limit from `200000` to `1000000` to verify the proofs on TestNet.