### PR TITLE
[Load Testing] fix: relay stress test duration calculation

### DIFF
--- a/load-testing/tests/relays_stress_helpers_test.go
+++ b/load-testing/tests/relays_stress_helpers_test.go
@@ -378,10 +378,10 @@ func (plans *actorLoadTestIncrementPlans) totalDurationBlocks(
 ) int64 {
 	// The last block of the last session SHOULD align with the last block of the
 	// last increment duration (i.e. **after** maxActorCount actors are activated).
-	blocksToLastSessionEnd := plans.maxActorBlocksToFinalIncrementEnd()
-	lastSessionEndHeight := +shared.GetSessionEndHeight(sharedParams, currentHeight+blocksToLastSessionEnd)
+	blocksToFinalSessionEnd := plans.maxActorBlocksToFinalIncrementEnd()
+	finalSessionEndHeight := shared.GetSessionEndHeight(sharedParams, currentHeight+blocksToFinalSessionEnd)
 
-	return shared.GetProofWindowCloseHeight(sharedParams, lastSessionEndHeight) - currentHeight
+	return shared.GetProofWindowCloseHeight(sharedParams, finalSessionEndHeight) - currentHeight
 }
 
 // blocksToFinalIncrementStart returns the number of blocks that will have

--- a/load-testing/tests/relays_stress_test.go
+++ b/load-testing/tests/relays_stress_test.go
@@ -162,11 +162,7 @@ type relaysSuite struct {
 	// It is calculated as the longest duration of the three actor increments.
 	relayLoadDurationBlocks int64
 
-	// testDurationBlocks is the duration of the test in blocks and is used to determine
-	// when the test is done.
-	// It is calculated as the time it takes to send all relay requests plus the time
-	// it takes so submit all claims and proofs.
-	testDurationBlocks int64
+	plans *actorLoadTestIncrementPlans
 
 	// gatewayUrls is a map of gatewayAddress->URL representing the provisioned gateways.
 	// These gateways are not staked yet but have their off-chain instance running
@@ -392,16 +388,12 @@ func (s *relaysSuite) MoreActorsAreStakedAsFollows(table gocuke.DataTable) {
 	// Parse and validate the actor increment plans from the given step table.
 	plans := s.parseActorLoadTestIncrementPlans(table)
 	s.validateActorLoadTestIncrementPlans(plans)
+	s.plans = plans
 
 	// The relay load duration is the longest duration of the three actor increments.
 	// The duration of each actor is calculated as how many blocks it takes to
 	// increment the actor count to the maximum.
 	s.relayLoadDurationBlocks = plans.maxActorBlocksToFinalIncrementEnd()
-
-	// The test duration indicates when the test is complete.
-	// It is calculated as the relay load duration plus the time it takes to
-	// submit all claims and proofs.
-	s.testDurationBlocks = plans.totalDurationBlocks(s.sharedParams)
 
 	if s.isEphemeralChain {
 		// Adjust the max delegations parameter to the max gateways to permit all

--- a/load-testing/tests/relays_stress_test.go
+++ b/load-testing/tests/relays_stress_test.go
@@ -162,6 +162,8 @@ type relaysSuite struct {
 	// It is calculated as the longest duration of the three actor increments.
 	relayLoadDurationBlocks int64
 
+	// plans is the actor load test increment plans used to increment the actors during the test
+	// and calculate the test duration.
 	plans *actorLoadTestIncrementPlans
 
 	// gatewayUrls is a map of gatewayAddress->URL representing the provisioned gateways.
@@ -386,23 +388,22 @@ func (s *relaysSuite) TheFollowingInitialActorsAreStaked(table gocuke.DataTable)
 
 func (s *relaysSuite) MoreActorsAreStakedAsFollows(table gocuke.DataTable) {
 	// Parse and validate the actor increment plans from the given step table.
-	plans := s.parseActorLoadTestIncrementPlans(table)
-	s.validateActorLoadTestIncrementPlans(plans)
-	s.plans = plans
+	s.plans = s.parseActorLoadTestIncrementPlans(table)
+	s.validateActorLoadTestIncrementPlans(s.plans)
 
 	// The relay load duration is the longest duration of the three actor increments.
 	// The duration of each actor is calculated as how many blocks it takes to
 	// increment the actor count to the maximum.
-	s.relayLoadDurationBlocks = plans.maxActorBlocksToFinalIncrementEnd()
+	s.relayLoadDurationBlocks = s.plans.maxActorBlocksToFinalIncrementEnd()
 
 	if s.isEphemeralChain {
 		// Adjust the max delegations parameter to the max gateways to permit all
 		// applications to delegate to all gateways.
 		// This is to ensure that requests are distributed evenly across all gateways
 		// at any given time.
-		s.sendAdjustMaxDelegationsParamTx(plans.gateways.maxActorCount)
+		s.sendAdjustMaxDelegationsParamTx(s.plans.gateways.maxActorCount)
 		s.waitForTxsToBeCommitted()
-		s.ensureUpdatedMaxDelegations(plans.gateways.maxActorCount)
+		s.ensureUpdatedMaxDelegations(s.plans.gateways.maxActorCount)
 	}
 
 	// Fund all the provisioned suppliers and gateways since their addresses are


### PR DESCRIPTION
## Summary

Fix relays stress test duration calculation to account for #516.

## Issue

- #516

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved calculation logic for test duration based on shared parameters and current height in load-testing modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->