### PR TITLE
[LoadTest] Add missing block query client to load test

### DIFF
--- a/load-testing/tests/relays_stress_helpers_test.go
+++ b/load-testing/tests/relays_stress_helpers_test.go
@@ -1361,12 +1361,11 @@ func (s *relaysSuite) countClaimAndProofs() {
 
 // querySharedParams queries the current on-chain shared module parameters for use
 // over the duration of the test.
-func (s *relaysSuite) querySharedParams() {
+func (s *relaysSuite) querySharedParams(queryNodeRPCURL string) {
 	s.Helper()
 
 	deps := depinject.Supply(s.txContext.GetClientCtx())
 
-	queryNodeRPCURL := testclient.CometLocalWebsocketURL
 	blockQueryClient, err := sdkclient.NewClientFromNode(queryNodeRPCURL)
 	require.NoError(s, err)
 	deps = depinject.Configs(deps, depinject.Supply(blockQueryClient))

--- a/load-testing/tests/relays_stress_helpers_test.go
+++ b/load-testing/tests/relays_stress_helpers_test.go
@@ -1365,6 +1365,12 @@ func (s *relaysSuite) querySharedParams() {
 	s.Helper()
 
 	deps := depinject.Supply(s.txContext.GetClientCtx())
+
+	queryNodeRPCURL := testclient.CometLocalWebsocketURL
+	blockQueryClient, err := sdkclient.NewClientFromNode(queryNodeRPCURL)
+	require.NoError(s, err)
+	deps = depinject.Configs(deps, depinject.Supply(blockQueryClient))
+
 	sharedQueryClient, err := query.NewSharedQuerier(deps)
 	require.NoError(s, err)
 

--- a/load-testing/tests/relays_stress_test.go
+++ b/load-testing/tests/relays_stress_test.go
@@ -358,7 +358,7 @@ func (s *relaysSuite) LocalnetIsRunning() {
 	s.countClaimAndProofs()
 
 	// Query for the current shared on-chain params.
-	s.querySharedParams()
+	s.querySharedParams(loadTestParams.TestNetNode)
 
 	// Some suppliers may already be staked at genesis, ensure that staking during
 	// this test succeeds by increasing the sake amount.


### PR DESCRIPTION
## Summary

Add missing `BlockQueryClient` dependency required by `SharedClient` to the load test.

## Issue

`SharedClient` was updated to have a `BlockQueryClient` dependency which was not supplied in the load test suite.

![image](https://github.com/pokt-network/poktroll/assets/231488/ac367819-abbd-4324-9275-9932a18d0444)

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Local Testing** (only if making code changes)
- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
