### PR TITLE
[LocalNet] Add option to turn on/off delve

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -207,6 +207,8 @@ helm_resource(
         + str(localnet_config["validator"]["logs"]["format"]),
         "--set=serviceMonitor.enabled="
         + str(localnet_config["observability"]["enabled"]),
+        "--set=development.delve.enabled="
+        + str(localnet_config["validator"]["delve"]["enabled"]),
     ],
     image_deps=["poktrolld"],
     image_keys=[("image.repository", "image.tag")],
@@ -227,6 +229,8 @@ for x in range(localnet_config["relayminers"]["count"]):
             + ".yaml",
             "--set=metrics.serviceMonitor.enabled="
             + str(localnet_config["observability"]["enabled"]),
+            "--set=development.delve.enabled="
+            + str(localnet_config["relayminers"]["delve"]["enabled"]),
         ],
         image_deps=["poktrolld"],
         image_keys=[("image.repository", "image.tag")],
@@ -266,6 +270,8 @@ for x in range(localnet_config["appgateservers"]["count"]):
             "--set=config.signing_key=app" + str(actor_number),
             "--set=metrics.serviceMonitor.enabled="
             + str(localnet_config["observability"]["enabled"]),
+            "--set=development.delve.enabled="
+            + str(localnet_config["appgateservers"]["delve"]["enabled"]),
         ],
         image_deps=["poktrolld"],
         image_keys=[("image.repository", "image.tag")],
@@ -305,6 +311,8 @@ for x in range(localnet_config["gateways"]["count"]):
             "--set=config.signing_key=gateway" + str(actor_number),
             "--set=metrics.serviceMonitor.enabled="
             + str(localnet_config["observability"]["enabled"]),
+            "--set=development.delve.enabled="
+            + str(localnet_config["gateways"]["delve"]["enabled"]),
         ],
         image_deps=["poktrolld"],
         image_keys=[("image.repository", "image.tag")],

--- a/Tiltfile
+++ b/Tiltfile
@@ -250,7 +250,7 @@ for x in range(localnet_config["relayminers"]["count"]):
             str(8084 + actor_number)
             + ":8545",  # relayminer1 - exposes 8545, relayminer2 exposes 8546, etc.
             str(40044 + actor_number)
-            + ":40005",  # DLV port. relayminer1 - exposes 40045, relayminer2 exposes 40046, etc.
+            + ":40004",  # DLV port. relayminer1 - exposes 40045, relayminer2 exposes 40046, etc.
             # Run `curl localhost:PORT` to see the current snapshot of relayminer metrics.
             str(9069 + actor_number)
             + ":9090",  # Relayminer metrics port. relayminer1 - exposes 9070, relayminer2 exposes 9071, etc.
@@ -291,7 +291,7 @@ for x in range(localnet_config["appgateservers"]["count"]):
             str(42068 + actor_number)
             + ":42069",  # appgateserver1 - exposes 42069, appgateserver2 exposes 42070, etc.
             str(40054 + actor_number)
-            + ":40006",  # DLV port. appgateserver1 - exposes 40055, appgateserver2 exposes 40056, etc.
+            + ":40004",  # DLV port. appgateserver1 - exposes 40055, appgateserver2 exposes 40056, etc.
             # Run `curl localhost:PORT` to see the current snapshot of appgateserver metrics.
             str(9079 + actor_number)
             + ":9090",  # appgateserver metrics port. appgateserver1 - exposes 9080, appgateserver2 exposes 9081, etc.
@@ -332,7 +332,7 @@ for x in range(localnet_config["gateways"]["count"]):
             str(42078 + actor_number)
             + ":42069",  # gateway1 - exposes 42079, gateway2 exposes 42080, etc.
             str(40064 + actor_number)
-            + ":40006",  # DLV port. gateway1 - exposes 40065, gateway2 exposes 40066, etc.
+            + ":40004",  # DLV port. gateway1 - exposes 40065, gateway2 exposes 40066, etc.
             # Run `curl localhost:PORT` to see the current snapshot of gateway metrics.
             str(9089 + actor_number)
             + ":9090",  # gateway metrics port. gateway1 - exposes 9090, gateway2 exposes 9091, etc.

--- a/Tiltfile
+++ b/Tiltfile
@@ -25,11 +25,21 @@ localnet_config_defaults = {
             "level": "info",
             "format": "json",
         },
+        "delve": {"enabled": False},
     },
     "observability": {"enabled": True},
-    "relayminers": {"count": 1},
-    "gateways": {"count": 1},
-    "appgateservers": {"count": 1},
+    "relayminers": {
+        "count": 1,
+        "delve": {"enabled": False}
+    },
+    "gateways": {
+        "count": 1,
+        "delve": {"enabled": False},    
+    },
+    "appgateservers": {
+        "count": 1,
+        "delve": {"enabled": False},    
+    },
     # By default, we use the `helm_repo` function below to point to the remote repository
     # but can update it to the locally cloned repo for testing & development
     "helm_chart_local_repo": {"enabled": False, "path": "../helm-charts"},


### PR DESCRIPTION
## Summary

Allows to turn delve on and off using `localnet_config.yaml`.

The related changes to helm charts were added in [this PR](https://github.com/pokt-network/helm-charts/pull/34/files) - new functionality is optional and turned off by default, so I felt confident to merge.

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
