### PR TITLE
[Documentation] Improve RelayMiner staking related documentation

### DIFF
--- a/docusaurus/docs/operate/configs/relayminer_config.md
+++ b/docusaurus/docs/operate/configs/relayminer_config.md
@@ -116,6 +116,20 @@ The name of the key that will be used to sign transactions, derive the public ke
 and the corresponding address. This key name MUST be present in the keyring that is used
 to start the `RelayMiner` instance.
 
+:::note
+
+Multiple `RelayMiner`s can be configured with the same `signing_key_name` to
+sign `RelayResponse`s and submit `Claim`s and `Proof`s transactions to the Pocket
+network. (e.g. This is useful for a `Supplier` that is willing to provide redundant
+or geographically distributed services.)
+
+But it is not possible to have a single `RelayMiner` instance running with multiple
+`signing_key_name`s as this would involve more complex logic and/or configuration
+to determine which key to use, especially in the case of `Supplier`s that have
+overlapping services provided.
+
+:::
+
 ### `smt_store_path`
 
 _`Required`_

--- a/docusaurus/docs/operate/configs/relayminer_config.md
+++ b/docusaurus/docs/operate/configs/relayminer_config.md
@@ -154,13 +154,13 @@ flowchart
     S2 -.- RM4
 ```
 
-But it is not possible to have a single `RelayMiner` instance running with multiple
-`signing_key_name`s as this would involve more complex logic and/or configuration
-to determine which key to use, especially in the case of `Supplier`s that have
-overlapping services provided.
+TODO(#528): It is not currently possible to have a single `RelayMiner` instance
+running with multiple `signing_key_name`s as this would involve more complex logic
+and/or configuration to determine which key to use, especially in the case of
+`Supplier`s that have overlapping services provided.
 
-TL;DR A 1:N Supplier:RelayMiner is okay, but a N:1 RelayMiner:Supplier relationship
-is not.
+TL;DR A 1:N Supplier:RelayMiner is possible, but a 1:N RelayMiner:Supplier relationship
+is not until #528 is complete.
 
 :::
 

--- a/docusaurus/docs/operate/configs/relayminer_config.md
+++ b/docusaurus/docs/operate/configs/relayminer_config.md
@@ -123,10 +123,44 @@ sign `RelayResponse`s and submit `Claim`s and `Proof`s transactions to the Pocke
 network. (e.g. This is useful for a `Supplier` that is willing to provide redundant
 or geographically distributed services.)
 
+```mermaid
+flowchart
+
+    subgraph USW[US West]
+        RM1["Relay Miner 1 <br> (signing_key_name=Supplier1)"]
+    end
+
+    subgraph USE[US East]
+        RM2["Relay Miner 2 <br> (signing_key_name=Supplier1)"]
+    end
+
+    subgraph EUC[EU Central]
+        RM3["Relay Miner 3 <br> (signing_key_name=Supplier1)"]
+    end
+
+    subgraph CAC[CA Central]
+        RM4["Relay Miner 4 <br> (signing_key_name=Supplier2)"]
+    end
+
+    subgraph PB[POKT Blockchain]
+        direction TB
+        S1[Supplier1]
+        S2[Supplier2]
+    end
+
+    S1 -.- RM1
+    S1 -.- RM2
+    S1 -.- RM3
+    S2 -.- RM4
+```
+
 But it is not possible to have a single `RelayMiner` instance running with multiple
 `signing_key_name`s as this would involve more complex logic and/or configuration
 to determine which key to use, especially in the case of `Supplier`s that have
 overlapping services provided.
+
+TL;DR A 1:N Supplier:RelayMiner is okay, but a N:1 RelayMiner:Supplier relationship
+is not.
 
 :::
 

--- a/docusaurus/docs/operate/configs/supplier_staking_config.md
+++ b/docusaurus/docs/operate/configs/supplier_staking_config.md
@@ -67,10 +67,8 @@ from the `Supplier`'s account balance.
 
 The upstaking requirement is to ensure that a `Supplier` incurs a cost for
 changing the services they provide too frequently, which could lead to a poor user
-experience for `Gateways` and `Applications`.
-
-The upstake amount may be adjusted in the future based on network conditions
-and feedback from the community.
+experience for `Gateways` and `Applications`. It is also necessary to dissuade
+sybil or flooding attacks on the network.
 
 :::
 

--- a/docusaurus/docs/operate/configs/supplier_staking_config.md
+++ b/docusaurus/docs/operate/configs/supplier_staking_config.md
@@ -65,6 +65,13 @@ a new `service`, then `stake_amount: 1001upokt` should be specified in the
 configuration file. This will increase the stake by `1upokt` and deduct `1upokt`
 from the `Supplier`'s account balance.
 
+The upstaking requirement is to ensure that a `Supplier` incurs a cost for
+changing the services they provide too frequently, which could lead to a poor user
+experience for `Gateways` and `Applications`.
+
+The upstake amount may be adjusted in the future based on network conditions
+and feedback from the community.
+
 :::
 
 ### `services`
@@ -122,4 +129,30 @@ the `Supplier`'s `RelayMiner` which in turn forwards these requests to the servi
 _`Required`_
 
 `rpc_type` is a string that defines the type of RPC service that the `Supplier`
-is providing. The `rpc_type` MUST be one of the [supported types found here](https://github.com/pokt-network/poktroll/tree/main/pkg/relayer/config/types.go#L8).
+is providing.
+
+Since services may support multiple types of RPCs (e.g., Ethereum has both
+JSON-RPC and WebSocket), a `Supplier` needs to specify which one it provides.
+
+This allows `Gateways` and `Applications` to know which ones are supported by
+a given `Supplier` and select the appropriate one to send `RelayRequest`s to.
+
+:::note
+
+The same url can be used for different `rpc_type`s and it is up to the `Gateway`
+or `Application` to build the `RelayRequest` with the desired `rpc_type`.
+
+For example, a `Supplier` can provide `JSON_RPC` and `GRPC` `rpc_type`s to be
+served from the same endpoint:
+
+```yaml
+endpoints:
+  - publicly_exposed_url: http://service-host
+    rpc_type: JSON_RPC
+  - publicly_exposed_url: http://service-host
+    rpc_type: GRPC
+```
+
+:::
+
+The `rpc_type` MUST be one of the [supported types found here](https://github.com/pokt-network/poktroll/tree/main/pkg/relayer/config/types.go#L8).


### PR DESCRIPTION
## Summary

Improve supplier staking config and relay miner config documentation w.r.t upstaking, PRC types and Supplier<->RelayMiner `signing_keyname` relationship.

## Issue

The documentation was not clear enough as to
* Why upstaking is needed to update the `Supplier` provided services.
* Why it is not possible to have multiple `Supplier`s assigned to the same `RelayMiner`
* What is the purpose of having multiple `RPCType`s per `Service` provided

![image](https://github.com/pokt-network/poktroll/assets/231488/891b7159-d683-4ffe-b323-37202639d722)

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [x] `make docusaurus_start`; only needed if you make doc changes

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
