### PR TITLE
[Testutils] refactor: keeper testutils

### DIFF
--- a/testutil/keeper/common/interface.go
+++ b/testutil/keeper/common/interface.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"context"
+
+	apptypes "github.com/pokt-network/poktroll/x/application/types"
+	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+)
+
+type MultiKeeper interface {
+	ApplicationKeeper
+	SupplierKeeper
+}
+
+type ApplicationKeeper interface {
+	SetApplication(context.Context, apptypes.Application)
+}
+
+type SupplierKeeper interface {
+	SetSupplier(context.Context, sharedtypes.Supplier)
+}
+
+type SessionKeeper interface {
+	GetSession(context.Context, *sessiontypes.QueryGetSessionRequest) (*sessiontypes.QueryGetSessionResponse, error)
+	StoreBlockHash(ctx context.Context)
+}

--- a/testutil/keeper/common/keeper.go
+++ b/testutil/keeper/common/keeper.go
@@ -1,0 +1,111 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/poktroll/pkg/relayer"
+	apptypes "github.com/pokt-network/poktroll/x/application/types"
+	prooftypes "github.com/pokt-network/poktroll/x/proof/types"
+	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
+	"github.com/pokt-network/poktroll/x/shared"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+)
+
+// AddServiceActors adds a supplier and an application for a specific
+// service so a successful session can be generated for testing purposes.
+func AddServiceActors(
+	ctx context.Context,
+	t *testing.T,
+	supplierKeeper SupplierKeeper,
+	appKeeper ApplicationKeeper,
+	service *sharedtypes.Service,
+	supplierAddr string,
+	appAddr string,
+) {
+	t.Helper()
+
+	supplierKeeper.SetSupplier(ctx, sharedtypes.Supplier{
+		Address: supplierAddr,
+		Services: []*sharedtypes.SupplierServiceConfig{
+			{Service: service},
+		},
+	})
+
+	appKeeper.SetApplication(ctx, apptypes.Application{
+		Address: appAddr,
+		ServiceConfigs: []*sharedtypes.ApplicationServiceConfig{
+			{Service: service},
+		},
+	})
+}
+
+// CreateClaimAndStoreBlockHash creates a valid claim, submits it on-chain,
+// and on success, stores the block hash for retrieval at future heights.
+// TODO_TECHDEBT(@bryanchriswhite): Consider if we could/should split
+// this into two functions.
+func CreateClaimAndStoreBlockHash(
+	ctx context.Context,
+	t *testing.T,
+	sessionKeeper SessionKeeper,
+	proofMsgServer prooftypes.MsgServer,
+	sessionStartHeight int64,
+	supplierAddr, appAddr string,
+	service *sharedtypes.Service,
+	sessionTree relayer.SessionTree,
+	sessionHeader *sessiontypes.SessionHeader,
+) {
+	merkleRootBz, err := sessionTree.Flush()
+	require.NoError(t, err)
+
+	// Create a create claim message.
+	claimMsg := NewTestClaimMsg(t,
+		sessionStartHeight,
+		sessionHeader.GetSessionId(),
+		supplierAddr,
+		appAddr,
+		service,
+		merkleRootBz,
+	)
+	_, err = proofMsgServer.CreateClaim(ctx, claimMsg)
+	require.NoError(t, err)
+
+	// TODO_TECHDEBT(@red-0ne): Centralize the business logic that involves taking
+	// into account the heights, windows and grace periods into helper functions.
+	proofSubmissionHeight :=
+		claimMsg.GetSessionHeader().GetSessionEndBlockHeight() +
+			shared.SessionGracePeriodBlocks
+
+	// Set block height to be after the session grace period.
+	blockHeightCtx := SetBlockHeight(ctx, proofSubmissionHeight)
+
+	// Store the current context's block hash for future height, which is currently an EndBlocker operation.
+	sessionKeeper.StoreBlockHash(blockHeightCtx)
+}
+
+// GetSessionHeader is a helper to retrieve the session header
+// for a specific (app, service, height).
+func GetSessionHeader(
+	ctx context.Context,
+	t *testing.T,
+	sessionKeeper SessionKeeper,
+	appAddr string,
+	service *sharedtypes.Service,
+	blockHeight int64,
+) *sessiontypes.SessionHeader {
+	t.Helper()
+
+	sessionRes, err := sessionKeeper.GetSession(
+		ctx,
+		&sessiontypes.QueryGetSessionRequest{
+			ApplicationAddress: appAddr,
+			Service:            service,
+			BlockHeight:        blockHeight,
+		},
+	)
+	require.NoError(t, err)
+
+	return sessionRes.GetSession().GetHeader()
+}

