### PR TITLE
[SDK] Client TLS Support

### DIFF
--- a/pkg/client/events/websocket/dialer.go
+++ b/pkg/client/events/websocket/dialer.go
@@ -2,6 +2,9 @@ package websocket
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"strings"
 
 	"github.com/gorilla/websocket"
 
@@ -25,9 +28,21 @@ func (wsDialer *websocketDialer) DialContext(
 	ctx context.Context,
 	urlString string,
 ) (client.Connection, error) {
+
+	dialer := websocket.DefaultDialer
+
+	if strings.HasPrefix(urlString, "wss://") {
+		systemRoots, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, err
+		}
+
+		dialer.TLSClientConfig = &tls.Config{RootCAs: systemRoots}
+	}
+
 	// TODO_IMPROVE: check http response status and potential err
 	// TODO_TECHDEBT: add test coverage and ensure support for a 3xx responses
-	conn, _, err := websocket.DefaultDialer.DialContext(ctx, urlString, nil)
+	conn, _, err := dialer.DialContext(ctx, urlString, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/events/websocket/dialer.go
+++ b/pkg/client/events/websocket/dialer.go
@@ -3,7 +3,6 @@ package websocket
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"strings"
 
 	"github.com/gorilla/websocket"
@@ -32,12 +31,7 @@ func (wsDialer *websocketDialer) DialContext(
 	dialer := websocket.DefaultDialer
 
 	if strings.HasPrefix(urlString, "wss://") {
-		systemRoots, err := x509.SystemCertPool()
-		if err != nil {
-			return nil, err
-		}
-
-		dialer.TLSClientConfig = &tls.Config{RootCAs: systemRoots}
+		dialer.TLSClientConfig = &tls.Config{}
 	}
 
 	// TODO_IMPROVE: check http response status and potential err

--- a/pkg/client/events/websocket/dialer.go
+++ b/pkg/client/events/websocket/dialer.go
@@ -27,7 +27,6 @@ func (wsDialer *websocketDialer) DialContext(
 	ctx context.Context,
 	urlString string,
 ) (client.Connection, error) {
-
 	dialer := websocket.DefaultDialer
 
 	if strings.HasPrefix(urlString, "wss://") {

--- a/pkg/client/events/websocket/dialer.go
+++ b/pkg/client/events/websocket/dialer.go
@@ -10,6 +10,8 @@ import (
 	"github.com/pokt-network/poktroll/pkg/client"
 )
 
+const wssPrefix = "wss://"
+
 var _ client.Dialer = (*websocketDialer)(nil)
 
 // websocketDialer implements the Dialer interface using the gorilla websocket
@@ -29,7 +31,7 @@ func (wsDialer *websocketDialer) DialContext(
 ) (client.Connection, error) {
 	dialer := websocket.DefaultDialer
 
-	if strings.HasPrefix(urlString, "wss://") {
+	if strings.HasPrefix(urlString, wssPrefix) {
 		dialer.TLSClientConfig = &tls.Config{}
 	}
 

--- a/pkg/deps/config/suppliers.go
+++ b/pkg/deps/config/suppliers.go
@@ -69,7 +69,7 @@ func NewSupplyEventsQueryClientFn(queryNodeRPCURL *url.URL) SupplierFn {
 		_ *cobra.Command,
 	) (depinject.Config, error) {
 		// Convert the host to a websocket URL
-		queryNodeWebsocketURL := sdk.HostToWebsocketURL(queryNodeRPCURL)
+		queryNodeWebsocketURL := sdk.RPCToWebsocketURL(queryNodeRPCURL)
 		eventsQueryClient := events.NewEventsQueryClient(queryNodeWebsocketURL)
 
 		return depinject.Configs(deps, depinject.Supply(eventsQueryClient)), nil

--- a/pkg/deps/config/suppliers.go
+++ b/pkg/deps/config/suppliers.go
@@ -69,7 +69,7 @@ func NewSupplyEventsQueryClientFn(queryNodeRPCURL *url.URL) SupplierFn {
 		_ *cobra.Command,
 	) (depinject.Config, error) {
 		// Convert the host to a websocket URL
-		queryNodeWebsocketURL := sdk.HostToWebsocketURL(queryNodeRPCURL.Host)
+		queryNodeWebsocketURL := sdk.HostToWebsocketURL(queryNodeRPCURL)
 		eventsQueryClient := events.NewEventsQueryClient(queryNodeWebsocketURL)
 
 		return depinject.Configs(deps, depinject.Supply(eventsQueryClient)), nil

--- a/pkg/sdk/deps_builder.go
+++ b/pkg/sdk/deps_builder.go
@@ -107,19 +107,16 @@ func (sdk *poktrollSDK) buildDeps(
 func getTransportCreds(url *url.URL) (credentials.TransportCredentials, error) {
 	urlString := HostToGRPCUrl(url)
 
-	var creds credentials.TransportCredentials
 	if strings.HasPrefix(urlString, "grpcs://") {
 		systemRoots, err := x509.SystemCertPool()
 		if err != nil {
 			return nil, err
 		}
 
-		creds = credentials.NewTLS(&tls.Config{
+		return credentials.NewTLS(&tls.Config{
 			RootCAs: systemRoots,
-		})
-	} else {
-		creds = insecure.NewCredentials()
+		}), nil
 	}
-
-	return creds, nil
+	
+	return insecure.NewCredentials(), nil
 }

--- a/pkg/sdk/deps_builder.go
+++ b/pkg/sdk/deps_builder.go
@@ -3,7 +3,6 @@ package sdk
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"net/url"
 	"strings"
 
@@ -28,7 +27,7 @@ func (sdk *poktrollSDK) buildDeps(
 	ctx context.Context,
 	config *POKTRollSDKConfig,
 ) (depinject.Config, error) {
-	pocketNodeWebsocketURL := HostToWebsocketURL(config.QueryNodeUrl)
+	pocketNodeWebsocketURL := RPCToWebsocketURL(config.QueryNodeUrl)
 
 	// Have a new depinject config
 	deps := depinject.Configs()
@@ -105,18 +104,11 @@ func (sdk *poktrollSDK) buildDeps(
 
 // getTransportCreds creates transport credentials based on the provided URL scheme
 func getTransportCreds(url *url.URL) (credentials.TransportCredentials, error) {
-	urlString := HostToGRPCUrl(url)
+	urlString := ConstructGRPCUrl(url)
 
 	if strings.HasPrefix(urlString, "grpcs://") {
-		systemRoots, err := x509.SystemCertPool()
-		if err != nil {
-			return nil, err
-		}
-
-		return credentials.NewTLS(&tls.Config{
-			RootCAs: systemRoots,
-		}), nil
+		return credentials.NewTLS(&tls.Config{}), nil
 	}
-	
+
 	return insecure.NewCredentials(), nil
 }

--- a/pkg/sdk/deps_builder.go
+++ b/pkg/sdk/deps_builder.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"net/url"
-	"strings"
 
 	"cosmossdk.io/depinject"
 	grpctypes "github.com/cosmos/gogoproto/grpc"
@@ -102,13 +101,14 @@ func (sdk *poktrollSDK) buildDeps(
 	return deps, nil
 }
 
-// getTransportCreds creates transport credentials based on the provided URL scheme
+// getTransportCreds creates TLS or non-TLS credentials based on the url scheme provided
 func getTransportCreds(url *url.URL) (credentials.TransportCredentials, error) {
-	urlString := ConstructGRPCUrl(url)
 
-	if strings.HasPrefix(urlString, "https://") {
-		return credentials.NewTLS(&tls.Config{}), nil
+	// Config has forced non-TLS
+	if url.Scheme == "http" || url.Scheme == "tcp" {
+		return insecure.NewCredentials(), nil
 	}
 
-	return insecure.NewCredentials(), nil
+	// Default to TLS
+	return credentials.NewTLS(&tls.Config{}), nil
 }

--- a/pkg/sdk/deps_builder.go
+++ b/pkg/sdk/deps_builder.go
@@ -106,7 +106,7 @@ func (sdk *poktrollSDK) buildDeps(
 func getTransportCreds(url *url.URL) (credentials.TransportCredentials, error) {
 	urlString := ConstructGRPCUrl(url)
 
-	if strings.HasPrefix(urlString, "grpcs://") {
+	if strings.HasPrefix(urlString, "https://") {
 		return credentials.NewTLS(&tls.Config{}), nil
 	}
 

--- a/pkg/sdk/deps_builder.go
+++ b/pkg/sdk/deps_builder.go
@@ -103,7 +103,6 @@ func (sdk *poktrollSDK) buildDeps(
 
 // getTransportCreds creates TLS or non-TLS credentials based on the url scheme provided
 func getTransportCreds(url *url.URL) (credentials.TransportCredentials, error) {
-
 	// Config has forced non-TLS
 	if url.Scheme == "http" || url.Scheme == "tcp" {
 		return insecure.NewCredentials(), nil

--- a/pkg/sdk/deps_builder_test.go
+++ b/pkg/sdk/deps_builder_test.go
@@ -31,7 +31,7 @@ func TestGetTransportCreds(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			u, err := url.Parse(tc.hostUrl)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			got, err := getTransportCreds(u)
 			require.Nil(t, err)

--- a/pkg/sdk/deps_builder_test.go
+++ b/pkg/sdk/deps_builder_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestGetTransportCreds(t *testing.T) {
-
 	systemRoots, err := x509.SystemCertPool()
 	require.NoError(t, err)
 

--- a/pkg/sdk/deps_builder_test.go
+++ b/pkg/sdk/deps_builder_test.go
@@ -2,7 +2,6 @@ package sdk
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"net/url"
 	"testing"
 
@@ -12,13 +11,6 @@ import (
 )
 
 func TestGetTransportCreds(t *testing.T) {
-	systemRoots, err := x509.SystemCertPool()
-	require.NoError(t, err)
-
-	tlsCreds := credentials.NewTLS(&tls.Config{
-		RootCAs: systemRoots,
-	})
-
 	tests := []struct {
 		desc    string
 		hostUrl string
@@ -27,7 +19,7 @@ func TestGetTransportCreds(t *testing.T) {
 		{
 			desc:    "Test grpcs scheme",
 			hostUrl: "grpcs://poktroll.com",
-			want:    tlsCreds,
+			want:    credentials.NewTLS(&tls.Config{}),
 		},
 		{
 			desc:    "Test any non-grpcs scheme",
@@ -38,7 +30,8 @@ func TestGetTransportCreds(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			u, _ := url.Parse(tc.hostUrl)
+			u, err := url.Parse(tc.hostUrl)
+			require.Nil(t, err)
 
 			got, err := getTransportCreds(u)
 			require.Nil(t, err)

--- a/pkg/sdk/deps_builder_test.go
+++ b/pkg/sdk/deps_builder_test.go
@@ -1,0 +1,53 @@
+package sdk
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestGetTransportCreds(t *testing.T) {
+
+	systemRoots, err := x509.SystemCertPool()
+	if err != nil {
+		t.Error(err)
+	}
+
+	tlsCreds := credentials.NewTLS(&tls.Config{
+		RootCAs: systemRoots,
+	})
+
+	tests := []struct {
+		desc    string
+		hostUrl string
+		want    credentials.TransportCredentials
+	}{
+		{
+			desc:    "Test grpcs scheme",
+			hostUrl: "grpcs://poktroll.com",
+			want:    tlsCreds,
+		},
+		{
+			desc:    "Test any non-grpcs scheme",
+			hostUrl: "http://poktroll.com",
+			want:    insecure.NewCredentials(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			u, _ := url.Parse(tc.hostUrl)
+
+			got, err := getTransportCreds(u)
+			require.Nil(t, err)
+
+			// Comparing tc.want and got directly resulted in an error due to unexported fields
+			require.Equal(t, tc.want.Info(), got.Info())
+		})
+	}
+}

--- a/pkg/sdk/deps_builder_test.go
+++ b/pkg/sdk/deps_builder_test.go
@@ -14,7 +14,7 @@ func TestGetTransportCreds(t *testing.T) {
 	tests := []struct {
 		desc    string
 		hostUrl string
-		want    credentials.TransportCredentials
+		expectedCredentials    credentials.TransportCredentials
 	}{
 		{
 			desc:    "Test grpcs scheme",

--- a/pkg/sdk/deps_builder_test.go
+++ b/pkg/sdk/deps_builder_test.go
@@ -14,9 +14,7 @@ import (
 func TestGetTransportCreds(t *testing.T) {
 
 	systemRoots, err := x509.SystemCertPool()
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	tlsCreds := credentials.NewTLS(&tls.Config{
 		RootCAs: systemRoots,

--- a/pkg/sdk/deps_builder_test.go
+++ b/pkg/sdk/deps_builder_test.go
@@ -12,19 +12,19 @@ import (
 
 func TestGetTransportCreds(t *testing.T) {
 	tests := []struct {
-		desc    string
-		hostUrl string
-		expectedCredentials    credentials.TransportCredentials
+		desc                string
+		hostUrl             string
+		expectedCredentials credentials.TransportCredentials
 	}{
 		{
-			desc:    "Test grpcs scheme",
-			hostUrl: "grpcs://poktroll.com",
-			want:    credentials.NewTLS(&tls.Config{}),
+			desc:                "Test grpcs scheme",
+			hostUrl:             "grpcs://poktroll.com",
+			expectedCredentials: credentials.NewTLS(&tls.Config{}),
 		},
 		{
-			desc:    "Test any non-grpcs scheme",
-			hostUrl: "http://poktroll.com",
-			want:    insecure.NewCredentials(),
+			desc:                "Test any non-grpcs scheme",
+			hostUrl:             "http://poktroll.com",
+			expectedCredentials: insecure.NewCredentials(),
 		},
 	}
 
@@ -37,7 +37,7 @@ func TestGetTransportCreds(t *testing.T) {
 			require.Nil(t, err)
 
 			// Comparing tc.want and got directly resulted in an error due to unexported fields
-			require.Equal(t, tc.want.Info(), got.Info())
+			require.Equal(t, tc.expectedCredentials.Info(), got.Info())
 		})
 	}
 }

--- a/pkg/sdk/deps_builder_test.go
+++ b/pkg/sdk/deps_builder_test.go
@@ -17,14 +17,19 @@ func TestGetTransportCreds(t *testing.T) {
 		expectedCredentials credentials.TransportCredentials
 	}{
 		{
-			desc:                "Test https scheme",
-			hostUrl:             "https://poktroll.com",
-			expectedCredentials: credentials.NewTLS(&tls.Config{}),
-		},
-		{
-			desc:                "Test any non-https scheme",
+			desc:                "Test http results in insecure",
 			hostUrl:             "http://poktroll.com",
 			expectedCredentials: insecure.NewCredentials(),
+		},
+		{
+			desc:                "Test tcp results in insecure",
+			hostUrl:             "tcp://poktroll.com",
+			expectedCredentials: insecure.NewCredentials(),
+		},
+		{
+			desc:                "Test default is tls credentials",
+			hostUrl:             "other://poktroll.com",
+			expectedCredentials: credentials.NewTLS(&tls.Config{}),
 		},
 	}
 

--- a/pkg/sdk/deps_builder_test.go
+++ b/pkg/sdk/deps_builder_test.go
@@ -17,12 +17,12 @@ func TestGetTransportCreds(t *testing.T) {
 		expectedCredentials credentials.TransportCredentials
 	}{
 		{
-			desc:                "Test grpcs scheme",
-			hostUrl:             "grpcs://poktroll.com",
+			desc:                "Test https scheme",
+			hostUrl:             "https://poktroll.com",
 			expectedCredentials: credentials.NewTLS(&tls.Config{}),
 		},
 		{
-			desc:                "Test any non-grpcs scheme",
+			desc:                "Test any non-https scheme",
 			hostUrl:             "http://poktroll.com",
 			expectedCredentials: insecure.NewCredentials(),
 		},

--- a/pkg/sdk/urls.go
+++ b/pkg/sdk/urls.go
@@ -5,24 +5,29 @@ import (
 	"net/url"
 )
 
-// HostToWebsocketURL converts the provided URL into a websocket URL string that can
+// RPCToWebsocketURL converts the provided URL into a websocket URL string that can
 // be used to subscribe to onchain events and query the chain via a client
 // context or send transactions via a tx client context.
-func HostToWebsocketURL(hostUrl *url.URL) string {
-	if hostUrl.Scheme == "https" {
-		return fmt.Sprintf("wss://%s/websocket", hostUrl.Host)
-	} else {
+func RPCToWebsocketURL(hostUrl *url.URL) string {
+	if hostUrl.Scheme == "http" {
+		return fmt.Sprintf("ws://%s/websocket", hostUrl.Host)
+	} else if hostUrl.Scheme == "ws" {
 		return fmt.Sprintf("ws://%s/websocket", hostUrl.Host)
 	}
+
+	return fmt.Sprintf("wss://%s/websocket", hostUrl.Host)
 }
 
-// HostToGRPCUrl converts the provided URL into a gRPC URL string
-func HostToGRPCUrl(hostUrl *url.URL) string {
-	if hostUrl.Scheme == "https" {
-		return fmt.Sprintf("grpcs://%s", hostUrl.Host)
-	} else if hostUrl.Scheme == "grpcs" {
-		return fmt.Sprintf("grpcs://%s", hostUrl.Host)
-	} else {
+// ConstructGRPCUrl constructs a gRPC url string ensuring it contains either the scheme "grpcs" or "grpc"
+// This allows the SDK client control whether a TLS-enabled connection is used and some flexibility when specifying the gRPC URL.
+func ConstructGRPCUrl(hostUrl *url.URL) string {
+	if hostUrl.Scheme == "http" {
 		return fmt.Sprintf("grpc://%s", hostUrl.Host)
+	} else if hostUrl.Scheme == "grpc" {
+		return fmt.Sprintf("grpc://%s", hostUrl.Host)
+	} else if hostUrl.Scheme == "tcp" {
+		return fmt.Sprintf("tcp://%s", hostUrl.Host)
 	}
+
+	return fmt.Sprintf("grpcs://%s", hostUrl.Host)
 }

--- a/pkg/sdk/urls.go
+++ b/pkg/sdk/urls.go
@@ -1,10 +1,17 @@
 package sdk
 
-import "fmt"
+import (
+	"fmt"
+	"net/url"
+)
 
 // HostToWebsocketURL converts the provided host into a websocket URL that can
 // be used to subscribe to onchain events and query the chain via a client
 // context or send transactions via a tx client context.
-func HostToWebsocketURL(host string) string {
-	return fmt.Sprintf("ws://%s/websocket", host)
+func HostToWebsocketURL(hostUrl *url.URL) string {
+	if hostUrl.Scheme == "https" {
+		return fmt.Sprintf("wss://%s/websocket", hostUrl.Host)
+	} else {
+		return fmt.Sprintf("ws://%s/websocket", hostUrl.Host)
+	}
 }

--- a/pkg/sdk/urls.go
+++ b/pkg/sdk/urls.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 )
 
-// HostToWebsocketURL converts the provided host into a websocket URL that can
+// HostToWebsocketURL converts the provided URL into a websocket URL string that can
 // be used to subscribe to onchain events and query the chain via a client
 // context or send transactions via a tx client context.
 func HostToWebsocketURL(hostUrl *url.URL) string {
@@ -13,5 +13,16 @@ func HostToWebsocketURL(hostUrl *url.URL) string {
 		return fmt.Sprintf("wss://%s/websocket", hostUrl.Host)
 	} else {
 		return fmt.Sprintf("ws://%s/websocket", hostUrl.Host)
+	}
+}
+
+// HostToGRPCUrl converts the provided URL into a gRPC URL string
+func HostToGRPCUrl(hostUrl *url.URL) string {
+	if hostUrl.Scheme == "https" {
+		return fmt.Sprintf("grpcs://%s", hostUrl.Host)
+	} else if hostUrl.Scheme == "grpcs" {
+		return fmt.Sprintf("grpcs://%s", hostUrl.Host)
+	} else {
+		return fmt.Sprintf("grpc://%s", hostUrl.Host)
 	}
 }

--- a/pkg/sdk/urls.go
+++ b/pkg/sdk/urls.go
@@ -18,15 +18,3 @@ func RPCToWebsocketURL(hostUrl *url.URL) string {
 		return fmt.Sprintf("wss://%s/websocket", hostUrl.Host)
 	}
 }
-
-// ConstructGRPCUrl constructs a gRPC url string ensuring it contains either the scheme "https" or "http"
-func ConstructGRPCUrl(hostUrl *url.URL) string {
-	switch hostUrl.Scheme {
-	case "http":
-		return fmt.Sprintf("http://%s", hostUrl.Host)
-	case "tcp":
-		return fmt.Sprintf("tcp://%s", hostUrl.Host)
-	default:
-		return fmt.Sprintf("https://%s", hostUrl.Host)
-	}
-}

--- a/pkg/sdk/urls.go
+++ b/pkg/sdk/urls.go
@@ -9,25 +9,24 @@ import (
 // be used to subscribe to onchain events and query the chain via a client
 // context or send transactions via a tx client context.
 func RPCToWebsocketURL(hostUrl *url.URL) string {
-	if hostUrl.Scheme == "http" {
+	switch hostUrl.Scheme {
+	case "http":
 		return fmt.Sprintf("ws://%s/websocket", hostUrl.Host)
-	} else if hostUrl.Scheme == "ws" {
+	case "ws":
 		return fmt.Sprintf("ws://%s/websocket", hostUrl.Host)
+	default:
+		return fmt.Sprintf("wss://%s/websocket", hostUrl.Host)
 	}
-
-	return fmt.Sprintf("wss://%s/websocket", hostUrl.Host)
 }
 
-// ConstructGRPCUrl constructs a gRPC url string ensuring it contains either the scheme "grpcs" or "grpc"
-// This allows the SDK client control whether a TLS-enabled connection is used and some flexibility when specifying the gRPC URL.
+// ConstructGRPCUrl constructs a gRPC url string ensuring it contains either the scheme "https" or "http"
 func ConstructGRPCUrl(hostUrl *url.URL) string {
-	if hostUrl.Scheme == "http" {
-		return fmt.Sprintf("grpc://%s", hostUrl.Host)
-	} else if hostUrl.Scheme == "grpc" {
-		return fmt.Sprintf("grpc://%s", hostUrl.Host)
-	} else if hostUrl.Scheme == "tcp" {
+	switch hostUrl.Scheme {
+	case "http":
+		return fmt.Sprintf("http://%s", hostUrl.Host)
+	case "tcp":
 		return fmt.Sprintf("tcp://%s", hostUrl.Host)
+	default:
+		return fmt.Sprintf("https://%s", hostUrl.Host)
 	}
-
-	return fmt.Sprintf("grpcs://%s", hostUrl.Host)
 }

--- a/pkg/sdk/urls.go
+++ b/pkg/sdk/urls.go
@@ -11,9 +11,9 @@ import (
 func RPCToWebsocketURL(hostUrl *url.URL) string {
 	switch hostUrl.Scheme {
 	case "http":
-		return fmt.Sprintf("ws://%s/websocket", hostUrl.Host)
+		fallthrough
 	case "ws":
-		return fmt.Sprintf("ws://%s/websocket", hostUrl.Host)
+		fallthrough
 	case "tcp":
 		return fmt.Sprintf("ws://%s/websocket", hostUrl.Host)
 	default:

--- a/pkg/sdk/urls.go
+++ b/pkg/sdk/urls.go
@@ -14,6 +14,8 @@ func RPCToWebsocketURL(hostUrl *url.URL) string {
 		return fmt.Sprintf("ws://%s/websocket", hostUrl.Host)
 	case "ws":
 		return fmt.Sprintf("ws://%s/websocket", hostUrl.Host)
+	case "tcp":
+		return fmt.Sprintf("ws://%s/websocket", hostUrl.Host)
 	default:
 		return fmt.Sprintf("wss://%s/websocket", hostUrl.Host)
 	}

--- a/pkg/sdk/urls_test.go
+++ b/pkg/sdk/urls_test.go
@@ -12,7 +12,7 @@ func TestRPCToWebsocketURL(t *testing.T) {
 	tests := []struct {
 		desc    string
 		hostUrl string
-		want    string
+		expectedUrl    string
 	}{
 		{
 			desc:    "https results in wss",

--- a/pkg/sdk/urls_test.go
+++ b/pkg/sdk/urls_test.go
@@ -5,72 +5,69 @@ import (
 	"testing"
 
 	"github.com/pokt-network/poktroll/pkg/sdk"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHostToWebsocketURL(t *testing.T) {
 	tests := []struct {
-		name    string
+		desc    string
 		hostUrl string
 		want    string
 	}{
 		{
-			name:    "Test HTTPS",
+			desc:    "Test HTTPS",
 			hostUrl: "https://poktroll.com",
 			want:    "wss://poktroll.com/websocket",
 		},
 		{
-			name:    "Test HTTP",
+			desc:    "Test HTTP",
 			hostUrl: "http://poktroll.com",
 			want:    "ws://poktroll.com/websocket",
 		},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.desc, func(t *testing.T) {
 			u, _ := url.Parse(tc.hostUrl)
 			got := sdk.HostToWebsocketURL(u)
-			if got != tc.want {
-				t.Fatalf("expected %s; got %s", tc.want, got)
-			}
+			require.Equal(t, tc.want, got)
 		})
 	}
 }
 
 func TestHostToGRPCUrl(t *testing.T) {
 	tests := []struct {
-		name    string
+		desc    string
 		hostUrl string
 		want    string
 	}{
 		{
-			name:    "Test HTTPS",
+			desc:    "Test HTTPS",
 			hostUrl: "https://poktroll.com",
 			want:    "grpcs://poktroll.com",
 		},
 		{
-			name:    "Test with port",
+			desc:    "Test with port",
 			hostUrl: "https://poktroll.com:443",
 			want:    "grpcs://poktroll.com:443",
 		},
 		{
-			name:    "Test gRPCs",
+			desc:    "Test gRPCs",
 			hostUrl: "grpcs://poktroll.com",
 			want:    "grpcs://poktroll.com",
 		},
 		{
-			name:    "Test HTTP",
+			desc:    "Test HTTP",
 			hostUrl: "http://poktroll.com",
 			want:    "grpc://poktroll.com",
 		},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.desc, func(t *testing.T) {
 			u, _ := url.Parse(tc.hostUrl)
 			got := sdk.HostToGRPCUrl(u)
-			if got != tc.want {
-				t.Fatalf("expected %s; got %s", tc.want, got)
-			}
+			require.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/pkg/sdk/urls_test.go
+++ b/pkg/sdk/urls_test.go
@@ -92,7 +92,7 @@ func TestConstructGRPCUrl(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			u, err := url.Parse(tc.hostUrl)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			got := sdk.ConstructGRPCUrl(u)
 			require.Equal(t, tc.want, got)
 		})

--- a/pkg/sdk/urls_test.go
+++ b/pkg/sdk/urls_test.go
@@ -10,29 +10,29 @@ import (
 
 func TestRPCToWebsocketURL(t *testing.T) {
 	tests := []struct {
-		desc    string
-		hostUrl string
-		expectedUrl    string
+		desc        string
+		hostUrl     string
+		expectedUrl string
 	}{
 		{
-			desc:    "https results in wss",
-			hostUrl: "https://poktroll.com",
-			want:    "wss://poktroll.com/websocket",
+			desc:        "https results in wss",
+			hostUrl:     "https://poktroll.com",
+			expectedUrl: "wss://poktroll.com/websocket",
 		},
 		{
-			desc:    "wss stays wss",
-			hostUrl: "wss://poktroll.com",
-			want:    "wss://poktroll.com/websocket",
+			desc:        "wss stays wss",
+			hostUrl:     "wss://poktroll.com",
+			expectedUrl: "wss://poktroll.com/websocket",
 		},
 		{
-			desc:    "http results in ws",
-			hostUrl: "http://poktroll.com",
-			want:    "ws://poktroll.com/websocket",
+			desc:        "http results in ws",
+			hostUrl:     "http://poktroll.com",
+			expectedUrl: "ws://poktroll.com/websocket",
 		},
 		{
-			desc:    "default is wss",
-			hostUrl: "other://poktroll.com/websocket",
-			want:    "wss://poktroll.com/websocket",
+			desc:        "default is wss",
+			hostUrl:     "other://poktroll.com/websocket",
+			expectedUrl: "wss://poktroll.com/websocket",
 		},
 	}
 
@@ -41,51 +41,51 @@ func TestRPCToWebsocketURL(t *testing.T) {
 			u, err := url.Parse(tc.hostUrl)
 			require.NoError(t, err)
 			got := sdk.RPCToWebsocketURL(u)
-			require.Equal(t, tc.want, got)
+			require.Equal(t, tc.expectedUrl, got)
 		})
 	}
 }
 
 func TestConstructGRPCUrl(t *testing.T) {
 	tests := []struct {
-		desc    string
-		hostUrl string
-		expectedUrl    string
+		desc        string
+		hostUrl     string
+		expectedUrl string
 	}{
 		{
-			desc:    "https results in grpcs",
-			hostUrl: "https://poktroll.com",
-			want:    "grpcs://poktroll.com",
+			desc:        "https results in grpcs",
+			hostUrl:     "https://poktroll.com",
+			expectedUrl: "grpcs://poktroll.com",
 		},
 		{
-			desc:    "https with port results in grpcs",
-			hostUrl: "https://poktroll.com:443",
-			want:    "grpcs://poktroll.com:443",
+			desc:        "https with port results in grpcs",
+			hostUrl:     "https://poktroll.com:443",
+			expectedUrl: "grpcs://poktroll.com:443",
 		},
 		{
-			desc:    "grpcs stays grpcs",
-			hostUrl: "grpcs://poktroll.com",
-			want:    "grpcs://poktroll.com",
+			desc:        "grpcs stays grpcs",
+			hostUrl:     "grpcs://poktroll.com",
+			expectedUrl: "grpcs://poktroll.com",
 		},
 		{
-			desc:    "grpc stays grpc",
-			hostUrl: "grpc://poktroll.com",
-			want:    "grpc://poktroll.com",
+			desc:        "grpc stays grpc",
+			hostUrl:     "grpc://poktroll.com",
+			expectedUrl: "grpc://poktroll.com",
 		},
 		{
-			desc:    "tcp stays tcp",
-			hostUrl: "tcp://poktroll.com",
-			want:    "tcp://poktroll.com",
+			desc:        "tcp stays tcp",
+			hostUrl:     "tcp://poktroll.com",
+			expectedUrl: "tcp://poktroll.com",
 		},
 		{
-			desc:    "http results in grpc",
-			hostUrl: "http://poktroll.com",
-			want:    "grpc://poktroll.com",
+			desc:        "http results in grpc",
+			hostUrl:     "http://poktroll.com",
+			expectedUrl: "grpc://poktroll.com",
 		},
 		{
-			desc:    "default is grpcs",
-			hostUrl: "other://poktroll.com",
-			want:    "grpcs://poktroll.com",
+			desc:        "default is grpcs",
+			hostUrl:     "other://poktroll.com",
+			expectedUrl: "grpcs://poktroll.com",
 		},
 	}
 
@@ -94,7 +94,7 @@ func TestConstructGRPCUrl(t *testing.T) {
 			u, err := url.Parse(tc.hostUrl)
 			require.NoError(t, err)
 			got := sdk.ConstructGRPCUrl(u)
-			require.Equal(t, tc.want, got)
+			require.Equal(t, tc.expectedUrl, got)
 		})
 	}
 }

--- a/pkg/sdk/urls_test.go
+++ b/pkg/sdk/urls_test.go
@@ -8,65 +8,92 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHostToWebsocketURL(t *testing.T) {
+func TestRPCToWebsocketURL(t *testing.T) {
 	tests := []struct {
 		desc    string
 		hostUrl string
 		want    string
 	}{
 		{
-			desc:    "Test HTTPS",
+			desc:    "https results in wss",
 			hostUrl: "https://poktroll.com",
 			want:    "wss://poktroll.com/websocket",
 		},
 		{
-			desc:    "Test HTTP",
+			desc:    "wss stays wss",
+			hostUrl: "wss://poktroll.com",
+			want:    "wss://poktroll.com/websocket",
+		},
+		{
+			desc:    "http results in ws",
 			hostUrl: "http://poktroll.com",
 			want:    "ws://poktroll.com/websocket",
+		},
+		{
+			desc:    "default is wss",
+			hostUrl: "other://poktroll.com/websocket",
+			want:    "wss://poktroll.com/websocket",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			u, _ := url.Parse(tc.hostUrl)
-			got := sdk.HostToWebsocketURL(u)
+			u, err := url.Parse(tc.hostUrl)
+			require.Nil(t, err)
+			got := sdk.RPCToWebsocketURL(u)
 			require.Equal(t, tc.want, got)
 		})
 	}
 }
 
-func TestHostToGRPCUrl(t *testing.T) {
+func TestConstructGRPCUrl(t *testing.T) {
 	tests := []struct {
 		desc    string
 		hostUrl string
 		want    string
 	}{
 		{
-			desc:    "Test HTTPS",
+			desc:    "https results in grpcs",
 			hostUrl: "https://poktroll.com",
 			want:    "grpcs://poktroll.com",
 		},
 		{
-			desc:    "Test with port",
+			desc:    "https with port results in grpcs",
 			hostUrl: "https://poktroll.com:443",
 			want:    "grpcs://poktroll.com:443",
 		},
 		{
-			desc:    "Test gRPCs",
+			desc:    "grpcs stays grpcs",
 			hostUrl: "grpcs://poktroll.com",
 			want:    "grpcs://poktroll.com",
 		},
 		{
-			desc:    "Test HTTP",
+			desc:    "grpc stays grpc",
+			hostUrl: "grpc://poktroll.com",
+			want:    "grpc://poktroll.com",
+		},
+		{
+			desc:    "tcp stays tcp",
+			hostUrl: "tcp://poktroll.com",
+			want:    "tcp://poktroll.com",
+		},
+		{
+			desc:    "http results in grpc",
 			hostUrl: "http://poktroll.com",
 			want:    "grpc://poktroll.com",
+		},
+		{
+			desc:    "default is grpcs",
+			hostUrl: "other://poktroll.com",
+			want:    "grpcs://poktroll.com",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			u, _ := url.Parse(tc.hostUrl)
-			got := sdk.HostToGRPCUrl(u)
+			u, err := url.Parse(tc.hostUrl)
+			require.Nil(t, err)
+			got := sdk.ConstructGRPCUrl(u)
 			require.Equal(t, tc.want, got)
 		})
 	}

--- a/pkg/sdk/urls_test.go
+++ b/pkg/sdk/urls_test.go
@@ -1,0 +1,76 @@
+package sdk_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/pokt-network/poktroll/pkg/sdk"
+)
+
+func TestHostToWebsocketURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		hostUrl string
+		want    string
+	}{
+		{
+			name:    "Test HTTPS",
+			hostUrl: "https://poktroll.com",
+			want:    "wss://poktroll.com/websocket",
+		},
+		{
+			name:    "Test HTTP",
+			hostUrl: "http://poktroll.com",
+			want:    "ws://poktroll.com/websocket",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u, _ := url.Parse(tc.hostUrl)
+			got := sdk.HostToWebsocketURL(u)
+			if got != tc.want {
+				t.Fatalf("expected %s; got %s", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestHostToGRPCUrl(t *testing.T) {
+	tests := []struct {
+		name    string
+		hostUrl string
+		want    string
+	}{
+		{
+			name:    "Test HTTPS",
+			hostUrl: "https://poktroll.com",
+			want:    "grpcs://poktroll.com",
+		},
+		{
+			name:    "Test with port",
+			hostUrl: "https://poktroll.com:443",
+			want:    "grpcs://poktroll.com:443",
+		},
+		{
+			name:    "Test gRPCs",
+			hostUrl: "grpcs://poktroll.com",
+			want:    "grpcs://poktroll.com",
+		},
+		{
+			name:    "Test HTTP",
+			hostUrl: "http://poktroll.com",
+			want:    "grpc://poktroll.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u, _ := url.Parse(tc.hostUrl)
+			got := sdk.HostToGRPCUrl(u)
+			if got != tc.want {
+				t.Fatalf("expected %s; got %s", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/sdk/urls_test.go
+++ b/pkg/sdk/urls_test.go
@@ -39,7 +39,7 @@ func TestRPCToWebsocketURL(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			u, err := url.Parse(tc.hostUrl)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			got := sdk.RPCToWebsocketURL(u)
 			require.Equal(t, tc.want, got)
 		})

--- a/pkg/sdk/urls_test.go
+++ b/pkg/sdk/urls_test.go
@@ -50,7 +50,7 @@ func TestConstructGRPCUrl(t *testing.T) {
 	tests := []struct {
 		desc    string
 		hostUrl string
-		want    string
+		expectedUrl    string
 	}{
 		{
 			desc:    "https results in grpcs",

--- a/pkg/sdk/urls_test.go
+++ b/pkg/sdk/urls_test.go
@@ -53,24 +53,9 @@ func TestConstructGRPCUrl(t *testing.T) {
 		expectedUrl string
 	}{
 		{
-			desc:        "https results in grpcs",
-			hostUrl:     "https://poktroll.com",
-			expectedUrl: "grpcs://poktroll.com",
-		},
-		{
-			desc:        "https with port results in grpcs",
+			desc:        "https with port",
 			hostUrl:     "https://poktroll.com:443",
-			expectedUrl: "grpcs://poktroll.com:443",
-		},
-		{
-			desc:        "grpcs stays grpcs",
-			hostUrl:     "grpcs://poktroll.com",
-			expectedUrl: "grpcs://poktroll.com",
-		},
-		{
-			desc:        "grpc stays grpc",
-			hostUrl:     "grpc://poktroll.com",
-			expectedUrl: "grpc://poktroll.com",
+			expectedUrl: "https://poktroll.com:443",
 		},
 		{
 			desc:        "tcp stays tcp",
@@ -78,14 +63,9 @@ func TestConstructGRPCUrl(t *testing.T) {
 			expectedUrl: "tcp://poktroll.com",
 		},
 		{
-			desc:        "http results in grpc",
-			hostUrl:     "http://poktroll.com",
-			expectedUrl: "grpc://poktroll.com",
-		},
-		{
-			desc:        "default is grpcs",
+			desc:        "default is https",
 			hostUrl:     "other://poktroll.com",
-			expectedUrl: "grpcs://poktroll.com",
+			expectedUrl: "https://poktroll.com",
 		},
 	}
 

--- a/pkg/sdk/urls_test.go
+++ b/pkg/sdk/urls_test.go
@@ -45,36 +45,3 @@ func TestRPCToWebsocketURL(t *testing.T) {
 		})
 	}
 }
-
-func TestConstructGRPCUrl(t *testing.T) {
-	tests := []struct {
-		desc        string
-		hostUrl     string
-		expectedUrl string
-	}{
-		{
-			desc:        "https with port",
-			hostUrl:     "https://poktroll.com:443",
-			expectedUrl: "https://poktroll.com:443",
-		},
-		{
-			desc:        "tcp stays tcp",
-			hostUrl:     "tcp://poktroll.com",
-			expectedUrl: "tcp://poktroll.com",
-		},
-		{
-			desc:        "default is https",
-			hostUrl:     "other://poktroll.com",
-			expectedUrl: "https://poktroll.com",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-			u, err := url.Parse(tc.hostUrl)
-			require.NoError(t, err)
-			got := sdk.ConstructGRPCUrl(u)
-			require.Equal(t, tc.expectedUrl, got)
-		})
-	}
-}


### PR DESCRIPTION
## Summary

Adds TLS support to the Websocket and gRPC clients

## Issue

TLS support had not yet been added to the clients in the SDK. This support is required for testnet & mainnet.
## Type of change

Select one or more:

- [X] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR. **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
- [ ] **Documentation changes**: `make docusaurus_start`

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and referenced any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
