### PR TITLE
[Load Testing] fix: stress test duration calculation

### DIFF
--- a/load-testing/tests/relays_stress_helpers_test.go
+++ b/load-testing/tests/relays_stress_helpers_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pokt-network/poktroll/testutil/testclient/testeventsquery"
 	apptypes "github.com/pokt-network/poktroll/x/application/types"
 	gatewaytypes "github.com/pokt-network/poktroll/x/gateway/types"
+	"github.com/pokt-network/poktroll/x/shared"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 	suppliertypes "github.com/pokt-network/poktroll/x/supplier/types"
 )
@@ -376,11 +377,9 @@ func (plans *actorLoadTestIncrementPlans) totalDurationBlocks(sharedParams *shar
 	// last increment duration (i.e. **after** maxActorCount actors are activated).
 	blocksToLastSessionEnd := plans.maxActorBlocksToFinalIncrementEnd()
 
-	blocksToLastProofWindowEnd := blocksToLastSessionEnd + int64(sharedParams.GetGracePeriodEndOffsetBlocks())
-
-	// Add one session length so that the duration is inclusive of the block which
-	// commits the last session's proof.
-	return blocksToLastProofWindowEnd + int64(sharedParams.GetNumBlocksPerSession())
+	// Wait until the proof window of the last session number closes in order to
+	// ensure that all suppliers have submitted all proofs.
+	return shared.GetProofWindowCloseHeight(sharedParams, blocksToLastSessionEnd)
 }
 
 // blocksToFinalIncrementStart returns the number of blocks that will have


### PR DESCRIPTION
## Summary

Fixes the test duration calculation for the relays stress test. This reduces (but does not seem to completely eliminate) the flakiness of the `TheCorrectPairsCountOfClaimAndProofMessagesShouldBeCommittedOnchain` assertion step.

## Issue

Observation made while working on #643.

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the calculation method for total duration blocks in load testing, enhancing accuracy and consistency by leveraging shared parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->