### PR TITLE
[WIP] E2E test helper to reset params to defaults

### DIFF
--- a/e2e/tests/parse_params_test.go
+++ b/e2e/tests/parse_params_test.go
@@ -109,6 +109,15 @@ func (s *suite) newTokenomicsMsgUpdateParams(params paramsMap) cosmostypes.Msg {
 	return proto.Message(msgUpdateParams)
 }
 
+func (s *suite) newTokenomicsMsgUpdateParamsToDefault(params paramsMap) cosmostypes.Msg {
+	authority := authtypes.NewModuleAddress(s.granterName).String()
+	msgUpdateParams := &tokenomicstypes.MsgUpdateParams{
+		Authority: authority,
+		Params:    tokenomicstypes.DefaultParams(),
+	}
+	return proto.Message(msgUpdateParams)
+}
+
 func (s *suite) newProofMsgUpdateParams(params paramsMap) cosmostypes.Msg {
 	authority := authtypes.NewModuleAddress(s.granterName).String()
 
@@ -125,6 +134,15 @@ func (s *suite) newProofMsgUpdateParams(params paramsMap) cosmostypes.Msg {
 		default:
 			s.Fatalf("unexpected %q type param name %q", paramValue.typeStr, paramName)
 		}
+	}
+	return proto.Message(msgUpdateParams)
+}
+
+func (s *suite) newProofMsgUpdateParamsToDefault(params paramsMap) cosmostypes.Msg {
+	authority := authtypes.NewModuleAddress(s.granterName).String()
+	msgUpdateParams := &prooftypes.MsgUpdateParams{
+		Authority: authority,
+		Params:    prooftypes.DefaultParams(),
 	}
 	return proto.Message(msgUpdateParams)
 }

--- a/e2e/tests/update_params.feature
+++ b/e2e/tests/update_params.feature
@@ -2,7 +2,8 @@ Feature: Params Namespace
   #  TODO_DOCUMENT(@Olshansk): Document all of the on-chain governance parameters.
 
   Background:
-  
+    Given all module params are reset to their default values
+
   Scenario: An unauthorized user cannot update a module params
     Given the user has the pocketd binary installed
     And all "tokenomics" module params are set to their default values

--- a/e2e/tests/update_params_test.go
+++ b/e2e/tests/update_params_test.go
@@ -31,6 +31,9 @@ const (
 	// txFeesCoinStr is the string representation of the amount & denom of tokens
 	// which are sufficient to pay for tx fees in the test.
 	txFeesCoinStr = "1000000upokt"
+	// PNF is the account that acts on behalf of the DAO and is therefore the only
+	// one authorized to perform certain actions such as updating params.
+	pnfKeyName = "pnf"
 )
 
 // AllModuleParamsAreSetToTheirDefaultValues asserts that all module params are set to their default values.
@@ -41,6 +44,7 @@ func (s *suite) AllModuleParamsAreSetToTheirDefaultValues(moduleName string) {
 		"params",
 		fmt.Sprintf("--%s=json", cometcli.OutputFlag),
 	}
+
 	res, err := s.pocketd.RunCommandOnHost("", argsAndFlags...)
 	require.NoError(s, err)
 
@@ -156,6 +160,27 @@ func (s *suite) AnAuthzGrantFromTheAccountToTheAccountForTheMessageExists(
 }
 
 // AllModuleParamsShouldBeSetToTheirDefaultValues asserts that all module params are set to their default values.
+func (s *suite) AllModuleParamsAreResetToTheirDefaultValues() {
+	// defaultParamsList := []interface{
+	// 	apptypes.DefaultParams(),
+	// 	gatewaytypes.DefaultParams(),
+	// 	prooftypes.DefaultParams(),
+	// 	servicetypes.DefaultParams(),
+	// 	sessiontypes.DefaultParams(),
+	// 	sharedtypes.DefaultParams(),
+	// 	suppliertypes.DefaultParams(),
+	// 	tokenomicstypes.DefaultParams(),
+	// }
+
+	params := apptypes.DefaultParams()
+
+	// for _, defaultParams := range defaultParamsList {
+	txJSONFile := s.newTempUpdateParamsTxJSONFile(defaultParams)
+	s.sendAuthzExecTx(pnfKeyName, txJSONFile.Name())
+	// }
+}
+
+// AllModuleParamsShouldBeSetToTheirDefaultValues asserts that all module params are set to their default values.
 func (s *suite) AllModuleParamsShouldBeSetToTheirDefaultValues(moduleName string) {
 	s.AllModuleParamsAreSetToTheirDefaultValues(moduleName)
 }
@@ -251,7 +276,7 @@ func (s *suite) fundAddress(addr string, coin cosmostypes.Coin) {
 		"tx",
 		"bank",
 		"send",
-		"pnf",
+		pnfKeyName,
 		addr,
 		coin.String(),
 		"--yes",


### PR DESCRIPTION
<!-- README: DELETE THIS COMMENT BLOCK after:
    1. Add a descriptive title `[<Tag>] <DESCRIPTION>`
    2. Update _Assignee(s)_
    3. Add _Label(s)_
    4. Set _Project(s)_
    5. Specify _Epic_ and _Iteration_ under _Project_
    6. Set _Milestone_
-->

## Summary

<!-- README: DELETE THIS COMMENT BLOCK after
      - Providing a quick summary of the changes yourself
-->

## Issue

<!-- README: DELETE THIS COMMENT BLOCK after:
     - Explain the reasoning for the PR in 1-2 sentences. Adding a screenshot is fair game.
     - If applicable: specify the ticket number below if there is a relevant issue; _keep the `-` so the full issue is referenced._
-->

- #{ISSUE_NUMBER}

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
