### PR TITLE
[Code Health] chore: cleanup localnet testutils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,7 +450,7 @@ todo_count: ## Print a count of all the TODOs in the project
 
 .PHONY: todo_this_commit
 todo_this_commit: ## List all the TODOs needed to be done in this commit
-	grep --exclude-dir={.git,vendor,.vscode} --exclude=Makefile -r -e "TODO_IN_THIS_"
+	grep -n --exclude-dir={.git,vendor,.vscode,.idea} --exclude={Makefile,reviewdog.yml} -r -e "TODO_IN_THIS_"
 
 ####################
 ###   Gateways   ###

--- a/testutil/testclient/localnet.go
+++ b/testutil/testclient/localnet.go
@@ -4,8 +4,12 @@ import (
 	"fmt"
 	"os"
 
+	"cosmossdk.io/depinject"
+	"cosmossdk.io/log"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/regen-network/gocuke"
 	"github.com/spf13/pflag"
@@ -21,11 +25,32 @@ var (
 
 	// CometLocalWebsocketURL provides a default URL pointing to the localnet websocket endpoint.
 	CometLocalWebsocketURL = "ws://localhost:36657/websocket"
+
+	// TxConfig provided by ... ?
+	TxConfig          client.TxConfig
+	Marshaler         codec.Codec
+	InterfaceRegistry codectypes.InterfaceRegistry
 )
 
 // init initializes the SDK configuration upon package import.
 func init() {
 	cmd.InitSDKConfig()
+
+	deps := depinject.Configs(
+		app.AppConfig(),
+		depinject.Supply(
+			app.AppConfig(),
+			log.NewLogger(os.Stderr),
+		),
+	)
+	if err := depinject.Inject(
+		deps,
+		&TxConfig,
+		&Marshaler,
+		&InterfaceRegistry,
+	); err != nil {
+		panic(err)
+	}
 
 	// If VALIDATOR_RPC_ENDPOINT environment variable is set, use it to override the default localnet endpoint.
 	if endpoint := os.Getenv("VALIDATOR_RPC_ENDPOINT"); endpoint != "" {
@@ -50,8 +75,11 @@ func NewLocalnetClientCtx(t gocuke.TestingT, flagSet *pflag.FlagSet) *client.Con
 
 	homedir := app.DefaultNodeHome
 	clientCtx := client.Context{}.
+		WithCodec(Marshaler).
+		WithTxConfig(TxConfig).
 		WithHomeDir(homedir).
-		WithAccountRetriever(authtypes.AccountRetriever{})
+		WithAccountRetriever(authtypes.AccountRetriever{}).
+		WithInterfaceRegistry(InterfaceRegistry)
 
 	clientCtx, err := client.ReadPersistentCommandFlags(clientCtx, flagSet)
 	require.NoError(t, err)

--- a/testutil/testclient/localnet.go
+++ b/testutil/testclient/localnet.go
@@ -26,9 +26,11 @@ var (
 	// CometLocalWebsocketURL provides a default URL pointing to the localnet websocket endpoint.
 	CometLocalWebsocketURL = "ws://localhost:36657/websocket"
 
-	// TxConfig provided by ... ?
-	TxConfig          client.TxConfig
-	Marshaler         codec.Codec
+	// TxConfig provided by app.AppConfig(), intended as a convenience for use in tests.
+	TxConfig client.TxConfig
+	// Marshaler provided by app.AppConfig(), intended as a convenience for use in tests.
+	Marshaler codec.Codec
+	// InterfaceRegistry provided by app.AppConfig(), intended as a convenience for use in tests.
 	InterfaceRegistry codectypes.InterfaceRegistry
 )
 
@@ -39,10 +41,11 @@ func init() {
 	deps := depinject.Configs(
 		app.AppConfig(),
 		depinject.Supply(
-			app.AppConfig(),
 			log.NewLogger(os.Stderr),
 		),
 	)
+
+	// Ensure that the global variables are initialized.
 	if err := depinject.Inject(
 		deps,
 		&TxConfig,

--- a/testutil/testclient/localnet.go
+++ b/testutil/testclient/localnet.go
@@ -4,12 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"cosmossdk.io/depinject"
-	"cosmossdk.io/log"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/codec"
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/regen-network/gocuke"
 	"github.com/spf13/pflag"
@@ -25,32 +21,11 @@ var (
 
 	// CometLocalWebsocketURL provides a default URL pointing to the localnet websocket endpoint.
 	CometLocalWebsocketURL = "ws://localhost:36657/websocket"
-
-	// TODO_IN_THIS_COMMIT: godoc comments...
-	TxConfig          client.TxConfig
-	Marshaler         codec.Codec
-	InterfaceRegistry codectypes.InterfaceRegistry
 )
 
 // init initializes the SDK configuration upon package import.
 func init() {
 	cmd.InitSDKConfig()
-
-	deps := depinject.Configs(
-		app.AppConfig(),
-		depinject.Supply(
-			app.AppConfig(),
-			log.NewLogger(os.Stderr),
-		),
-	)
-	if err := depinject.Inject(
-		deps,
-		&TxConfig,
-		&Marshaler,
-		&InterfaceRegistry,
-	); err != nil {
-		panic(err)
-	}
 
 	// If VALIDATOR_RPC_ENDPOINT environment variable is set, use it to override the default localnet endpoint.
 	if endpoint := os.Getenv("VALIDATOR_RPC_ENDPOINT"); endpoint != "" {
@@ -75,11 +50,8 @@ func NewLocalnetClientCtx(t gocuke.TestingT, flagSet *pflag.FlagSet) *client.Con
 
 	homedir := app.DefaultNodeHome
 	clientCtx := client.Context{}.
-		WithCodec(Marshaler).
-		WithTxConfig(TxConfig).
 		WithHomeDir(homedir).
-		WithAccountRetriever(authtypes.AccountRetriever{}).
-		WithInterfaceRegistry(InterfaceRegistry)
+		WithAccountRetriever(authtypes.AccountRetriever{})
 
 	clientCtx, err := client.ReadPersistentCommandFlags(clientCtx, flagSet)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Exclude Jetbrains IDE dotfiles (`.idea/`) & reviewdog.yml from `make todo_this_commit`
- Simplify localnet testutil; remove unused/unnecessary dependency injected variables
- Add godoc comments for global test variables

## Issue

Observations made while using `make todo_this_commit`.

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [x] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [x] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
