### PR TITLE
[LoadTest] Switch funding account to key name instead of address

### DIFF
--- a/load-testing/config/load_test_manifest_reader.go
+++ b/load-testing/config/load_test_manifest_reader.go
@@ -21,11 +21,12 @@ type ProvisionedActorConfig struct {
 type LoadTestManifestYAML struct {
 	// IsEphemeralChain is a flag that indicates whether the test is expected to be
 	// run on LocalNet or long-living remote chain (i.e. TestNet/DevNet).
-	IsEphemeralChain bool                     `yaml:"is_ephemeral_chain"`
-	TestNetNode      string                   `yaml:"testnet_node"`
-	ServiceId        string                   `yaml:"service_id"`
-	Suppliers        []ProvisionedActorConfig `yaml:"suppliers"`
-	Gateways         []ProvisionedActorConfig `yaml:"gateways"`
+	IsEphemeralChain      bool                     `yaml:"is_ephemeral_chain"`
+	TestNetNode           string                   `yaml:"testnet_node"`
+	ServiceId             string                   `yaml:"service_id"`
+	Suppliers             []ProvisionedActorConfig `yaml:"suppliers"`
+	Gateways              []ProvisionedActorConfig `yaml:"gateways"`
+	FundingAccountAddress string                   `yaml:"funding_account_address"`
 }
 
 // ParseLoadTestManifest reads the load test manifest from the given byte slice
@@ -60,6 +61,10 @@ func validatedEphemeralChainManifest(manifest *LoadTestManifestYAML) (*LoadTestM
 
 	if len(manifest.ServiceId) == 0 {
 		return nil, ErrEphemeralChainLoadTestInvalidManifest.Wrap("empty service id")
+	}
+
+	if len(manifest.FundingAccountAddress) == 0 {
+		return nil, ErrEphemeralChainLoadTestInvalidManifest.Wrap("empty funding account address")
 	}
 
 	for _, gateway := range manifest.Gateways {
@@ -108,6 +113,10 @@ func validatedNonEphemeralChainManifest(manifest *LoadTestManifestYAML) (*LoadTe
 
 	if len(manifest.ServiceId) == 0 {
 		return nil, ErrNonEphemeralChainLoadTestInvalidManifest.Wrap("empty service id")
+	}
+
+	if len(manifest.FundingAccountAddress) == 0 {
+		return nil, ErrNonEphemeralChainLoadTestInvalidManifest.Wrap("empty funding account address")
 	}
 
 	for _, gateway := range manifest.Gateways {

--- a/load-testing/loadtest_manifest.yaml
+++ b/load-testing/loadtest_manifest.yaml
@@ -6,6 +6,9 @@ is_ephemeral_chain: false
 testnet_node: https://testnet-validated-validator-rpc.poktroll.com
 # The service ID to request relays from.
 service_id: "0021"
+# The address of the account that will be used to fund the the application accounts
+# so that they can stake on the network.
+funding_account_address: pokt14eh973xt99s7edugnyvd5d5u50d6j0hysw2vsm
 # In non-ephemeral chains, the gateways are identified by their address.
 gateways:
   # address is the bech32 pokt address of the gateway.

--- a/load-testing/loadtest_manifest.yaml
+++ b/load-testing/loadtest_manifest.yaml
@@ -8,7 +8,7 @@ testnet_node: https://testnet-validated-validator-rpc.poktroll.com
 service_id: "0021"
 # The address of the account that will be used to fund the the application accounts
 # so that they can stake on the network.
-funding_account_address: pokt14eh973xt99s7edugnyvd5d5u50d6j0hysw2vsm
+funding_account_address: pokt14eh973xt99s7edugnyvd5d5u50d6j0hysw2vsm # address for pnf account
 # In non-ephemeral chains, the gateways are identified by their address.
 gateways:
   # address is the bech32 pokt address of the gateway.

--- a/load-testing/localnet_loadtest_manifest.yaml
+++ b/load-testing/localnet_loadtest_manifest.yaml
@@ -6,7 +6,7 @@ is_ephemeral_chain: true
 service_id: anvil
 # The address of the account that will be used to fund the the application,
 # gateway and supplier accounts so that they can stake on the network.
-funding_account_address: pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw
+funding_account_address: pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw # address for pnf account
 
 # List of pre-provisioned suppliers used for load testing.
 # Thse suppliers will be progressively staked during the load test, according

--- a/load-testing/localnet_loadtest_manifest.yaml
+++ b/load-testing/localnet_loadtest_manifest.yaml
@@ -4,6 +4,9 @@
 is_ephemeral_chain: true
 # The service ID to use for the load test.
 service_id: anvil
+# The address of the account that will be used to fund the the application,
+# gateway and supplier accounts so that they can stake on the network.
+funding_account_address: pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw
 
 # List of pre-provisioned suppliers used for load testing.
 # Thse suppliers will be progressively staked during the load test, according

--- a/load-testing/tests/relays_stress_helpers_test.go
+++ b/load-testing/tests/relays_stress_helpers_test.go
@@ -102,17 +102,17 @@ func (s *relaysSuite) setupTxEventListeners() {
 }
 
 // initFundingAccount initializes the account that will be funding the onchain actors.
-func (s *relaysSuite) initFundingAccount(fundingAccountKeyName string) {
+func (s *relaysSuite) initFundingAccount(fundingAccountAddress string) {
 	// The funding account record should already exist in the keyring.
-	fundingAccountKeyRecord, err := s.txContext.GetKeyring().Key(fundingAccountKeyName) //KeyByAddress(accAddress)
+	accAddress, err := sdk.AccAddressFromBech32(fundingAccountAddress)
+	require.NoError(s, err)
+
+	fundingAccountKeyRecord, err := s.txContext.GetKeyring().KeyByAddress(accAddress)
 	require.NoError(s, err)
 	require.NotNil(s, fundingAccountKeyRecord)
 
-	fundingAccountAddress, err := fundingAccountKeyRecord.GetAddress()
-	require.NoError(s, err)
-
 	s.fundingAccountInfo = &accountInfo{
-		address:     fundingAccountAddress.String(),
+		address:     fundingAccountAddress,
 		pendingMsgs: []sdk.Msg{},
 	}
 }

--- a/load-testing/tests/relays_stress_helpers_test.go
+++ b/load-testing/tests/relays_stress_helpers_test.go
@@ -102,17 +102,17 @@ func (s *relaysSuite) setupTxEventListeners() {
 }
 
 // initFundingAccount initializes the account that will be funding the onchain actors.
-func (s *relaysSuite) initFundingAccount(fundingAccountAddress string) {
+func (s *relaysSuite) initFundingAccount(fundingAccountKeyName string) {
 	// The funding account record should already exist in the keyring.
-	accAddress, err := sdk.AccAddressFromBech32(fundingAccountAddress)
-	require.NoError(s, err)
-
-	fundingAccountKeyRecord, err := s.txContext.GetKeyring().KeyByAddress(accAddress)
+	fundingAccountKeyRecord, err := s.txContext.GetKeyring().Key(fundingAccountKeyName) //KeyByAddress(accAddress)
 	require.NoError(s, err)
 	require.NotNil(s, fundingAccountKeyRecord)
 
+	fundingAccountAddress, err := fundingAccountKeyRecord.GetAddress()
+	require.NoError(s, err)
+
 	s.fundingAccountInfo = &accountInfo{
-		address:     fundingAccountAddress,
+		address:     fundingAccountAddress.String(),
 		pendingMsgs: []sdk.Msg{},
 	}
 }

--- a/load-testing/tests/relays_stress_test.go
+++ b/load-testing/tests/relays_stress_test.go
@@ -77,8 +77,8 @@ var (
 	// maxConcurrentRequestLimit is the maximum number of concurrent requests that can be made.
 	// By default, it is set to the number of logical CPUs available to the process.
 	maxConcurrentRequestLimit = runtime.GOMAXPROCS(0)
-	// fundingAccountAddress is the key name of the account used to fund other accounts.
-	fundingAccountAddress = "pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw" // address for pnf account
+	// fundingAccountKeyName is the key name of the account used to fund other accounts.
+	fundingAccountKeyName = "pnf" // address for pnf account
 	// supplierStakeAmount is the amount of tokens to stake by suppliers.
 	supplierStakeAmount sdk.Coin
 	// gatewayStakeAmount is the amount of tokens to stake by gateways.
@@ -191,7 +191,7 @@ type relaysSuite struct {
 	// It is used to ensure that the suppliers are staked in the order they are provisioned.
 	availableSupplierAddresses []string
 
-	// fundingAccountInfo is the account entry corresponding to the fundingAccountAddress.
+	// fundingAccountInfo is the account entry corresponding to the fundingAccountKeyName.
 	// It is used to send transactions to fund other accounts.
 	fundingAccountInfo *accountInfo
 	// preparedGateways is the list of gateways that are already staked, delegated
@@ -349,7 +349,7 @@ func (s *relaysSuite) LocalnetIsRunning() {
 	s.setupTxEventListeners()
 
 	// Initialize the funding account.
-	s.initFundingAccount(fundingAccountAddress)
+	s.initFundingAccount(fundingAccountKeyName)
 
 	// Initialize the on-chain claims and proofs counter.
 	s.countClaimAndProofs()

--- a/load-testing/tests/relays_stress_test.go
+++ b/load-testing/tests/relays_stress_test.go
@@ -77,8 +77,8 @@ var (
 	// maxConcurrentRequestLimit is the maximum number of concurrent requests that can be made.
 	// By default, it is set to the number of logical CPUs available to the process.
 	maxConcurrentRequestLimit = runtime.GOMAXPROCS(0)
-	// fundingAccountKeyName is the key name of the account used to fund other accounts.
-	fundingAccountKeyName = "pnf" // address for pnf account
+	// fundingAccountAddress is the address of the account used to fund other accounts.
+	fundingAccountAddress string
 	// supplierStakeAmount is the amount of tokens to stake by suppliers.
 	supplierStakeAmount sdk.Coin
 	// gatewayStakeAmount is the amount of tokens to stake by gateways.
@@ -349,7 +349,7 @@ func (s *relaysSuite) LocalnetIsRunning() {
 	s.setupTxEventListeners()
 
 	// Initialize the funding account.
-	s.initFundingAccount(fundingAccountKeyName)
+	s.initFundingAccount(loadTestParams.FundingAccountAddress)
 
 	// Initialize the on-chain claims and proofs counter.
 	s.countClaimAndProofs()


### PR DESCRIPTION
## Summary

This change allows to run the load test against TestNet the same way we run it against LocalNet.

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
