### PR TITLE
[Relayminer] refactor: relayminer to use `proof_window_open_offset_blocks`

### DIFF
--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -285,7 +285,13 @@ type SessionQueryClient interface {
 type SharedQueryClient interface {
 	// GetParams queries the chain for the current shared module parameters.
 	GetParams(ctx context.Context) (*sharedtypes.Params, error)
+	// GetSessionGracePeriodEndHeight returns the block height at which the grace period
+	// for the session that includes queryHeight elapses.
+	GetSessionGracePeriodEndHeight(ctx context.Context, queryHeight int64) (int64, error)
 	// GetClaimWindowOpenHeight returns the block height at which the claim window of
 	// the session that includes queryHeight opens.
 	GetClaimWindowOpenHeight(ctx context.Context, queryHeight int64) (int64, error)
+	// GetProofWindowOpenHeight returns the block height at which the proof window of
+	// the session that includes queryHeight opens.
+	GetProofWindowOpenHeight(ctx context.Context, queryHeight int64) (int64, error)
 }

--- a/pkg/client/query/sharedquerier.go
+++ b/pkg/client/query/sharedquerier.go
@@ -70,3 +70,38 @@ func (sq *sharedQuerier) GetClaimWindowOpenHeight(ctx context.Context, queryHeig
 	}
 	return shared.GetClaimWindowOpenHeight(sharedParams, queryHeight), nil
 }
