### PR TITLE
[Dev Tools] Add .devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+# This Dockerfile is used to build container image for development purposes.
+# It intentionally contains no security features, ships with code and troubleshooting tools.
+
+FROM mcr.microsoft.com/devcontainers/go:1-1.22-bookworm
+
+RUN curl https://get.ignite.com/cli | bash
+RUN mv ignite /usr/local/bin/
+
+# enable faster module downloading.
+ENV GOPROXY https://proxy.golang.org

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"build": { "dockerfile": "Dockerfile" },
+	
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "go install \"github.com/golang/mock/mockgen@v1.6.0\""
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
## Summary

Adds simple support for VSC Containers or Github Codespaces.

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Dev Tools

## Testing

Open project in dev container using VSCode/Codespaces and run:
```sh
make go_develop_and_test
```


## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
