### PR TITLE
[LocalNet] Remove tilt-restart-wrapper

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -179,9 +179,6 @@ WORKDIR /
 """,
     only=["./bin/poktrolld"],
     entrypoint=[
-        "/tilt-restart-wrapper",
-        "--watch_file=/tmp/.restart-proc",
-        "--entr_flags=-r",
         "poktrolld",
     ],
     live_update=[sync("bin/poktrolld", "/usr/local/bin/poktrolld")],


### PR DESCRIPTION
## Summary

Removes `tilt-restart-wrapper` because apparently tilt also injects it when `entrypoint` argument is present. As a result we ended up having `tilt-restart-wrapper` that wraps `tilt-restart-wrapper` that wraps `poktrolld` :) 

Fixes an issue with port collision on hot reloading.