### PR TITLE
[Relayminer] fix: relayminer wait log

### DIFF
--- a/pkg/relayer/proxy/server_builder.go
+++ b/pkg/relayer/proxy/server_builder.go
@@ -15,11 +15,11 @@ import (
 )
 
 const (
-	// supplierStakeWaitTimeSeconds is the time to wait for the supplier to be staked before
+	// supplierStakeWaitTime is the time to wait for the supplier to be staked before
 	// attempting to (try again to) retrieve the supplier's on-chain record.
 	// This is useful for testing and development purposes, where the supplier
 	// may not be staked before the relay miner starts.
-	supplierStakeWaitTimeSeconds = 1 * time.Second
+	supplierStakeWaitTime = 1 * time.Second
 
 	// supplierMaxStakeWaitTimeMinutes is the time to wait before a panic is thrown
 	// if the supplier is still not staked when the time elapses.
@@ -162,10 +162,10 @@ func (rp *relayerProxy) waitForSupplierToStake(
 		if err != nil && suppliertypes.ErrSupplierNotFound.Is(err) {
 			rp.logger.Info().Msgf(
 				"Waiting %d seconds for the supplier with address %s to stake",
-				supplierStakeWaitTimeSeconds,
+				supplierStakeWaitTime/time.Second,
 				supplierAddress,
 			)
-			time.Sleep(supplierStakeWaitTimeSeconds)
+			time.Sleep(supplierStakeWaitTime)
 
 			// See the comment above `supplierMaxStakeWaitTimeMinutes` for why
 			// and how this is used.


### PR DESCRIPTION
## Summary


## Issue

Observation made while working on #644

Before:

```
{"level":"info","message":"Waiting 1000000000 seconds for the supplier with address pokt1re27pw4llwnatx4sq7rlggqzcm6j3f39epq2wa to stake"}
```

After:

```
{"level":"info","message":"Waiting 1 seconds for the supplier with address pokt1re27pw4llwnatx4sq7rlggqzcm6j3f39epq2wa to stake"}
```

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed `supplierStakeWaitTimeSeconds` to `supplierStakeWaitTime` to improve clarity in timing behavior for supplier staking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->