### PR TITLE
[Tokenomics] Update telemetry to include relay mining difficulty and EMA

### DIFF
--- a/localnet/grafana-dashboards/stress-test-dashboard.json
+++ b/localnet/grafana-dashboards/stress-test-dashboard.json
@@ -1337,9 +1337,209 @@
       ],
       "title": "Claim Settlement & Expiration",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "avg by(service_id) (event_type_gauge{container=\"poktrolld-validator\", type=\"relay_ema\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Relays EMA per Service",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "avg by(service_id) (event_type_gauge{container=\"poktrolld-validator\", type=\"relay_mining_difficulty\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Relay Mining Difficulty per Service",
+      "type": "timeseries"
     }
   ],
-  "refresh": "",
+  "refresh": "5s",
   "schemaVersion": 39,
   "tags": [
     "protocol"

--- a/telemetry/event_counters.go
+++ b/telemetry/event_counters.go
@@ -135,6 +135,36 @@ func ClaimCounter(
 	)
 }
 
+func RelayMiningDifficultyGauge(numbLeadingZeroBits int, serviceId string) {
+	labels := []metrics.Label{
+		{Name: "type", Value: "relay_mining_difficulty"},
+		{Name: "service_id", Value: serviceId},
+	}
+
+	telemetry.SetGaugeWithLabels(
+		// TODO_INVESTIGATE: Using the same metric key for counter and gauge doesn't
+		// seem to work. Prepend "gauge" to the gauge metric key to make it is displayed.
+		[]string{eventTypeMetricKey + "_gauge"},
+		float32(numbLeadingZeroBits),
+		labels,
+	)
+}
+
+func RelayEMAGauge(relayEMA uint64, serviceId string) {
+	labels := []metrics.Label{
+		{Name: "type", Value: "relay_ema"},
+		{Name: "service_id", Value: serviceId},
+	}
+
+	telemetry.SetGaugeWithLabels(
+		// TODO_INVESTIGATE: Using the same metric key for counter and gauge doesn't
+		// seem to work. Prepend "gauge" to the gauge metric key to make it is displayed.
+		[]string{eventTypeMetricKey + "_gauge"},
+		float32(relayEMA),
+		labels,
+	)
+}
+
 // AppendErrLabel appends a label with the name "error" and a value of the error's
 // message to the given labels slice if the error is not nil.
 func AppendErrLabel(err error, labels ...metrics.Label) []metrics.Label {

--- a/telemetry/event_counters.go
+++ b/telemetry/event_counters.go
@@ -144,11 +144,7 @@ func ClaimCounter(
 // RelayMiningDifficultyCounter sets a gauge which tracks the relay mining difficulty,
 // which is represented by number of leading zero bits.
 // The serviceId is used as a label to be able to track the difficulty for each service.
-func RelayMiningDifficultyGauge(numbLeadingZeroBits int, serviceId string, err error) {
-	if err != nil {
-		return
-	}
-
+func RelayMiningDifficultyGauge(numbLeadingZeroBits int, serviceId string) {
 	labels := []metrics.Label{
 		{Name: "type", Value: "relay_mining_difficulty"},
 		{Name: "service_id", Value: serviceId},
@@ -163,11 +159,7 @@ func RelayMiningDifficultyGauge(numbLeadingZeroBits int, serviceId string, err e
 
 // RelayEMAGauge sets a gauge which tracks the relay EMA for a service.
 // The serviceId is used as a label to be able to track the EMA for each service.
-func RelayEMAGauge(relayEMA uint64, serviceId string, err error) {
-	if err != nil {
-		return
-	}
-
+func RelayEMAGauge(relayEMA uint64, serviceId string) {
 	labels := []metrics.Label{
 		{Name: "type", Value: "relay_ema"},
 		{Name: "service_id", Value: serviceId},

--- a/telemetry/event_counters.go
+++ b/telemetry/event_counters.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	eventTypeMetricKey = "event_type"
-	// TODO_INVESTIGATE(@okdas): Using eventTypeMetricKey for counter and gauge
-	// doesn't seem to work. Add "_gauge" postfix to display it in the meantime.
+	// TODO_DECIDE: Decide if we want to continue using these generic metrics keys
+	// or opt for specific keys for each event_type.
+	// See: https://github.com/pokt-network/poktroll/pull/631#discussion_r1653760820
+	eventTypeMetricKey      = "event_type"
 	eventTypeMetricKeyGauge = "event_type_gauge"
 )
 
@@ -143,7 +144,11 @@ func ClaimCounter(
 // RelayMiningDifficultyCounter sets a gauge which tracks the relay mining difficulty,
 // which is represented by number of leading zero bits.
 // The serviceId is used as a label to be able to track the difficulty for each service.
-func RelayMiningDifficultyGauge(numbLeadingZeroBits int, serviceId string) {
+func RelayMiningDifficultyGauge(numbLeadingZeroBits int, serviceId string, err error) {
+	if err != nil {
+		return
+	}
+
 	labels := []metrics.Label{
 		{Name: "type", Value: "relay_mining_difficulty"},
 		{Name: "service_id", Value: serviceId},
@@ -158,7 +163,11 @@ func RelayMiningDifficultyGauge(numbLeadingZeroBits int, serviceId string) {
 
 // RelayEMAGauge sets a gauge which tracks the relay EMA for a service.
 // The serviceId is used as a label to be able to track the EMA for each service.
-func RelayEMAGauge(relayEMA uint64, serviceId string) {
+func RelayEMAGauge(relayEMA uint64, serviceId string, err error) {
+	if err != nil {
+		return
+	}
+
 	labels := []metrics.Label{
 		{Name: "type", Value: "relay_ema"},
 		{Name: "service_id", Value: serviceId},

--- a/telemetry/event_counters.go
+++ b/telemetry/event_counters.go
@@ -12,7 +12,12 @@ import (
 	"github.com/hashicorp/go-metrics"
 )
 
-const eventTypeMetricKey = "event_type"
+const (
+	eventTypeMetricKey = "event_type"
+	// TODO_INVESTIGATE(@okdas): Using eventTypeMetricKey for counter and gauge
+	// doesn't seem to work. Add "_gauge" postfix to display it in the meantime.
+	eventTypeMetricKeyGauge = "event_type_gauge"
+)
 
 type ClaimProofStage = string
 
@@ -135,6 +140,9 @@ func ClaimCounter(
 	)
 }
 
+// RelayMiningDifficultyCounter sets a gauge which tracks the relay mining difficulty,
+// which is represented by number of leading zero bits.
+// The serviceId is used as a label to be able to track the difficulty for each service.
 func RelayMiningDifficultyGauge(numbLeadingZeroBits int, serviceId string) {
 	labels := []metrics.Label{
 		{Name: "type", Value: "relay_mining_difficulty"},
@@ -142,14 +150,14 @@ func RelayMiningDifficultyGauge(numbLeadingZeroBits int, serviceId string) {
 	}
 
 	telemetry.SetGaugeWithLabels(
-		// TODO_INVESTIGATE: Using the same metric key for counter and gauge doesn't
-		// seem to work. Prepend "gauge" to the gauge metric key to make it is displayed.
-		[]string{eventTypeMetricKey + "_gauge"},
+		[]string{eventTypeMetricKeyGauge},
 		float32(numbLeadingZeroBits),
 		labels,
 	)
 }
 
+// RelayEMAGauge sets a gauge which tracks the relay EMA for a service.
+// The serviceId is used as a label to be able to track the EMA for each service.
 func RelayEMAGauge(relayEMA uint64, serviceId string) {
 	labels := []metrics.Label{
 		{Name: "type", Value: "relay_ema"},
@@ -157,9 +165,7 @@ func RelayEMAGauge(relayEMA uint64, serviceId string) {
 	}
 
 	telemetry.SetGaugeWithLabels(
-		// TODO_INVESTIGATE: Using the same metric key for counter and gauge doesn't
-		// seem to work. Prepend "gauge" to the gauge metric key to make it is displayed.
-		[]string{eventTypeMetricKey + "_gauge"},
+		[]string{eventTypeMetricKeyGauge},
 		float32(relayEMA),
 		labels,
 	)

--- a/x/session/keeper/session_hydrator.go
+++ b/x/session/keeper/session_hydrator.go
@@ -74,12 +74,12 @@ func (k Keeper) HydrateSession(ctx context.Context, sh *sessionHydrator) (*types
 	if err := k.hydrateSessionApplication(ctx, sh); err != nil {
 		return nil, err
 	}
-	logger.Info("Finished hydrating session application: %+v", sh.session.Application)
+	logger.Info(fmt.Sprintf("Finished hydrating session application: %+v", sh.session.Application))
 
 	if err := k.hydrateSessionSuppliers(ctx, sh); err != nil {
 		return nil, err
 	}
-	logger.Info("Finished hydrating session suppliers: %+v")
+	logger.Info("Finished hydrating session suppliers")
 
 	sh.session.Header = sh.sessionHeader
 	sh.session.SessionId = sh.sessionHeader.SessionId

--- a/x/tokenomics/keeper/update_relay_mining_difficulty.go
+++ b/x/tokenomics/keeper/update_relay_mining_difficulty.go
@@ -30,7 +30,7 @@ const (
 	// It indirectly drives the off-chain resource requirements of the network
 	// in additional to playing a critical role in Relay Mining.
 	// TODO_BLOCKER(@Olshansk, #542): Make this a governance parameter.
-	TargetNumRelays = uint64(2)
+	TargetNumRelays = uint64(10e4)
 )
 
 // UpdateRelayMiningDifficulty updates the on-chain relay mining difficulty
@@ -166,8 +166,7 @@ func computeEma(alpha float64, prevEma, currValue uint64) uint64 {
 	return uint64(alpha*float64(currValue) + (1-alpha)*float64(prevEma))
 }
 
-// getNumLeadingZeroBitsFromHash returns the number of leading zero bits for the
-// target hash.
+// getNumLeadingZeroBitsFromHash returns the number of leading zero bits for the target hash.
 func getNumLeadingZeroBitsFromHash(targetHash []byte) int {
 	numLeadingZeroBits := 0
 	for _, b := range targetHash {

--- a/x/tokenomics/keeper/update_relay_mining_difficulty_test.go
+++ b/x/tokenomics/keeper/update_relay_mining_difficulty_test.go
@@ -26,7 +26,7 @@ func TestUpdateRelayMiningDifficulty_Base(t *testing.T) {
 	relaysPerServiceMap := map[string]uint64{
 		"svc1": 1e3, // new service
 	}
-	err := keeper.UpdateRelayMiningDifficulty(ctx, relaysPerServiceMap)
+	_, err := keeper.UpdateRelayMiningDifficulty(ctx, relaysPerServiceMap)
 	require.NoError(t, err)
 
 	// The first time svc1 difficulty is updated, the relay EMA will be equal
@@ -40,7 +40,7 @@ func TestUpdateRelayMiningDifficulty_Base(t *testing.T) {
 		"svc1": 1e10, // higher than the first value above
 		"svc2": 1e5,  // new service
 	}
-	err = keeper.UpdateRelayMiningDifficulty(ctx, relaysPerServiceMap)
+	_, err = keeper.UpdateRelayMiningDifficulty(ctx, relaysPerServiceMap)
 	require.NoError(t, err)
 
 	difficultySvc12, found := keeper.GetRelayMiningDifficulty(ctx, "svc1")
@@ -65,7 +65,7 @@ func TestUpdateRelayMiningDifficulty_Base(t *testing.T) {
 		"svc2": 1e2,  // lower than the first value above
 		"svc3": 1e10, // new service
 	}
-	err = keeper.UpdateRelayMiningDifficulty(ctx, relaysPerServiceMap)
+	_, err = keeper.UpdateRelayMiningDifficulty(ctx, relaysPerServiceMap)
 	require.NoError(t, err)
 
 	// svc1 relays went up so the target hash is now a smaller number (more leading zeroes)
@@ -139,7 +139,7 @@ func TestUpdateRelayMiningDifficulty_FirstDifficulty(t *testing.T) {
 			relaysPerServiceMap := map[string]uint64{
 				"svc1": tt.numRelays,
 			}
-			err := keeper.UpdateRelayMiningDifficulty(ctx, relaysPerServiceMap)
+			_, err := keeper.UpdateRelayMiningDifficulty(ctx, relaysPerServiceMap)
 			require.NoError(t, err)
 
 			difficulty, found := keeper.GetRelayMiningDifficulty(ctx, "svc1")

--- a/x/tokenomics/module/abci.go
+++ b/x/tokenomics/module/abci.go
@@ -68,11 +68,9 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) (err error) {
 
 	// Emit telemetry for each service's relay mining difficulty.
 	for serviceId, newDifficulty := range difficultyPerServiceMap {
-		defer func() {
-			miningDifficultyNumBits := keeper.RelayMiningTargetHashToDifficulty(newDifficulty.TargetHash)
-			telemetry.RelayMiningDifficultyGauge(miningDifficultyNumBits, serviceId, err)
-			telemetry.RelayEMAGauge(newDifficulty.NumRelaysEma, serviceId, err)
-		}()
+		miningDifficultyNumBits := keeper.RelayMiningTargetHashToDifficulty(newDifficulty.TargetHash)
+		telemetry.RelayMiningDifficultyGauge(miningDifficultyNumBits, serviceId)
+		telemetry.RelayEMAGauge(newDifficulty.NumRelaysEma, serviceId)
 	}
 
 	return nil

--- a/x/tokenomics/module/abci.go
+++ b/x/tokenomics/module/abci.go
@@ -68,9 +68,11 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) (err error) {
 
 	// Emit telemetry for each service's relay mining difficulty.
 	for serviceId, newDifficulty := range difficultyPerServiceMap {
-		miningDifficultyNumBits := keeper.RelayMiningTargetHashToDifficulty(newDifficulty.TargetHash)
-		telemetry.RelayMiningDifficultyGauge(miningDifficultyNumBits, serviceId)
-		telemetry.RelayEMAGauge(newDifficulty.NumRelaysEma, serviceId)
+		defer func() {
+			miningDifficultyNumBits := keeper.RelayMiningTargetHashToDifficulty(newDifficulty.TargetHash)
+			telemetry.RelayMiningDifficultyGauge(miningDifficultyNumBits, serviceId, err)
+			telemetry.RelayEMAGauge(newDifficulty.NumRelaysEma, serviceId, err)
+		}()
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Add `RelayMiningDifficulty` and `Relays EMA` metrics to `UpdateRelayMiningDifficulty` keeper function and create the corresponding Grafana charts to the stress test dashboard

A `TargetNumRelays` of `2` was used for the chart below.

![image](https://github.com/pokt-network/poktroll/assets/231488/44011525-32bc-440a-8d1a-e0d9542321d4)

## Issue

- #626 

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [x] I create and reference any new tickets, if applicable
- [x] I have left TODOs throughout the codebase, if applicable