--- a/testutil/keeper/common/message.go
+++ b/testutil/keeper/common/message.go
@@ -1,0 +1,67 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/pokt-network/smt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/poktroll/pkg/relayer"
+	testsession "github.com/pokt-network/poktroll/testutil/session"
+	prooftypes "github.com/pokt-network/poktroll/x/proof/types"
+	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+)
+
+// NewTestClaimMsg returns a new MsgCreateClaim that can be submitted
+// to be validated and stored on-chain.
+func NewTestClaimMsg(
+	t *testing.T,
+	sessionStartHeight int64,
+	sessionId string,
+	supplierAddr string,
+	appAddr string,
+	service *sharedtypes.Service,
+	merkleRoot smt.MerkleRoot,
+) *prooftypes.MsgCreateClaim {
+	t.Helper()
+
+	return prooftypes.NewMsgCreateClaim(
+		supplierAddr,
+		&sessiontypes.SessionHeader{
+			ApplicationAddress:      appAddr,
+			Service:                 service,
+			SessionId:               sessionId,
+			SessionStartBlockHeight: sessionStartHeight,
+			SessionEndBlockHeight:   testsession.GetSessionEndHeightWithDefaultParams(sessionStartHeight),
+		},
+		merkleRoot,
+	)
+}
+
+// NewTestProofMsg creates a new submit proof message that can be submitted
+// to be validated and stored on-chain.
+func NewTestProofMsg(
+	t *testing.T,
+	supplierAddr string,
+	sessionHeader *sessiontypes.SessionHeader,
+	sessionTree relayer.SessionTree,
+	closestProofPath []byte,
+) *prooftypes.MsgSubmitProof {
+	t.Helper()
+
+	// Generate a closest proof from the session tree using closestProofPath.
+	merkleProof, err := sessionTree.ProveClosest(closestProofPath)
+	require.NoError(t, err)
+	require.NotNil(t, merkleProof)
+
+	// Serialize the closest merkle proof.
+	merkleProofBz, err := merkleProof.Marshal()
+	require.NoError(t, err)
+
+	return &prooftypes.MsgSubmitProof{
+		SupplierAddress: supplierAddr,
+		SessionHeader:   sessionHeader,
+		Proof:           merkleProofBz,
+	}
+}

--- a/testutil/keeper/common/options.go
+++ b/testutil/keeper/common/options.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"context"
+
+	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+)
+
+// GenericOptionFunc is an option func which receives a context and K type object for configuration.
+type GenericOptionFunc[K any] func(context.Context, K) context.Context
+
+// WithBlockHash sets the initial block hash for the context and returns the updated context.
+// The O generic type should be the concrete option function type, where K is the second
+// argument of the option function.
+func WithBlockHash[O GenericOptionFunc[K], K any](hash []byte) O {
+	return func(ctx context.Context, _ K) context.Context {
+		return SetBlockHash(ctx, hash)
+	}
+}
+
+// SetBlockHash updates the block hash for the given context and returns the updated context.
+func SetBlockHash(ctx context.Context, hash []byte) context.Context {
+	return cosmostypes.UnwrapSDKContext(ctx).WithHeaderHash(hash)
+}
+
+// WithBlockHeight sets the initial block height for the context and returns the updated context.
+// The O generic type should be the concrete option function type, where K is the second
+// argument of the option function.
+func WithBlockHeight[O GenericOptionFunc[K], K any](height int64) O {
+	return func(ctx context.Context, _ K) context.Context {
+		return SetBlockHeight(ctx, height)
+	}
+}
+
+// SetBlockHeight updates the block height for the given context and returns the updated context.
+func SetBlockHeight(ctx context.Context, height int64) context.Context {
+	return cosmostypes.UnwrapSDKContext(ctx).WithBlockHeight(height)
+}

