### PR TITLE
[Docs] add time & eliminate hard-to-measure metrics

### DIFF
--- a/docusaurus/docs/internal_infrastructure/testing/load_testing_plan_1.md
+++ b/docusaurus/docs/internal_infrastructure/testing/load_testing_plan_1.md
@@ -123,12 +123,12 @@ pie showData
 - `Block Publishing` - `Tx` aggregation (ingress) and `Block` publishing (egress) could be more expensive than expected w.r.t network usage
 - `Data Availability State` - `Disk` could be a limiting factor depending on how quickly state grows
 
-|                         | RAM  | CPU  | Network | Disk |
-| ----------------------- | ---- | ---- | ------- | ---- |
-| Proof Validation        |   ❓ |   ❓ |         |      |
-| Block Generation        |   ❓ |   ❓ |         |      |
-| Block Publishing        |      |      |   ❓    |      |
-| Data Availability State |      |      |         |   ❓ |
+|                         | RAM | CPU | Network | Disk | Time |
+|-------------------------|-----|-----|---------|------|------|
+| Proof Validation        | ❓   | ❓   |         |      | ❓    |
+| Block Generation        | ❓   |     |         |      |      |
+| Block Publishing        |     |     | ❓       |      |      |
+| Data Availability State |     |     |         | ❓    |      |
 
 #### 3. AppGate Server (Application, Gateway, etc…)
 
@@ -141,12 +141,12 @@ pie showData
 - `Request Processing` - Signature generation, request marshaling / unmarshaling, etc…
 - `Response handling` - Slow supplier responses could increase pending relays at the AppGate level (i.e. RAM)
 
-|                    | RAM | CPU | Network | Disk |
-| ------------------ | --- | --- | ------- | ---- |
-| Relay Proxies      |     |     |   ❓    |      |
-| Caches & State     | ❓  | ❓  |         |      |
-| Request Processing | ❓  | ❓  |         |      |
-| ???                |     |     |         |   ❓ |
+|                    | RAM | CPU | Network | Disk | Time |
+|--------------------|-----|-----|---------|------|------|
+| Relay Proxies      |     |     | ❓       |      | ❓    |
+| Caches & State     | ❓   | ❓   |         |      |      |
+| Request Processing |     |     |         |      | ❓    |
+| ???                |     |     |         | ❓    |      |
 
 #### 4. RelayMiner (Supplier, SMT, etc..)
 
@@ -159,12 +159,12 @@ pie showData
 - `Request Processing` - Signature generation, request marshaling / unmarshaling, etc…
 - `Request generation` - Generating the actual response to the request via the dummy service
 
-|                    | RAM  | CPU  | Network | Disk |
-| ------------------ | ---- | ---- | ------- | ---- |
-| SMT                |   ❓ |   ❓ |         | ❓   |
-| Caches & State     |   ❓ |      |         |      |
-| Request Processing |   ❓ |      |         |      |
-| Request Generation |   ❓ |   ❓ |   ❓    |      |
+|                     | RAM | CPU | Network | Disk | Time |
+|---------------------|-----|-----|---------|------|------|
+| SMT                 | ❓   | ❓   |         | ❓    | ❓    |
+| Caches & State      | ❓   |     |         |      |      |
+| Request Processing  |     |     |         |      | ❓    |
+| Response Generation |     | ❓   | ❓       |      | ❓    |
 
 ### Out-of-scope
 


### PR DESCRIPTION
## Summary

- Add a column for "time" to the service metrics tables with :question: where applicable.
- Remove :question: where measurement is not feasible at the specified resolution.
  - Correlating load timing/scaling with process-level CPU metering can be used to derive sub-process CPU metrics (e.g. req./res. processing).


## Issue

- #432 
- #449 

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR. **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
- [ ] **Documentation changes**: `make docusaurus_start`

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and referenced any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
