### PR TITLE
[Review] out-of-band review of #444

### DIFF
--- a/pkg/client/block/client.go
+++ b/pkg/client/block/client.go
@@ -146,8 +146,9 @@ func (b *blockClient) getInitialBlock(ctx context.Context) error {
 	// because it is guaranteed to be notified on block events in #goForEachBLockEvent().
 	var initialBlock client.Block
 	select {
-	case initialBlock = <-b.latestBlockReplayObs.Subscribe(ctx).Ch():
 	case initialBlock = <-blockQueryResultCh:
+	case <-b.latestBlockReplayObs.Subscribe(ctx).Ch():
+		return nil
 	case err := <-queryErrCh:
 		return err
 	}

--- a/pkg/client/block/client_integration_test.go
+++ b/pkg/client/block/client_integration_test.go
@@ -25,7 +25,7 @@ func TestBlockClient_LastNBlocks(t *testing.T) {
 	blockClient := testblock.NewLocalnetClient(ctx, t)
 	require.NotNil(t, blockClient)
 
-	block := blockClient.LastBlock()
+	block := blockClient.LastBlock(ctx)
 	require.NotEmpty(t, block)
 	require.NotZero(t, block.Height())
 	require.NotZero(t, block.Hash())

--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -10,6 +10,7 @@
 //go:generate mockgen -destination=../../testutil/mockclient/cosmos_tx_builder_mock.go -package=mockclient github.com/cosmos/cosmos-sdk/client TxBuilder
 //go:generate mockgen -destination=../../testutil/mockclient/cosmos_keyring_mock.go -package=mockclient github.com/cosmos/cosmos-sdk/crypto/keyring Keyring
 //go:generate mockgen -destination=../../testutil/mockclient/cosmos_client_mock.go -package=mockclient github.com/cosmos/cosmos-sdk/client AccountRetriever
+//go:generate mockgen -destination=../../testutil/mockclient/comet_rpc_client_mock.go -package=mockclient github.com/cosmos/cosmos-sdk/client CometRPC
 
 package client
 

--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -148,7 +148,7 @@ type BlockClient interface {
 	// the chain.
 	LastNBlocks(context.Context, int) []Block
 	// LastBlock returns the latest block that have been committed to the chain.
-	LastBlock() Block
+	LastBlock(context.Context) Block
 	// Close unsubscribes all observers of the committed block sequence
 	// observable and closes the events query client.
 	Close()

--- a/pkg/client/tx/client.go
+++ b/pkg/client/tx/client.go
@@ -229,7 +229,7 @@ func (txnClient *txClient) SignAndBroadcast(
 	}
 
 	// Calculate timeout height
-	timeoutHeight := txnClient.blockClient.LastBlock().
+	timeoutHeight := txnClient.blockClient.LastBlock(ctx).
 		Height() + txnClient.commitTimeoutHeightOffset
 
 	// TODO_TECHDEBT: this should be configurable

--- a/pkg/deps/config/suppliers.go
+++ b/pkg/deps/config/suppliers.go
@@ -91,8 +91,10 @@ func NewSupplyBlockClientFn(queryNodeRPCURL *url.URL) SupplierFn {
 			return nil, err
 		}
 
+		deps = depinject.Configs(deps, depinject.Supply(cosmosClient))
+
 		// Requires a query client to be supplied to the deps
-		blockClient, err := block.NewBlockClient(ctx, cosmosClient, deps)
+		blockClient, err := block.NewBlockClient(ctx, deps)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/deps/config/suppliers.go
+++ b/pkg/deps/config/suppliers.go
@@ -8,7 +8,7 @@ import (
 	cosmosclient "github.com/cosmos/cosmos-sdk/client"
 	cosmosflags "github.com/cosmos/cosmos-sdk/client/flags"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
-	grpc "github.com/cosmos/gogoproto/grpc"
+	"github.com/cosmos/gogoproto/grpc"
 	"github.com/spf13/cobra"
 
 	"github.com/pokt-network/poktroll/pkg/client/block"

--- a/pkg/relayer/proxy/relay_verifier.go
+++ b/pkg/relayer/proxy/relay_verifier.go
@@ -90,7 +90,7 @@ func (rp *relayerProxy) getTargetSessionBlockHeight(
 	ctx context.Context,
 	relayRequest *types.RelayRequest,
 ) (sessionBlockHeight int64, err error) {
-	currentBlockHeight := rp.blockClient.LastBlock().Height()
+	currentBlockHeight := rp.blockClient.LastBlock(ctx).Height()
 	sessionEndblockHeight := relayRequest.Meta.SessionHeader.GetSessionEndBlockHeight()
 
 	// Check if the RelayRequest's session has expired.

--- a/pkg/relayer/session/claim.go
+++ b/pkg/relayer/session/claim.go
@@ -124,7 +124,7 @@ func (rs *relayerSessionsManager) newMapClaimSessionFn(
 			return either.Error[relayer.SessionTree](err), false
 		}
 
-		latestBlock := rs.blockClient.LastBlock()
+		latestBlock := rs.blockClient.LastBlock(ctx)
 		logger.Info().
 			Int64("current_block", latestBlock.Height()+1).
 			Msg("submitting claim")

--- a/pkg/relayer/session/proof.go
+++ b/pkg/relayer/session/proof.go
@@ -95,7 +95,7 @@ func (rs *relayerSessionsManager) newMapProveSessionFn(
 		// TODO_BLOCKER: The block that'll be used as a source of entropy for which
 		// branch(es) to prove should be deterministic and use on-chain governance params
 		// rather than latest.
-		latestBlock := rs.blockClient.LastBlock()
+		latestBlock := rs.blockClient.LastBlock(ctx)
 		proof, err := session.ProveClosest(latestBlock.Hash())
 		if err != nil {
 			return either.Error[relayer.SessionTree](err), false

--- a/pkg/sdk/deps_builder.go
+++ b/pkg/sdk/deps_builder.go
@@ -26,23 +26,25 @@ func (sdk *poktrollSDK) buildDeps(
 ) (depinject.Config, error) {
 	pocketNodeWebsocketURL := HostToWebsocketURL(config.QueryNodeUrl.Host)
 
-	// Have a new depinject config
-	deps := depinject.Configs()
-
-	// Supply the logger
-	deps = depinject.Configs(deps, depinject.Supply(polylog.Ctx(ctx)))
-
 	cosmosClient, err := cosmosclient.NewClientFromNode(config.QueryNodeUrl.String())
 	if err != nil {
 		return nil, err
 	}
+
+	// Supply the logger & cosmos RPC client.
+	deps := depinject.Configs(
+		depinject.Supply(
+			polylog.Ctx(ctx),
+			cosmosClient,
+		),
+	)
 
 	// Create and supply the events query client
 	eventsQueryClient := eventsquery.NewEventsQueryClient(pocketNodeWebsocketURL)
 	deps = depinject.Configs(deps, depinject.Supply(eventsQueryClient))
 
 	// Create and supply the block client that depends on the events query client
-	blockClient, err := block.NewBlockClient(ctx, cosmosClient, deps)
+	blockClient, err := block.NewBlockClient(ctx, deps)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sdk/deps_builder.go
+++ b/pkg/sdk/deps_builder.go
@@ -6,10 +6,10 @@ import (
 	"cosmossdk.io/depinject"
 	cosmosclient "github.com/cosmos/cosmos-sdk/client"
 	grpctypes "github.com/cosmos/gogoproto/grpc"
-	grpc "google.golang.org/grpc"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	block "github.com/pokt-network/poktroll/pkg/client/block"
+	"github.com/pokt-network/poktroll/pkg/client/block"
 	"github.com/pokt-network/poktroll/pkg/client/delegation"
 	eventsquery "github.com/pokt-network/poktroll/pkg/client/events"
 	"github.com/pokt-network/poktroll/pkg/client/query"

--- a/pkg/sdk/session.go
+++ b/pkg/sdk/session.go
@@ -42,7 +42,7 @@ func (sdk *poktrollSDK) GetSessionSupplierEndpoints(
 	sdk.serviceSessionSuppliersMu.RLock()
 	defer sdk.serviceSessionSuppliersMu.RUnlock()
 
-	latestBlockHeight := sdk.blockClient.LastBlock().Height()
+	latestBlockHeight := sdk.blockClient.LastBlock(ctx).Height()
 
 	// Create the latestSessions map entry for the serviceId if it doesn't exist.
 	if _, ok := sdk.serviceSessionSuppliers[serviceId]; !ok {

--- a/testutil/testclient/testblock/client.go
+++ b/testutil/testclient/testblock/client.go
@@ -104,7 +104,7 @@ func NewAnyTimeLastNBlocksBlockClient(
 	// returns the mock block.
 	blockClientMock := mockclient.NewMockBlockClient(ctrl)
 	blockClientMock.EXPECT().LastNBlocks(gomock.Any(), gomock.Any()).Return([]client.Block{blockMock}).AnyTimes()
-	blockClientMock.EXPECT().LastBlock().Return(blockMock).AnyTimes()
+	blockClientMock.EXPECT().LastBlock(gomock.Any()).Return(blockMock).AnyTimes()
 
 	return blockClientMock
 }

--- a/testutil/testclient/testblock/client.go
+++ b/testutil/testclient/testblock/client.go
@@ -25,7 +25,7 @@ func NewLocalnetClient(ctx context.Context, t *testing.T) client.BlockClient {
 	require.NotNil(t, queryClient)
 
 	deps := depinject.Supply(queryClient)
-	bClient, err := block.NewBlockClient(ctx, nil, deps)
+	bClient, err := block.NewBlockClient(ctx, deps)
 	require.NoError(t, err)
 
 	return bClient


### PR DESCRIPTION

## Summary

Out-of-band review of #444.

### Proposed Changes

- Refactor concurrency primitives; swap `#latestBlock` & its mutex for a replay observable & corresponding publish channel.
- Simplify dependency injection; `NewBlockClient()` constructor expects an `cosmostypes.CometRPC` from `deps`.
- Replace `testCometClient` with a `cosmostypes.CometRPC` mock.

## Issue

- #444

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR. **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
- [ ] **Documentation changes**: `make docusaurus_start`

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and referenced any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