--- a/testutil/keeper/common/sessiontree.go
+++ b/testutil/keeper/common/sessiontree.go
@@ -1,0 +1,106 @@
+package common
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/poktroll/pkg/crypto"
+	"github.com/pokt-network/poktroll/pkg/relayer"
+	"github.com/pokt-network/poktroll/pkg/relayer/session"
+	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
+)
+
+// newFilledSessionTree creates a new session tree with numRelays of relays
+// filled out using the request and response headers provided where every
+// relay is signed by the supplier and application respectively.
+func NewFilledSessionTree(
+	ctx context.Context, t *testing.T,
+	numRelays uint,
+	supplierKeyUid, supplierAddr string,
+	sessionTreeHeader, reqHeader, resHeader *sessiontypes.SessionHeader,
+	keyRing keyring.Keyring,
+	ringClient crypto.RingClient,
+) relayer.SessionTree {
+	t.Helper()
+
+	// Initialize an empty session tree with the given session header.
+	sessionTree := NewEmptySessionTree(t, sessionTreeHeader)
+
+	// Add numRelays of relays to the session tree.
+	FillSessionTree(
+		ctx, t,
+		sessionTree, numRelays,
+		supplierKeyUid, supplierAddr,
+		reqHeader, resHeader,
+		keyRing,
+		ringClient,
+	)
+
+	return sessionTree
+}
+
+// newEmptySessionTree creates a new empty session tree with for given session.
+func NewEmptySessionTree(
+	t *testing.T,
+	sessionTreeHeader *sessiontypes.SessionHeader,
+) relayer.SessionTree {
+	t.Helper()
+
+	// Create a temporary session tree store directory for persistence.
+	testSessionTreeStoreDir, err := os.MkdirTemp("", "session_tree_store_dir")
+	require.NoError(t, err)
+
+	// Delete the temporary session tree store directory after the test completes.
+	t.Cleanup(func() {
+		_ = os.RemoveAll(testSessionTreeStoreDir)
+	})
+
+	// Construct a session tree to add relays to and generate a proof from.
+	sessionTree, err := session.NewSessionTree(
+		sessionTreeHeader,
+		testSessionTreeStoreDir,
+		func(*sessiontypes.SessionHeader) {},
+	)
+	require.NoError(t, err)
+
+	return sessionTree
+}
+
+// fillSessionTree fills the session tree with valid signed relays.
+// A total of numRelays relays are added to the session tree with
+// increasing weights (relay 1 has weight 1, relay 2 has weight 2, etc.).
+func FillSessionTree(
+	ctx context.Context, t *testing.T,
+	sessionTree relayer.SessionTree,
+	numRelays uint,
+	supplierKeyUid, supplierAddr string,
+	reqHeader, resHeader *sessiontypes.SessionHeader,
+	keyRing keyring.Keyring,
+	ringClient crypto.RingClient,
+) {
+	t.Helper()
+
+	for i := 0; i < int(numRelays); i++ {
+		relay := NewSignedEmptyRelay(
+			ctx, t,
+			supplierKeyUid, supplierAddr,
+			reqHeader, resHeader,
+			keyRing,
+			ringClient,
+		)
+		relayBz, err := relay.Marshal()
+		require.NoError(t, err)
+
+		relayKey, err := relay.GetHash()
+		require.NoError(t, err)
+
+		relayWeight := uint64(i)
+
+		err = sessionTree.Update(relayKey[:], relayBz, relayWeight)
+		require.NoError(t, err)
+	}
+}

