### PR TITLE
[Testing] Supplier staking E2E test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,6 +322,10 @@ test_e2e: test_e2e_env ## Run all E2E tests
 test_e2e_app:
 	go test -v ./e2e/tests/... -tags=e2e,test --features-path=stake_app.feature
 
+.PHONY: test_e2e_supplier
+test_e2e_supplier:
+	go test -v ./e2e/tests/... -tags=e2e,test --features-path=stake_supplier.feature
+
 .PHONY: test_e2e_gateway
 test_e2e_gateway:
 	go test -v ./e2e/tests/... -tags=e2e,test --features-path=stake_gateway.feature

--- a/e2e/tests/stake_supplier.feature
+++ b/e2e/tests/stake_supplier.feature
@@ -1,0 +1,28 @@
+Feature: Stake Supplier Namespace
+
+    Scenario: User can stake a Supplier
+        Given the user has the pocketd binary installed
+        And the "supplier" for account "supplier2" is not staked
+        # Stake with 1 uPOKT more than the current stake used in genesis to make
+        # the transaction succeed.
+        And the account "supplier2" has a balance greater than "1000070" uPOKT
+        When the user stakes a "supplier" with "1000070" uPOKT for "anvil" service from the account "supplier2"
+        Then the user should be able to see standard output containing "txhash:"
+        And the user should be able to see standard output containing "code: 0"
+        And the pocketd binary should exit without error
+        # TODO_TECHDEBT(@Olshansk, @red-0ne): Replace these time-based waits with event listening waits
+        And the user should wait for "5" seconds
+        And the "supplier" for account "supplier2" is staked with "1000070" uPOKT
+        And the account balance of "supplier2" should be "1000070" uPOKT "less" than before
+
+    Scenario: User can unstake a Supplier
+        Given the user has the pocketd binary installed
+        And the "supplier" for account "supplier2" is staked with "1000070" uPOKT
+        And an account exists for "supplier2"
+        When the user unstakes a "supplier" from the account "supplier2"
+        Then the user should be able to see standard output containing "txhash:"
+        And the user should be able to see standard output containing "code: 0"
+        And the pocketd binary should exit without error
+        And the user should wait for "5" seconds
+        And the "supplier" for account "supplier2" is not staked
+        And the account balance of "supplier2" should be "1000070" uPOKT "more" than before


### PR DESCRIPTION
## Summary

E2E Tests for staking the supplier: `make test_e2e_supplier`

## Issue

- #460

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing
**Local Testing** (only if making code changes)
- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [x] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)