### PR TITLE
[Bug] Fix pprof endpoint

### DIFF
--- a/localnet/kubernetes/values-appgateserver.yaml
+++ b/localnet/kubernetes/values-appgateserver.yaml
@@ -5,5 +5,5 @@ config:
     enabled: true
     addr: :9090
   pprof:
-    enabled: false
+    enabled: true
     addr: localhost:6060

--- a/localnet/kubernetes/values-gateway.yaml
+++ b/localnet/kubernetes/values-gateway.yaml
@@ -6,5 +6,5 @@ config:
     enabled: true
     addr: :9090
   pprof:
-    enabled: false
+    enabled: true
     addr: localhost:6060

--- a/localnet/kubernetes/values-relayminer-common.yaml
+++ b/localnet/kubernetes/values-relayminer-common.yaml
@@ -9,5 +9,5 @@ config:
     tx_node_rpc_url: tcp://validator-poktroll-validator:36657
   suppliers: []
   pprof:
-    enabled: false
+    enabled: true
     addr: localhost:6060

--- a/pkg/appgateserver/cmd/cmd.go
+++ b/pkg/appgateserver/cmd/cmd.go
@@ -145,7 +145,7 @@ func runAppGateServer(cmd *cobra.Command, _ []string) error {
 	}
 
 	if appGateConfigs.Pprof.Enabled {
-		err = appGateServer.ServePprof(appGateConfigs.Pprof.Addr)
+		err = appGateServer.ServePprof(ctx, appGateConfigs.Pprof.Addr)
 		if err != nil {
 			return fmt.Errorf("failed to start pprof endpoint: %w", err)
 		}

--- a/pkg/appgateserver/server.go
+++ b/pkg/appgateserver/server.go
@@ -287,8 +287,13 @@ func (app *appGateServer) ServePprof(addr string) error {
 		Handler: pprofMux,
 	}
 
-	app.logger.Info().Str("endpoint", addr).Msg("starting a pprof endpoint")
-	return server.ListenAndServe()
+	// If no error, start the server in a new goroutine
+	go func() {
+		app.logger.Info().Str("endpoint", addr).Msg("starting a pprof endpoint")
+		server.ListenAndServe()
+	}()
+
+	return nil
 }
 
 type appGateServerOption func(*appGateServer)

--- a/pkg/appgateserver/server.go
+++ b/pkg/appgateserver/server.go
@@ -296,7 +296,7 @@ func (app *appGateServer) ServePprof(ctx context.Context, addr string) error {
 	go func() {
 		<-ctx.Done()
 		app.logger.Info().Str("endpoint", addr).Msg("stopping a pprof endpoint")
-		server.Close()
+		server.Shutdown(ctx)
 	}()
 
 	return nil

--- a/pkg/appgateserver/server.go
+++ b/pkg/appgateserver/server.go
@@ -274,7 +274,7 @@ func (app *appGateServer) ServeMetrics(addr string) error {
 }
 
 // Starts a pprof server on the given address.
-func (app *appGateServer) ServePprof(addr string) error {
+func (app *appGateServer) ServePprof(ctx context.Context, addr string) error {
 	pprofMux := http.NewServeMux()
 	pprofMux.HandleFunc("/debug/pprof/", pprof.Index)
 	pprofMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
@@ -291,6 +291,12 @@ func (app *appGateServer) ServePprof(addr string) error {
 	go func() {
 		app.logger.Info().Str("endpoint", addr).Msg("starting a pprof endpoint")
 		server.ListenAndServe()
+	}()
+
+	go func() {
+		<-ctx.Done()
+		app.logger.Info().Str("endpoint", addr).Msg("stopping a pprof endpoint")
+		server.Close()
 	}()
 
 	return nil

--- a/pkg/relayer/cmd/cmd.go
+++ b/pkg/relayer/cmd/cmd.go
@@ -130,7 +130,7 @@ func runRelayer(cmd *cobra.Command, _ []string) error {
 	}
 
 	if relayMinerConfig.Pprof.Enabled {
-		err = relayMiner.ServePprof(relayMinerConfig.Pprof.Addr)
+		err = relayMiner.ServePprof(ctx, relayMinerConfig.Pprof.Addr)
 		if err != nil {
 			return fmt.Errorf("failed to start pprof endpoint: %w", err)
 		}

--- a/pkg/relayer/relayminer.go
+++ b/pkg/relayer/relayminer.go
@@ -118,7 +118,11 @@ func (rel *relayMiner) ServePprof(addr string) error {
 		Addr:    addr,
 		Handler: pprofMux,
 	}
+	// If no error, start the server in a new goroutine
+	go func() {
+		rel.logger.Info().Str("endpoint", addr).Msg("starting a pprof endpoint")
+		server.ListenAndServe()
+	}()
 
-	rel.logger.Info().Str("endpoint", addr).Msg("starting a pprof endpoint")
-	return server.ListenAndServe()
+	return nil
 }

--- a/pkg/relayer/relayminer.go
+++ b/pkg/relayer/relayminer.go
@@ -127,7 +127,7 @@ func (rel *relayMiner) ServePprof(ctx context.Context, addr string) error {
 	go func() {
 		<-ctx.Done()
 		rel.logger.Info().Str("endpoint", addr).Msg("stopping a pprof endpoint")
-		server.Close()
+		server.Shutdown(ctx)
 	}()
 
 	return nil

--- a/pkg/relayer/relayminer.go
+++ b/pkg/relayer/relayminer.go
@@ -106,7 +106,7 @@ func (rel *relayMiner) ServeMetrics(addr string) error {
 }
 
 // Starts a pprof server on the given address.
-func (rel *relayMiner) ServePprof(addr string) error {
+func (rel *relayMiner) ServePprof(ctx context.Context, addr string) error {
 	pprofMux := http.NewServeMux()
 	pprofMux.HandleFunc("/debug/pprof/", pprof.Index)
 	pprofMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
@@ -122,6 +122,12 @@ func (rel *relayMiner) ServePprof(addr string) error {
 	go func() {
 		rel.logger.Info().Str("endpoint", addr).Msg("starting a pprof endpoint")
 		server.ListenAndServe()
+	}()
+
+	go func() {
+		<-ctx.Done()
+		rel.logger.Info().Str("endpoint", addr).Msg("stopping a pprof endpoint")
+		server.Close()
 	}()
 
 	return nil


### PR DESCRIPTION
## Summary

Pprof prevents services from starting. It was not run inside a routine and caused a lock where it shouldn't have been.

## Issue

- #499

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
