### PR TITLE
[Quickfix] Add gcompact to container images

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -6,6 +6,9 @@ ARG TARGETARCH
 # Use `1025` G/UID so users can switch between this and `heighliner` image without a need to chown the files.
 RUN addgroup --gid 1025 -S pocket && adduser --uid 1025 -S pocket -G pocket
 
+# Install gcompat to provide compatibility with glibc binary on amd64
+RUN apk add --no-cache gcompat
+
 COPY --chown=pocket:pocket release_binaries/poktroll_linux_$TARGETARCH /bin/poktrolld
 
 USER pocket


### PR DESCRIPTION
## Summary

I ran into an issue when working with new container images on amd64 platform - `poktrolld` wasn't working. When I manually built an image with `gcompact` I was able to deploy the node. Let's include this in the next release.

## Testing

Replicated an issue and fixed by manually building an image on amd64 virtual machine.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
