### PR TITLE
[Redelegation] fix: EventRedelegation unmarshaling failure

### DIFF
--- a/pkg/client/tx/client.go
+++ b/pkg/client/tx/client.go
@@ -512,17 +512,17 @@ func (txnClient *txClient) getTxTimeoutError(ctx context.Context, txHashHex stri
 // If the resulting TxResult has empty transaction bytes, it assumes that
 // the message was not a transaction results and returns an error.
 func UnmarshalTxResult(txResultBz []byte) (*abci.TxResult, error) {
-	var rpcReponse rpctypes.RPCResponse
+	var rpcResponse rpctypes.RPCResponse
 
 	// Try to deserialize the provided bytes into an RPCResponse.
-	if err := json.Unmarshal(txResultBz, &rpcReponse); err != nil {
+	if err := json.Unmarshal(txResultBz, &rpcResponse); err != nil {
 		return nil, events.ErrEventsUnmarshalEvent.Wrap(err.Error())
 	}
 
 	var txResult cometTxEvent
 
 	// Try to deserialize the provided bytes into a TxResult.
-	if err := json.Unmarshal(rpcReponse.Result, &txResult); err != nil {
+	if err := json.Unmarshal(rpcResponse.Result, &txResult); err != nil {
 		return nil, events.ErrEventsUnmarshalEvent.Wrap(err.Error())
 	}
 

--- a/pkg/client/tx/client.go
+++ b/pkg/client/tx/client.go
@@ -529,7 +529,7 @@ func UnmarshalTxResult(txResultBz []byte) (*abci.TxResult, error) {
 	// Check if the TxResult has empty transaction bytes, which indicates
 	// the message might not be a valid transaction event.
 	if bytes.Equal(txResult.Data.Value.TxResult.Tx, []byte{}) {
-		return nil, events.ErrEventsUnmarshalEvent.Wrap("event bytes do not correspond to an comettypes.EventDataTx event")
+		return nil, events.ErrEventsUnmarshalEvent.Wrap("event bytes do not correspond to an abci.TxResult")
 	}
 
 	return &txResult.Data.Value.TxResult, nil

--- a/pkg/client/tx/client.go
+++ b/pkg/client/tx/client.go
@@ -43,13 +43,13 @@ const (
 // In order to simplify the logic of the TxClient
 var _ client.TxClient = (*txClient)(nil)
 
-// cometTxEvent is used to deserialize incoming transaction event messages
+// CometTxEvent is used to deserialize incoming transaction event messages
 // from the respective events query subscription. This structure is adapted
 // to handle CometBFT's unique serialization format, which diverges from
 // conventional approaches seen in implementations like rollkit's. The design
 // ensures accurate parsing and compatibility with CometBFT's serialization
 // of transaction results.
-type cometTxEvent struct {
+type CometTxEvent struct {
 	Data struct {
 		// TxResult is nested to accommodate CometBFT's serialization format,
 		// ensuring correct deserialization of transaction results.
@@ -519,7 +519,7 @@ func UnmarshalTxResult(txResultBz []byte) (*abci.TxResult, error) {
 		return nil, events.ErrEventsUnmarshalEvent.Wrap(err.Error())
 	}
 
-	var txResult cometTxEvent
+	var txResult CometTxEvent
 
 	// Try to deserialize the provided bytes into a TxResult.
 	if err := json.Unmarshal(rpcResponse.Result, &txResult); err != nil {

--- a/pkg/client/tx/client_test.go
+++ b/pkg/client/tx/client_test.go
@@ -8,7 +8,6 @@ import (
 
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/math"
-	abci "github.com/cometbft/cometbft/abci/types"
 	cometbytes "github.com/cometbft/cometbft/libs/bytes"
 	"github.com/cometbft/cometbft/libs/json"
 	rpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
@@ -108,13 +107,8 @@ func TestTxClient_SignAndBroadcast_Succeeds(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the expected transaction event bytes from the expected transaction bytes.
-	txResultEvent := &testTxEvent{
-		Data: testTxEventDataStruct{
-			Value: testTxEventValueStruct{
-				TxResult: abci.TxResult{Tx: expectedTx},
-			},
-		},
-	}
+	txResultEvent := &tx.CometTxEvent{}
+	txResultEvent.Data.Value.TxResult.Tx = expectedTx
 
 	txResultBz, err := json.Marshal(txResultEvent)
 	require.NoError(t, err)
@@ -437,21 +431,4 @@ func TestTxClient_SignAndBroadcast_Timeout(t *testing.T) {
 // TODO_TECHDEBT: add coverage for sending multiple messages simultaneously
 func TestTxClient_SignAndBroadcast_MultipleMsgs(t *testing.T) {
 	t.SkipNow()
-}
-
-// TODO_BLOCKER: Fix duplicate definitions of this type across tests & source code.
-// This duplicates the unexported `cometTxEvent` from `pkg/client/tx/client.go`.
-// We need to answer the following questions to avoid this:
-//   - Should tests be their own packages? (i.e. `package block` vs `package block_test`)
-//   - Should we prefer export types which are not required for API consumption?
-//   - Should we use `//go:build“ test constraint on new files using it for testing purposes?
-//   - Should we enforce all tests to use `-tags=test`?
-type testTxEvent struct {
-	Data testTxEventDataStruct `json:"data"`
-}
-type testTxEventDataStruct struct {
-	Value testTxEventValueStruct `json:"value"`
-}
-type testTxEventValueStruct struct {
-	TxResult abci.TxResult
 }

--- a/testutil/testclient/testdelegation/client.go
+++ b/testutil/testclient/testdelegation/client.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"cosmossdk.io/depinject"
-	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/libs/json"
 	rpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 	"github.com/golang/mock/gomock"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/pokt-network/poktroll/pkg/client"
 	"github.com/pokt-network/poktroll/pkg/client/delegation"
+	"github.com/pokt-network/poktroll/pkg/client/tx"
 	"github.com/pokt-network/poktroll/pkg/observable"
 	"github.com/pokt-network/poktroll/pkg/observable/channel"
 	"github.com/pokt-network/poktroll/testutil/mockclient"
@@ -153,11 +153,7 @@ func NewRedelegationEventBytes(
 	t.Helper()
 	jsonTemplate := `{"tx":"SGVsbG8sIHdvcmxkIQ==","result":{"events":[{"type":"message","attributes":[{"key":"action","value":"/pocket.application.MsgDelegateToGateway"},{"key":"sender","value":"pokt1exampleaddress"},{"key":"module","value":"application"}]},{"type":"pocket.application.EventRedelegation","attributes":[{"key":"app_address","value":"\"%s\""},{"key":"gateway_address","value":"\"%s\""}]}]}}`
 
-	txResultEvent := &testTxEvent{
-		Data: testTxEventDataStruct{
-			Value: testTxEventValueStruct{},
-		},
-	}
+	txResultEvent := &tx.CometTxEvent{}
 
 	err := json.Unmarshal(
 		[]byte(fmt.Sprintf(jsonTemplate, appAddress, gatewayAddress)),
@@ -173,21 +169,4 @@ func NewRedelegationEventBytes(
 	require.NoError(t, err)
 
 	return rpcResultBz
-}
-
-// TODO_BLOCKER: Fix duplicate definitions of this type across tests & source code.
-// This duplicates the unexported `cometTxEvent` from `pkg/client/tx/client.go`.
-// We need to answer the following questions to avoid this:
-//   - Should tests be their own packages? (i.e. `package block` vs `package block_test`)
-//   - Should we prefer export types which are not required for API consumption?
-//   - Should we use `//go:build“ test constraint on new files using it for testing purposes?
-//   - Should we enforce all tests to use `-tags=test`?
-type testTxEvent struct {
-	Data testTxEventDataStruct `json:"data"`
-}
-type testTxEventDataStruct struct {
-	Value testTxEventValueStruct `json:"value"`
-}
-type testTxEventValueStruct struct {
-	TxResult abci.TxResult
 }


### PR DESCRIPTION
## Summary

Unmarshalling transaction results logic in the delegation client is outdated, making the `RelayMiner` to panic when listening for these events.

This PR uses `tx.UnmarshalTxResult` from `txClient` to unmarshal the transaction.

## Issue

When the `RelayMiner` is running and observing `EventRedelegation`s by listening to `application` transactions, if a stake application occurs, the client tries to unmarshal it with a "pre-migration" code, causing the `RelayMiner` to panic

![image](https://github.com/pokt-network/poktroll/assets/231488/7af95bfe-c916-4afe-9d16-92149c5bd07e)

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR. **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
- [ ] **Documentation changes**: `make docusaurus_start`

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and referenced any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
