### PR TITLE
[Docs][Quickfix] Fix broken links

### DIFF
--- a/docusaurus/docs/operate/user_guide/check-balance.md
+++ b/docusaurus/docs/operate/user_guide/check-balance.md
@@ -26,7 +26,7 @@ balance using the `poktrolld` command-line interface (CLI).
 
 ## Pre-requisites
 
-1. `poktrolld` is installed on your system; see the [installation guide](./install-poktrolld) for more details
+1. `poktrolld` is installed on your system; see the [installation guide](./install) for more details
 2. You have the address of the wallet you wish to check
 3. You know the token denomination you wish to check; `upokt` for POKT tokens
 

--- a/docusaurus/docs/operate/user_guide/create-new-wallet.md
+++ b/docusaurus/docs/operate/user_guide/create-new-wallet.md
@@ -36,7 +36,7 @@ refer to the [Cosmos SDK Keyring documentation](https://docs.cosmos.network/main
 
 Ensure you have `poktrolld` installed on your system.
 
-Follow the [installation guide](./install-poktrolld) specific to your operating system.
+Follow the [installation guide](./install) specific to your operating system.
 
 ## Step 2: Creating the Wallet
 

--- a/docusaurus/docs/operate/user_guide/recover-with-mnemonic.md
+++ b/docusaurus/docs/operate/user_guide/recover-with-mnemonic.md
@@ -24,7 +24,7 @@ seed phrase, recovering your account is straightforward!
 ## Pre-requisites
 
 - You have the mnemonic seed phrase of the wallet you wish to recover
-- `poktrolld` is installed on your system; see the [installation guide](./install-poktrolld) for more details
+- `poktrolld` is installed on your system; see the [installation guide](./install) for more details
 
 ## Step 1: Prepare to Recover Your Wallet
 

--- a/docusaurus/docs/operate/user_guide/send-tokens.md
+++ b/docusaurus/docs/operate/user_guide/send-tokens.md
@@ -17,7 +17,7 @@ Pocket Network using the `poktrolld` command-line interface (CLI).
 
 ## Pre-requisites
 
-1. `poktrolld` is installed on your system; see the [installation guide](./install-poktrolld) for more details
+1. `poktrolld` is installed on your system; see the [installation guide](./install) for more details
 2. You have access to your wallet with sufficient tokens for the transaction and fees
 3. You have the recipient's address
 


### PR DESCRIPTION
I missed the error on CI on [my PR](https://github.com/pokt-network/poktroll/pull/539), ended up merging broken docs. I need to fix the links to deploy to dev.poktrolld.com. 

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1152e6e254be9fedc413ace799baea170d513442  | 
|--------|

### Summary:
This PR fixes broken links in the user guide documentation, ensuring correct redirection to the installation guide.

**Key points**:
- Updated broken links in four documentation files.
- Corrected links to point to `./install` instead of `./install-poktrolld`.
- Affected files: `check-balance.md`, `create-new-wallet.md`, `recover-with-mnemonic.md`, `send-tokens.md`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
