### PR TITLE
[E2E] Make relay feature to wait for the ClaimSettled event

### DIFF
--- a/e2e/tests/init_test.go
+++ b/e2e/tests/init_test.go
@@ -402,9 +402,9 @@ func (s *suite) TheApplicationReceivesASuccessfulRelayResponseSignedBy(appName s
 	require.Contains(s, stdout, `"result":"0x`)
 }
 
-// TODO_TECHDEBT: Factor out the common logic between this step and waitForTxResultEvent,
-// it is actually not possible since the later is getting the query client from
-// s.scenarioState which seems to cause query client to fail with EOF error.
+// TODO_TECHDEBT: Factor out the common logic between this step and waitForTxResultEvent.
+// It is not currently (easily) possible since the latter is getting the query client from
+// s.scenarioState, which seems to be the source of the query client's failure.
 func (s *suite) AModuleEventIsBroadcasted(module, event string) {
 	ctx, done := context.WithCancel(context.Background())
 
@@ -443,9 +443,9 @@ func (s *suite) AModuleEventIsBroadcasted(module, event string) {
 
 	select {
 	case <-time.After(eventTimeout):
-		s.Fatalf("timed out waiting for message with action %q", eventType)
+		s.Fatalf("timed out waiting for event to be emitted by module %q", eventType)
 	case <-ctx.Done():
-		s.Log("Success; message detected before timeout.")
+		s.Log("Success; event from module emitted before timeout.")
 	}
 }
 

--- a/e2e/tests/relay.feature
+++ b/e2e/tests/relay.feature
@@ -8,7 +8,7 @@ Feature: Relay Namespace
         And the session for application "app1" and service "anvil" contains the supplier "supplier1"
         When the application "app1" sends the supplier "supplier1" a request for service "anvil" with data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
         Then the application "app1" receives a successful relay response signed by "supplier1"
-        And a "proof" module "SubmitProof" message is submitted by "supplier1"
+        And a "tokenomics" module "ClaimSettled" event is broadcasted
 
     # TODO_TEST(@Olshansk):
     # - Successful relay through applicat's sovereign appgate server

--- a/e2e/tests/relay.feature
+++ b/e2e/tests/relay.feature
@@ -8,6 +8,7 @@ Feature: Relay Namespace
         And the session for application "app1" and service "anvil" contains the supplier "supplier1"
         When the application "app1" sends the supplier "supplier1" a request for service "anvil" with data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
         Then the application "app1" receives a successful relay response signed by "supplier1"
+        And a "proof" module "SubmitProof" message is submitted by "supplier1"
 
     # TODO_TEST(@Olshansk):
     # - Successful relay through applicat's sovereign appgate server


### PR DESCRIPTION
## Summary

Add `AModuleMessageIsSubmittedBy` step to the `relay.feature` that waits for its corresponding `ClaimSettled` event to be broadcasted before moving to the next test.

## Issue

Because `relay.feature` did not wait for its corresponding `ClaimSettled` event to be boradcasted, and due to the newly introduced C&P submission timings, the `session.feature` had it's initial claim count altered by the previous step.

This PR fixes this by adding the appropriate event waiting that makes `session.feature` start with a clean state.

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [x] I have left TODOs throughout the codebase, if applicable
