### PR TITLE
[Code Health] test: add makefile target for E2E param update tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,6 +380,10 @@ test_e2e_session: test_e2e_env ## Run only the E2E suite that exercises the sess
 test_e2e_settlement: test_e2e_env ## Run only the E2E suite that exercises the session & tokenomics settlement
 	go test -v ./e2e/tests/... -tags=e2e,test --features-path=0_settlement.feature
 
+.PHONY: test_e2e_params
+test_e2e_params: test_e2e_env ## Run only the E2E suite that exercises parameter updates for all modules
+	go test -v ./e2e/tests/... -tags=e2e,test --features-path=update_params.feature
+
 .PHONY: test_load_relays_stress
 test_load_relays_stress: ## Run the stress test for E2E relays on non-ephemeral chains
 	go test -v -count=1 ./load-testing/tests/... \


### PR DESCRIPTION
## Summary

Adds a makefile target to run parameter update E2E test, as per #517.

## Issue

- #517 

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