--- a/testutil/keeper/proof.go
+++ b/testutil/keeper/proof.go
@@ -64,7 +64,7 @@ type ProofModuleKeepers struct {
 
 // ProofKeepersOpt is a function which receives and potentially modifies the context
 // and proof keepers during construction of the aggregation.
-type ProofKeepersOpt func(context.Context, *ProofModuleKeepers) context.Context
+type ProofKeepersOpt = genericOptionFunc[*ProofModuleKeepers]
 
 // ProofKeeper is a helper function to create a proof keeper and a context. It uses
 // mocked dependencies only.
@@ -283,28 +283,4 @@ func (keepers *ProofModuleKeepers) GetSessionHeader(
 	require.NoError(t, err)
 
 	return sessionRes.GetSession().GetHeader()
-}
-
-// WithBlockHash sets the initial block hash for the context and returns the updated context.
-func WithBlockHash(hash []byte) ProofKeepersOpt {
-	return func(ctx context.Context, _ *ProofModuleKeepers) context.Context {
-		return SetBlockHash(ctx, hash)
-	}
-}
-
-// SetBlockHash updates the block hash for the given context and returns the updated context.
-func SetBlockHash(ctx context.Context, hash []byte) context.Context {
-	return sdk.UnwrapSDKContext(ctx).WithHeaderHash(hash)
-}
-
-// WithBlockHeight sets the initial block height for the context and returns the updated context.
-func WithBlockHeight(height int64) ProofKeepersOpt {
-	return func(ctx context.Context, _ *ProofModuleKeepers) context.Context {
-		return SetBlockHeight(ctx, height)
-	}
-}
-
-// SetBlockHeight updates the block height for the given context and returns the updated context.
-func SetBlockHeight(ctx context.Context, height int64) context.Context {
-	return sdk.UnwrapSDKContext(ctx).WithBlockHeight(height)
 }

--- a/testutil/keeper/tokenomics.go
+++ b/testutil/keeper/tokenomics.go
@@ -64,7 +64,7 @@ type TokenomicsModuleKeepers struct {
 
 // TokenomicsKeepersOpt is a function which receives and potentially modifies the context
 // and tokenomics keepers during construction of the aggregation.
-type TokenomicsKeepersOpt func(context.Context, *TokenomicsModuleKeepers) context.Context
+type TokenomicsKeepersOpt = genericOptionFunc[*TokenomicsModuleKeepers]
 
 func TokenomicsKeeper(t testing.TB) (tokenomicsKeeper tokenomicskeeper.Keeper, ctx context.Context) {
 	t.Helper()

--- a/x/proof/keeper/msg_server_create_claim_test.go
+++ b/x/proof/keeper/msg_server_create_claim_test.go
@@ -44,7 +44,7 @@ func TestMsgServer_CreateClaim_Success(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			// Set block height to 1 so there is a valid session on-chain.
 			blockHeight := int64(1)
-			blockHeightOpt := keepertest.WithBlockHeight(blockHeight)
+			blockHeightOpt := keepertest.WithBlockHeight[keepertest.ProofKeepersOpt](blockHeight)
 
 			// Create a new set of proof module keepers. This isolates each test
 			// case from side effects of other test cases.
@@ -125,7 +125,7 @@ func TestMsgServer_CreateClaim_Success(t *testing.T) {
 
 func TestMsgServer_CreateClaim_Error_OutsideOfWindow(t *testing.T) {
 	// Set block height to 1 so there is a valid session on-chain.
-	blockHeightOpt := keepertest.WithBlockHeight(1)
+	blockHeightOpt := keepertest.WithBlockHeight[keepertest.ProofKeepersOpt](1)
 	keepers, ctx := keepertest.NewProofModuleKeepers(t, blockHeightOpt)
 	sdkCtx := cosmostypes.UnwrapSDKContext(ctx)
 	srv := keeper.NewMsgServerImpl(*keepers.Keeper)
@@ -234,7 +234,10 @@ func TestMsgServer_CreateClaim_Error_OutsideOfWindow(t *testing.T) {
 
 func TestMsgServer_CreateClaim_Error(t *testing.T) {
 	// Set block height to 1 so there is a valid session on-chain.
-	blockHeightOpt := keepertest.WithBlockHeight(1)
+	blockHeightOpt := common.WithBlockHeight[
+		keepertest.ProofKeepersOpt,
+		*keepertest.ProofModuleKeepers,
+	](1)
 	keepers, ctx := keepertest.NewProofModuleKeepers(t, blockHeightOpt)
 	srv := keeper.NewMsgServerImpl(*keepers.Keeper)
 

--- a/x/proof/keeper/msg_server_submit_proof_test.go
+++ b/x/proof/keeper/msg_server_submit_proof_test.go
@@ -83,9 +83,15 @@ func TestMsgServer_SubmitProof_Success(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			opts := []keepertest.ProofKeepersOpt{
 				// Set block hash so we can have a deterministic expected on-chain proof requested by the protocol.
-				keepertest.WithBlockHash(blockHeaderHash),
+				common.WithBlockHash[
+					keepertest.ProofKeepersOpt,
+					*keepertest.ProofModuleKeepers,
+				](blockHeaderHash),
 				// Set block height to 1 so there is a valid session on-chain.
-				keepertest.WithBlockHeight(1),
+				common.WithBlockHeight[
+					keepertest.ProofKeepersOpt,
+					*keepertest.ProofModuleKeepers,
+				](1),
 			}
 			keepers, ctx := keepertest.NewProofModuleKeepers(t, opts...)
 			sharedParams := keepers.SharedKeeper.GetParams(ctx)
@@ -202,9 +208,15 @@ func TestMsgServer_SubmitProof_Success(t *testing.T) {
 func TestMsgServer_SubmitProof_Error_OutsideOfWindow(t *testing.T) {
 	opts := []keepertest.ProofKeepersOpt{
 		// Set block hash so we can have a deterministic expected on-chain proof requested by the protocol.
-		keepertest.WithBlockHash(blockHeaderHash),
+		common.WithBlockHash[
+			keepertest.ProofKeepersOpt,
+			*keepertest.ProofModuleKeepers,
+		](blockHeaderHash),
 		// Set block height to 1 so there is a valid session on-chain.
-		keepertest.WithBlockHeight(1),
+		common.WithBlockHeight[
+			keepertest.ProofKeepersOpt,
+			*keepertest.ProofModuleKeepers,
+		](1),
 	}
 	keepers, ctx := keepertest.NewProofModuleKeepers(t, opts...)
 
@@ -351,11 +363,16 @@ func TestMsgServer_SubmitProof_Error_OutsideOfWindow(t *testing.T) {
 
 func TestMsgServer_SubmitProof_Error(t *testing.T) {
 	opts := []keepertest.ProofKeepersOpt{
-		// Set block hash such that on-chain closest merkle proof validation
-		// uses the expected path.
-		keepertest.WithBlockHash(expectedMerkleProofPath),
+		// Set block hash so we can have a deterministic expected on-chain proof requested by the protocol.
+		common.WithBlockHash[
+			keepertest.ProofKeepersOpt,
+			*keepertest.ProofModuleKeepers,
+		](blockHeaderHash),
 		// Set block height to 1 so there is a valid session on-chain.
-		keepertest.WithBlockHeight(1),
+		common.WithBlockHeight[
+			keepertest.ProofKeepersOpt,
+			*keepertest.ProofModuleKeepers,
+		](1),
 	}
 	keepers, ctx := keepertest.NewProofModuleKeepers(t, opts...)
 

--- a/x/tokenomics/types/expected_keepers.go
+++ b/x/tokenomics/types/expected_keepers.go
@@ -9,6 +9,8 @@ import (
 
 	apptypes "github.com/pokt-network/poktroll/x/application/types"
 	prooftypes "github.com/pokt-network/poktroll/x/proof/types"
+	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
 
 // AccountKeeper defines the expected interface for the Account module.
@@ -28,8 +30,9 @@ type BankKeeper interface {
 }
 
 type ApplicationKeeper interface {
-	GetApplication(ctx context.Context, appAddr string) (app apptypes.Application, found bool)
-	SetApplication(ctx context.Context, app apptypes.Application)
+	GetApplication(ctx context.Context, address string) (app apptypes.Application, found bool)
+	GetAllApplications(ctx context.Context) []apptypes.Application
+	SetApplication(context.Context, apptypes.Application)
 }
 
 type ProofKeeper interface {
@@ -41,4 +44,19 @@ type ProofKeeper interface {
 	// Only used for testing & simulation
 	UpsertClaim(ctx context.Context, claim prooftypes.Claim)
 	UpsertProof(ctx context.Context, claim prooftypes.Proof)
+
+	SetParams(ctx context.Context, params prooftypes.Params) error
+}
+
+type SharedKeeper interface {
+	GetParams(ctx context.Context) sharedtypes.Params
+}
+
+type SupplierKeeper interface {
+	SetSupplier(context.Context, sharedtypes.Supplier)
+}
+
+type SessionKeeper interface {
+	GetSession(context.Context, *sessiontypes.QueryGetSessionRequest) (*sessiontypes.QueryGetSessionResponse, error)
+	StoreBlockHash(ctx context.Context)
 }


### PR DESCRIPTION
## Summary

- Refactors `WithBlockHeight()` and `WithBlockHash()` `ProofKeepersOpt` functions to be in terms of a new `genericOptionFunc` so that they can be reused between `ProofModuleKeepers` and `TokenomicsModuleKeepers` integration environments.
- Moves common helpers to a new package in `testutil/keeper/common`.

## Issue

- #579

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
