### PR TITLE
[Docs] Claim expiration

### DIFF
--- a/docusaurus/docs/protocol/primitives/claim_and_proof_lifecycle.md
+++ b/docusaurus/docs/protocol/primitives/claim_and_proof_lifecycle.md
@@ -130,16 +130,15 @@ gantt
 
 ### Claim Expiration
 
-If a claim requires a proof (as determined by [Probabilistic Proofs](probabilistic_proofs.md)) and a `Supplier` fails 
-to submit a `Proof` prior to the `Proof Window` closing, the claim will expire and the `Supplier` will forfeit any
+If a claim requires a proof (as determined by [Probabilistic Proofs](probabilistic_proofs.md)) and a `Supplier` fails
+to submit a `Proof` before the `Proof Window` closes, the claim will expire and the `Supplier` will forfeit any
 rewards for the work done.
 
 Claims MUST expire (and therefore the proof window MUST close) for the following reasons:
 
 1. The mint & burn associated with a given claim's settlement MUST occur while the application stake is still locked and applications must be allowed complete unstaking in finite time.
-1. Claim settlement SHOULD be limited to considering a claims created within a rolling window of blocks to decouple settlement from a long-tail accumulation of unsettled claims.
+1. Claim settlement SHOULD be limited to considering claims created within a rolling window of blocks to decouple settlement from a long-tail accumulation of unsettled claims.
 1. Proofs MUST be pruned to prevent network state bloat over time. Pruning proofs makes the number of proofs in network state at any given time a function of recent relay demand.
-
 ## Session
 
 A session is a necessary pre-requisite for the `Claim & Proof` lifecycle to work.
@@ -346,8 +345,8 @@ to submit a `SubmitProof` transaction containing a `Proof`. If it is submitted t
 early or too late, it will be rejected by the protocol.
 
 If a proof is required (as determined by [Probabilistic Proofs](probabilistic_proofs.md)) and a `Supplier` fails to
-submit a `Proof` during the Proof Window, the Claim will expire and the supplier will forfeit rewards for the claimed
-work done. See [Claim Expiration](#claim-expiration) for more. 
+submit a `Proof` during the Proof Window, the Claim will expire, and the supplier will forfeit rewards for the claimed
+work done. See [Claim Expiration](#claim-expiration) for more.
 
 See [Session Windows & On-Chain Parameters](#session-windows--on-chain-parameters) for more details.
 

--- a/docusaurus/docs/protocol/primitives/claim_and_proof_lifecycle.md
+++ b/docusaurus/docs/protocol/primitives/claim_and_proof_lifecycle.md
@@ -136,9 +136,10 @@ rewards for the work done.
 
 Claims MUST expire (and therefore the proof window MUST close) for the following reasons:
 
-1. The mint & burn associated with a given claim's settlement MUST occur while the application stake is still locked and applications must be allowed complete unstaking in finite time.
+1. The mint & burn associated with a given claim's settlement MUST occur while the application stake is still locked and applications must be allowed to complete unstaking in finite time.
 1. Claim settlement SHOULD be limited to considering claims created within a rolling window of blocks to decouple settlement from a long-tail accumulation of unsettled claims.
 1. Proofs MUST be pruned to prevent network state bloat over time. Pruning proofs makes the number of proofs in network state at any given time a function of recent relay demand.
+
 ## Session
 
 A session is a necessary pre-requisite for the `Claim & Proof` lifecycle to work.

--- a/docusaurus/docs/protocol/primitives/claim_and_proof_lifecycle.md
+++ b/docusaurus/docs/protocol/primitives/claim_and_proof_lifecycle.md
@@ -15,6 +15,8 @@ to all readers.
 :::
 
 - [Introduction](#introduction)
+- [Session Windows & On-Chain Parameters](#session-windows--on-chain-parameters)
+  - [Claim Expiration](#claim-expiration)
 - [Session](#session)
   - [Session Duration](#session-duration)
   - [Session End](#session-end)
@@ -125,6 +127,18 @@ gantt
 #### References:
 
 - [`poktroll.shared.Params` / `sharedtypes.Params`](https://github.com/pokt-network/poktroll/blob/main/proto/poktroll/shared/params.proto)
+
+### Claim Expiration
+
+If a claim requires a proof (as determined by [Probabilistic Proofs](probabilistic_proofs.md)) and a `Supplier` fails 
+to submit a `Proof` prior to the `Proof Window` closing, the claim will expire and the `Supplier` will forfeit any
+rewards for the work done.
+
+Claims MUST expire (and therefore the proof window MUST close) for the following reasons:
+
+1. The mint & burn associated with a given claim's settlement MUST occur while the application stake is still locked and applications must be allowed complete unstaking in finite time.
+1. Claim settlement SHOULD be limited to considering a claims created within a rolling window of blocks to decouple settlement from a long-tail accumulation of unsettled claims.
+1. Proofs MUST be pruned to prevent network state bloat over time. Pruning proofs makes the number of proofs in network state at any given time a function of recent relay demand.
 
 ## Session
 
@@ -331,8 +345,9 @@ After the `Proof Window` opens, a `Supplier` has several blocks, a `Proof Window
 to submit a `SubmitProof` transaction containing a `Proof`. If it is submitted too
 early or too late, it will be rejected by the protocol.
 
-If a `Supplier` fails to submit a `Proof` during the Proof Window, the Claim will
-expire and the supplier will forfeit rewards for the claimed work done.
+If a proof is required (as determined by [Probabilistic Proofs](probabilistic_proofs.md)) and a `Supplier` fails to
+submit a `Proof` during the Proof Window, the Claim will expire and the supplier will forfeit rewards for the claimed
+work done. See [Claim Expiration](#claim-expiration) for more. 
 
 See [Session Windows & On-Chain Parameters](#session-windows--on-chain-parameters) for more details.
 


### PR DESCRIPTION
## Summary

- Add "Claim Expiration" sub-section to "Session Window & On-Chain Parameters".
- Update the table of contents.

## Issue

- #419 

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [x] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to elaborate on the claim expiration process and its consequences.
  - Added a subsection on claim expiration under `Session Windows & On-Chain Parameters` to emphasize the importance of closing the proof window for operational efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->