### PR TITLE
[Utility] Update SessionSettlement when app goes into a negative amount

### DIFF
--- a/x/tokenomics/types/errors.go
+++ b/x/tokenomics/types/errors.go
@@ -19,5 +19,5 @@ var (
 	ErrTokenomicsApplicationAddressInvalid  = sdkerrors.Register(ModuleName, 1112, "the application address in the claim is not a valid bech32 address")
 	ErrTokenomicsParamsInvalid              = sdkerrors.Register(ModuleName, 1113, "provided params are invalid")
 	ErrTokenomicsRootHashInvalid            = sdkerrors.Register(ModuleName, 1114, "the root hash in the claim is invalid")
-	ErrTokenomicsApplicationNewStakeInvalid = sdkerrors.Register(ModuleName, 1115, "application stake cannot be reduce to a -ve amount")
+	ErrTokenomicsApplicationNewStakeInvalid = sdkerrors.Register(ModuleName, 1115, "application stake cannot be reduced to a -ve amount")
 )


### PR DESCRIPTION
## Summary

When an app exceeds its stake, make the settlement amount its full balance.

Prevent an error to avoid consensus breaking issues.

## Issue

It seems that a segfault occurs when we restart due to the -ve balance an app tries to hit.

Started with this:

<img width="762" alt="Screenshot 2024-04-27 at 6 28 01 PM" src="https://github.com/pokt-network/poktroll/assets/1892194/6231033b-f90e-43bc-aeb7-24285ba8a10f">

And then we found this:

<img width="1063" alt="Screenshot 2024-04-27 at 5 37 33 PM" src="https://github.com/pokt-network/poktroll/assets/1892194/df55a2f0-78cd-43f2-98d5-07bd0d1fca0f">

<img width="1234" alt="Screenshot 2024-04-27 at 5 37 26 PM" src="https://github.com/pokt-network/poktroll/assets/1892194/b255a28c-f357-4e95-8bb1-0dad10f3951a">

Which led us to discovering this:

<img width="1840" alt="Screenshot 2024-04-27 at 6 13 50 PM" src="https://github.com/pokt-network/poktroll/assets/1892194/55bbfb19-ca2a-49f2-bca8-0c008b6d9b85">


## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Local Testing** (only if making code changes)
- [x] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