+
+// GetProofWindowOpenHeight returns the block height at which the proof window of
+// the session that includes queryHeight opens.
+//
+// TODO_TECHDEBT(#543): We don't really want to have to query the params for every method call.
+// Once `ModuleParamsClient` is implemented, use its replay observable's `#Last()` method
+// to get the most recently (asynchronously) observed (and cached) value.
+// TODO_BLOCKER(@bryanchriswhite,#543): We also don't really want to use the current value of the params. Instead,
+// we should be using the value that the params had for the session which includes queryHeight.
+func (sq *sharedQuerier) GetProofWindowOpenHeight(ctx context.Context, queryHeight int64) (int64, error) {
+	sharedParams, err := sq.GetParams(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return shared.GetProofWindowOpenHeight(sharedParams, queryHeight), nil
+}
+
+// GetSessionGracePeriodEndHeight returns the block height at which the grace period
+// for the session which includes queryHeight elapses.
+//
+// TODO_TECHDEBT(#543): We don't really want to have to query the params for every method call.
+// Once `ModuleParamsClient` is implemented, use its replay observable's `#Last()` method
+// to get the most recently (asynchronously) observed (and cached) value.
+// TODO_BLOCKER(@bryanchriswhite, #543): We also don't really want to use the current value of the params.
+// Instead, we should be using the value that the params had for the session which includes queryHeight.
+func (sq *sharedQuerier) GetSessionGracePeriodEndHeight(
+	ctx context.Context,
+	queryHeight int64,
+) (int64, error) {
+	sharedParams, err := sq.GetParams(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return shared.GetSessionGracePeriodEndHeight(sharedParams, queryHeight), nil
+}

--- a/pkg/relayer/proxy/proxy.go
+++ b/pkg/relayer/proxy/proxy.go
@@ -43,6 +43,11 @@ type relayerProxy struct {
 	// incoming relay request.
 	sessionQuerier client.SessionQueryClient
 
+	// sharedQuerier is the query client used to get the current shared & shared params
+	// from the blockchain, which are needed to check if the relay proxy should be serving an
+	// incoming relay request.
+	sharedQuerier client.SharedQueryClient
+
 	// servers is a map of listenAddress -> RelayServer provided by the relayer proxy,
 	// where listenAddress is the address of the server defined in the config file and
 	// RelayServer is the server that listens for incoming relay requests.
@@ -73,6 +78,9 @@ type relayerProxy struct {
 // Required dependencies:
 //   - cosmosclient.Context
 //   - client.BlockClient
+//   - client.SessionQueryClient
+//   - client.SharedQueryClient
+//   - client.SupplierQueryClient
 //
 // Available options:
 //   - WithSigningKeyName
@@ -90,6 +98,7 @@ func NewRelayerProxy(
 		&rp.ringCache,
 		&rp.supplierQuerier,
 		&rp.sessionQuerier,
+		&rp.sharedQuerier,
 		&rp.keyring,
 	); err != nil {
 		return nil, err

--- a/pkg/relayer/proxy/relay_verifier.go
+++ b/pkg/relayer/proxy/relay_verifier.go
@@ -92,27 +92,37 @@ func (rp *relayerProxy) VerifyRelayRequest(
 func (rp *relayerProxy) getTargetSessionBlockHeight(
 	ctx context.Context,
 	relayRequest *types.RelayRequest,
-) (sessionBlockHeight int64, err error) {
-	currentBlockHeight := rp.blockClient.LastBlock(ctx).Height()
-	sessionEndblockHeight := relayRequest.Meta.SessionHeader.GetSessionEndBlockHeight()
+) (sessionHeight int64, err error) {
+	currentHeight := rp.blockClient.LastBlock(ctx).Height()
+	sessionEndHeight := relayRequest.Meta.SessionHeader.GetSessionEndBlockHeight()
+
+	// TODO_TECHDEBT(#543): We don't really want to have to query the params for every method call.
+	// Once `ModuleParamsClient` is implemented, use its replay observable's `#Last()` method
+	// to get the most recently (asynchronously) observed (and cached) value.
+	// TODO_BLOCKER(@bryanchriswhite, #543): We also don't really want to use the current value of the params.
+	// Instead, we should be using the value that the params had for the session given by sessionEndHeight.
+	sharedParams, err := rp.sharedQuerier.GetParams(ctx)
+	if err != nil {
+		return 0, err
+	}
 
 	// Check if the RelayRequest's session has expired.
-	if sessionEndblockHeight < currentBlockHeight {
+	if sessionEndHeight < currentHeight {
 		// Do not process the `RelayRequest` if the session has expired and the current
 		// block height is outside the session's grace period.
-		if !shared.IsGracePeriodElapsed(sessionEndblockHeight, currentBlockHeight) {
+		if !shared.IsGracePeriodElapsed(sharedParams, sessionEndHeight, currentHeight) {
 			// The RelayRequest's session has expired but is still within the
 			// grace period so process it as if the session is still active.
-			return sessionEndblockHeight, nil
+			return sessionEndHeight, nil
 		}
 
 		return 0, ErrRelayerProxyInvalidSession.Wrapf(
 			"session expired, expecting: %d, got: %d",
-			sessionEndblockHeight,
-			currentBlockHeight,
+			sessionEndHeight,
+			currentHeight,
 		)
 	}
 
 	// The RelayRequest's session is active so return the current block height.
-	return currentBlockHeight, nil
+	return currentHeight, nil
 }

--- a/pkg/relayer/session/claim.go
+++ b/pkg/relayer/session/claim.go
@@ -96,9 +96,6 @@ func (rs *relayerSessionsManager) waitForEarliestCreateClaimsHeight(
 		return nil
 	}
 
-	// TODO_BLOCKER(@bryanchriswhite): query the on-chain governance parameter once available.
-	// + claimproofparams.GovCreateClaimWindowStartHeightOffset
-
 	// we wait for createClaimsWindowOpenHeight to be received before proceeding since we need its hash
 	// to know where this servicer's claim submission window starts.
 	rs.logger.Info().

--- a/pkg/relayer/session/session.go
+++ b/pkg/relayer/session/session.go
@@ -219,7 +219,7 @@ func (rs *relayerSessionsManager) forEachBlockClaimSessionsFn(
 			// before emitting the on-time sessions.
 			var lateSessions []relayer.SessionTree
 
-			sessionGracePeriodEndHeight := shared.GetSessionGracePeriodEndHeight(sessionEndHeight)
+			sessionGracePeriodEndHeight := shared.GetSessionGracePeriodEndHeight(sharedParams, sessionEndHeight)
 
 			// Checking for sessions to claim with <= operator,
 			// which means that it would include sessions that were supposed to be

--- a/pkg/relayer/session/session_test.go
+++ b/pkg/relayer/session/session_test.go
@@ -105,22 +105,18 @@ func TestRelayerSessionsManager_Start(t *testing.T) {
 
 	// Calculate the session grace period end block height to emit that block height
 	// to the blockPublishCh to trigger claim creation for the session.
-	//sessionClaimWindowOpenHeight := int64(sessionEndHeight + shared.SessionGracePeriodBlocks)
 	sharedParams := sharedtypes.DefaultParams()
 	sessionClaimWindowOpenHeight := shared.GetClaimWindowOpenHeight(&sharedParams, sessionEndHeight)
 
 	// Publish a block to the blockPublishCh to trigger claim creation for the session.
-	// TODO_BLOCKER(@bryanchriswhite, #516): assumes claiming at sessionClaimWindowOpenHeight is valid.
-	// This will likely change in future work.
 	triggerClaimBlock := testblock.NewAnyTimesBlock(t, emptyBlockHash, sessionClaimWindowOpenHeight)
 	blockPublishCh <- triggerClaimBlock
 
 	// TODO_IMPROVE: ensure correctness of persisted session trees here.
 
 	// Publish a block to the blockPublishCh to trigger proof submission for the session.
-	// TODO_BLOCKER(@bryanchriswhite, #516): assumes proving at sessionClaimWindowOpenHeight + 1 is valid.
-	// This will likely change in future work.
-	triggerProofBlock := testblock.NewAnyTimesBlock(t, emptyBlockHash, sessionClaimWindowOpenHeight+1)
+	sessionProofWindowOpenHeight := shared.GetProofWindowOpenHeight(&sharedParams, sessionEndHeight)
+	triggerProofBlock := testblock.NewAnyTimesBlock(t, emptyBlockHash, sessionProofWindowOpenHeight)
 	blockPublishCh <- triggerProofBlock
 
 	// Wait a tick to allow the relayer sessions manager to process asynchronously.

--- a/testutil/testclient/testqueryclients/sharedquerier.go
+++ b/testutil/testclient/testqueryclients/sharedquerier.go
@@ -36,5 +36,25 @@ func NewTestSharedQueryClient(
 		).
 		AnyTimes()
 
+	sharedQuerier.EXPECT().
+		GetProofWindowOpenHeight(gomock.Any(), gomock.Any()).
+		DoAndReturn(
+			func(ctx context.Context, queryHeight int64) (int64, error) {
+				sharedParams := sharedtypes.DefaultParams()
+				return shared.GetProofWindowOpenHeight(&sharedParams, queryHeight), nil
+			},
+		).
+		AnyTimes()
+
+	sharedQuerier.EXPECT().
+		GetSessionGracePeriodEndHeight(gomock.Any(), gomock.Any()).
+		DoAndReturn(
+			func(ctx context.Context, queryHeight int64) (int64, error) {
+				sharedParams := sharedtypes.DefaultParams()
+				return shared.GetSessionGracePeriodEndHeight(&sharedParams, queryHeight), nil
+			},
+		).
+		AnyTimes()
+
 	return sharedQuerier
 }

--- a/x/proof/keeper/msg_server_submit_proof.go
+++ b/x/proof/keeper/msg_server_submit_proof.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pokt-network/poktroll/x/proof/types"
 	servicetypes "github.com/pokt-network/poktroll/x/service/types"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
-	"github.com/pokt-network/poktroll/x/shared"
 )
 
 // SMT specification used for the proof verification.
@@ -432,12 +431,10 @@ func (k msgServer) validateClosestPath(
 	//
 	// Since smt.ProveClosest is defined in terms of submitProofWindowStartHeight,
 	// this block's hash needs to be used for validation too.
-	//
-	// TODO_TECHDEBT(@red-0ne): Centralize the business logic that involves taking
-	// into account the heights, windows and grace periods into helper functions.
-	// TODO_BLOCKER(@bryanchriswhite, #516): Update `blockHeight` to be the value of when the `ProofWindow`
-	// opens once the variable is added.
-	sessionGracePeriodEndHeight := shared.GetSessionGracePeriodEndHeight(sessionHeader.GetSessionEndBlockHeight())
+	sessionGracePeriodEndHeight, err := k.sharedQuerier.GetSessionGracePeriodEndHeight(ctx, sessionHeader.GetSessionEndBlockHeight())
+	if err != nil {
+		return err
+	}
 	blockHash := k.sessionKeeper.GetBlockHash(ctx, sessionGracePeriodEndHeight)
 
 	// TODO_BETA: Investigate "proof for the path provided does not match one expected by the on-chain protocol"

--- a/x/proof/types/shared_query_client.go
+++ b/x/proof/types/shared_query_client.go
@@ -31,13 +31,23 @@ func (sharedQueryClient *SharedKeeperQueryClient) GetParams(
 	return &sharedParams, nil
 }
 
+// GetSessionGracePeriodEndHeight returns the block height at which the grace period
+// for the session which includes queryHeight elapses.
+//
+// TODO_BLOCKER(@bryanchriswhite, #543): We don't really want to use the current value of the params.
+// Instead, we should be using the value that the params had for the session given by blockHeight.
+func (sharedQueryClient *SharedKeeperQueryClient) GetSessionGracePeriodEndHeight(
+	ctx context.Context,
+	queryHeight int64,
+) (int64, error) {
+	sharedParams := sharedQueryClient.keeper.GetParams(ctx)
+	return shared.GetSessionGracePeriodEndHeight(&sharedParams, queryHeight), nil
+}
+
 // GetClaimWindowOpenHeight returns the block height at which the claim window of
 // the session that includes queryHeight opens.
 //
-// TODO_TECHDEBT(#543): We don't really want to have to query the params for every method call.
-// Once `ModuleParamsClient` is implemented, use its replay observable's `#Last()` method
-// to get the most recently (asynchronously) observed (and cached) value.
-// TODO_BLOCKER(@bryanchriswhite, #543): We also don't really want to use the current value of the params.
+// TODO_BLOCKER(@bryanchriswhite, #543): We don't really want to use the current value of the params.
 // Instead, we should be using the value that the params had for the session given by blockHeight.
 func (sharedQueryClient *SharedKeeperQueryClient) GetClaimWindowOpenHeight(
 	ctx context.Context,
@@ -45,4 +55,17 @@ func (sharedQueryClient *SharedKeeperQueryClient) GetClaimWindowOpenHeight(
 ) (int64, error) {
 	sharedParams := sharedQueryClient.keeper.GetParams(ctx)
 	return shared.GetClaimWindowOpenHeight(&sharedParams, queryHeight), nil
+}
+
+// GetProofWindowOpenHeight returns the block height at which the proof window of
+// the session that includes queryHeight opens.
+//
+// TODO_BLOCKER(@bryanchriswhite, #543): We don't really want to use the current value of the params.
+// Instead, we should be using the value that the params had for the session given by blockHeight.
+func (sharedQueryClient *SharedKeeperQueryClient) GetProofWindowOpenHeight(
+	ctx context.Context,
+	queryHeight int64,
+) (int64, error) {
+	sharedParams := sharedQueryClient.keeper.GetParams(ctx)
+	return shared.GetProofWindowOpenHeight(&sharedParams, queryHeight), nil
 }

--- a/x/shared/session.go
+++ b/x/shared/session.go
@@ -58,15 +58,16 @@ func GetSessionNumber(sharedParams *sharedtypes.Params, queryHeight int64) int64
 }
 
 // GetSessionGracePeriodEndHeight returns the block height at which the grace period
-// for the session ending with sessionEndHeight elapses.
-func GetSessionGracePeriodEndHeight(sessionEndHeight int64) int64 {
+// for the session that includes queryHeight elapses, given the passed sharedParams.
+func GetSessionGracePeriodEndHeight(sharedParams *sharedtypes.Params, queryHeight int64) int64 {
+	sessionEndHeight := GetSessionEndHeight(sharedParams, queryHeight)
 	return sessionEndHeight + SessionGracePeriodBlocks
 }
 
 // IsGracePeriodElapsed returns true if the grace period for the session ending with
 // sessionEndHeight has elapsed, given currentHeight.
-func IsGracePeriodElapsed(sessionEndHeight, currentHeight int64) bool {
-	return currentHeight > GetSessionGracePeriodEndHeight(sessionEndHeight)
+func IsGracePeriodElapsed(sharedParams *sharedtypes.Params, queryHeight, currentHeight int64) bool {
+	return currentHeight > GetSessionGracePeriodEndHeight(sharedParams, queryHeight)
 }
 
 // GetClaimWindowOpenHeight returns the block height at which the claim window of
@@ -76,7 +77,7 @@ func GetClaimWindowOpenHeight(sharedParams *sharedtypes.Params, queryHeight int6
 
 	// An additional block is added to permit to relays arriving at the last block
 	// of the session to be included in the claim before the smt is closed.
-	sessionGracePeriodEndHeight := GetSessionGracePeriodEndHeight(sessionEndHeight)
+	sessionGracePeriodEndHeight := GetSessionGracePeriodEndHeight(sharedParams, sessionEndHeight)
 	claimWindowOpenOffsetBlocks := int64(sharedParams.GetClaimWindowOpenOffsetBlocks())
 	return claimWindowOpenOffsetBlocks + sessionGracePeriodEndHeight + 1
 }
@@ -86,4 +87,11 @@ func GetClaimWindowOpenHeight(sharedParams *sharedtypes.Params, queryHeight int6
 func GetClaimWindowCloseHeight(sharedParams *sharedtypes.Params, queryHeight int64) int64 {
 	return GetClaimWindowOpenHeight(sharedParams, queryHeight) +
 		int64(sharedParams.GetClaimWindowCloseOffsetBlocks())
+}
+
+// GetProofWindowOpenHeight returns the block height at which the claim window of
+// the session that includes queryHeight opens, given the passed sharedParams.
+func GetProofWindowOpenHeight(sharedParams *sharedtypes.Params, queryHeight int64) int64 {
+	return GetClaimWindowCloseHeight(sharedParams, queryHeight) +
+		int64(sharedParams.GetProofWindowOpenOffsetBlocks())
 }


### PR DESCRIPTION
## Summary

- Refactor relayminer to use `proof_window_open_offset_blocks` to determine when to submit proofs.
- Add `#GetSessionGracePeriodEndHeight()` and `#GetProofWindowOpenHeight()` to `client.SharedQueryClient`.
- Refactor `shared.GetSessionGracePeriodEndHeight()` to receive `sharedParams` in preparation for making `GracePeriodBlocks` a shared param.

## Issue

- #516 

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [x] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [x] I have left TODOs throughout the codebase, if applicable
