### PR TITLE
[CI] Add GATEWAY_URL envar for e2e tests

### DIFF
--- a/.github/workflows-helpers/run-e2e-test-job-template.yaml
+++ b/.github/workflows-helpers/run-e2e-test-job-template.yaml
@@ -11,42 +11,44 @@ spec:
         pokt.network/purpose: e2e-tests
     spec:
       containers:
-        - name: e2e-tests
-          image: ghcr.io/pokt-network/poktrolld:${IMAGE_TAG}
-          command: ["/bin/sh"]
-          args:
-            - "-c"
-            - |
-              poktrolld q gateway list-gateway --node=$POCKET_NODE && \
-              poktrolld q application list-application --node=$POCKET_NODE && \
-              poktrolld q supplier list-supplier --node=$POCKET_NODE && \
-              make acc_initialize_pubkeys && \
-              go test -v ./e2e/tests/... -tags=e2e
-          env:
-            - name: POCKET_NODE
-              value: tcp://${NAMESPACE}-validator-poktrolld:36657
-            - name: VALIDATOR_RPC_ENDPOINT
-              value: ${NAMESPACE}-validator-poktrolld:36657
-            - name: E2E_DEBUG_OUTPUT
-              value: "false" # Flip to true to see the command and result of the execution
-            - name: POKTROLLD_HOME
-              value: /root/.poktroll
-            - name: APPGATE_SERVER_URL
-              value: http://${NAMESPACE}-appgate-server:80
-          volumeMounts:
-            - mountPath: /root/.poktroll/keyring-test/
-              name: keys-volume
-            - mountPath: /root/.poktroll/config/
-              name: configs-volume
+      - name: e2e-tests
+        image: ghcr.io/pokt-network/poktrolld:${IMAGE_TAG}
+        command: ["/bin/sh"]
+        args:
+        - "-c"
+        - |
+          poktrolld q gateway list-gateway --node=$POCKET_NODE && \
+          poktrolld q application list-application --node=$POCKET_NODE && \
+          poktrolld q supplier list-supplier --node=$POCKET_NODE && \
+          make acc_initialize_pubkeys && \
+          go test -v ./e2e/tests/... -tags=e2e
+        env:
+        - name: POCKET_NODE
+          value: tcp://${NAMESPACE}-validator-poktrolld:36657
+        - name: VALIDATOR_RPC_ENDPOINT
+          value: ${NAMESPACE}-validator-poktrolld:36657
+        - name: E2E_DEBUG_OUTPUT
+          value: "false" # Flip to true to see the command and result of the execution
+        - name: POKTROLLD_HOME
+          value: /root/.poktroll
+        - name: APPGATE_SERVER_URL
+          value: http://${NAMESPACE}-appgate-server:80
+        - name: GATEWAY_URL
+          value: http://${NAMESPACE}-gateway:80
+        volumeMounts:
+        - mountPath: /root/.poktroll/keyring-test/
+          name: keys-volume
+        - mountPath: /root/.poktroll/config/
+          name: configs-volume
       restartPolicy: Never
       volumes:
-        - secret:
-            defaultMode: 420
-            secretName: keys-${IMAGE_TAG}
-          name: keys-volume
-        - configMap:
-            defaultMode: 420
-            name: configs-${IMAGE_TAG}
-          name: configs-volume
+      - secret:
+          defaultMode: 420
+          secretName: keys-${IMAGE_TAG}
+        name: keys-volume
+      - configMap:
+          defaultMode: 420
+          name: configs-${IMAGE_TAG}
+        name: configs-volume
       serviceAccountName: default
   backoffLimit: 0

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHELL = /bin/sh
 POKTROLLD_HOME ?= ./localnet/poktrolld
 POCKET_NODE ?= tcp://127.0.0.1:36657 # The pocket node (validator in the localnet context)
 APPGATE_SERVER ?= http://localhost:42069
+GATEWAY_URL ?= http://localhost:42079
 POCKET_ADDR_PREFIX = pokt
 CHAIN_ID = poktroll
 


### PR DESCRIPTION
## Summary

Gateway has been deployed on our DevNets. This PR introduces `GATEWAY_URL` environment variable in CI that points to the gateway on DevNet infrastructure.
