### PR TITLE
[RelayMiner] Support https backend urls

### DIFF
--- a/pkg/relayer/config/proxy_http_config_parser.go
+++ b/pkg/relayer/config/proxy_http_config_parser.go
@@ -26,11 +26,11 @@ func (serverConfig *RelayMinerServerConfig) parseHTTPServerConfig(
 	return nil
 }
 
-// parseHTTPSupplierConfig populates the supplier fields of the target structure
-// that are relevant to "http" specific service configurations.
+// parseSupplierBackendUrl populates the supplier fields of the target structure
+// that are relevant to "http" and "https" backend url service configurations.
 // This function alters the target RelayMinerSupplierServiceConfig structure
 // as a side effect.
-func (supplierServiceConfig *RelayMinerSupplierServiceConfig) parseHTTPSupplierConfig(
+func (supplierServiceConfig *RelayMinerSupplierServiceConfig) parseSupplierBackendUrl(
 	yamlSupplierServiceConfig YAMLRelayMinerSupplierServiceConfig,
 ) error {
 	// Check if the supplier backend url is empty

--- a/pkg/relayer/config/supplier_hydrator.go
+++ b/pkg/relayer/config/supplier_hydrator.go
@@ -68,10 +68,10 @@ func (supplierConfig *RelayMinerSupplierConfig) HydrateSupplier(
 	// by their own functions.
 	supplierConfig.ServiceConfig = &RelayMinerSupplierServiceConfig{}
 	switch backendUrl.Scheme {
-	case "http":
+	case "http", "https":
 		supplierConfig.ServerType = RelayMinerServerTypeHTTP
 		if err := supplierConfig.ServiceConfig.
-			parseHTTPSupplierConfig(yamlSupplierConfig.ServiceConfig); err != nil {
+			parseSupplierBackendUrl(yamlSupplierConfig.ServiceConfig); err != nil {
 			return err
 		}
 	default:

--- a/pkg/relayer/proxy/synchronous.go
+++ b/pkg/relayer/proxy/synchronous.go
@@ -278,6 +278,8 @@ func (sync *synchronousRPCServer) serveHTTP(
 		relayHTTPRequest.Header.Add(key, value)
 	}
 
+	// Configure the HTTP client to use the appropriate transport based on the
+	// backend URL scheme.
 	var client *http.Client
 	switch serviceConfig.BackendUrl.Scheme {
 	case "https":

--- a/pkg/relayer/proxy/synchronous.go
+++ b/pkg/relayer/proxy/synchronous.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -277,8 +278,19 @@ func (sync *synchronousRPCServer) serveHTTP(
 		relayHTTPRequest.Header.Add(key, value)
 	}
 
+	var client *http.Client
+	switch serviceConfig.BackendUrl.Scheme {
+	case "https":
+		transport := &http.Transport{
+			TLSClientConfig: &tls.Config{},
+		}
+		client = &http.Client{Transport: transport}
+	default:
+		client = http.DefaultClient
+	}
+
 	// Send the relay request to the native service.
-	httpResponse, err := http.DefaultClient.Do(relayHTTPRequest)
+	httpResponse, err := client.Do(relayHTTPRequest)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Make `RelayMiner` support forwarding relay requests to `https` backends.

It infers the protocol to use from the `backend_url` schema and constructs the appropriate client.

Updates the `RelayMiner` config parser and make it accept `https` backend urls.

## Issue

The `RelayMiner` is not capable of forwarding relay requests to `https` `backend_url`s, which is a quite widespread setup among node runners.

https://github.com/pokt-network/poktroll/issues/499#issuecomment-2078487122

![image](https://github.com/pokt-network/poktroll/assets/231488/cce8528a-5e9f-4bb2-bbcc-a29a5162f4a4)


## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Local Testing** (only if making code changes)
- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
