### PR TITLE
[Observability] refactor: remove error labels from metrics

### DIFF
--- a/telemetry/event_counters.go
+++ b/telemetry/event_counters.go
@@ -60,7 +60,6 @@ func ProofRequirementCounter(
 	// Ensure the counter is not incremented if there was an error.
 	if err != nil {
 		incrementAmount = 0
-		labels = AppendErrLabel(err, labels...)
 	}
 
 	telemetry.IncrCounterWithLabels(
@@ -88,7 +87,6 @@ func ClaimComputeUnitsCounter(
 	// Ensure the counter is not incremented if there was an error.
 	if err != nil {
 		incrementAmount = 0
-		labels = AppendErrLabel(err, labels...)
 	}
 
 	telemetry.IncrCounterWithLabels(
@@ -116,7 +114,6 @@ func ClaimCounter(
 	// Ensure the counter is not incremented if there was an error.
 	if err != nil {
 		incrementAmount = 0
-		labels = AppendErrLabel(err, labels...)
 	}
 
 	telemetry.IncrCounterWithLabels(
@@ -155,14 +152,4 @@ func RelayEMAGauge(relayEMA uint64, serviceId string) {
 		float32(relayEMA),
 		labels,
 	)
-}
-
-// AppendErrLabel appends a label with the name "error" and a value of the error's
-// message to the given labels slice if the error is not nil.
-func AppendErrLabel(err error, labels ...metrics.Label) []metrics.Label {
-	if err == nil {
-		return labels
-	}
-
-	return append(labels, metrics.Label{Name: "error", Value: err.Error()})
 }


### PR DESCRIPTION


## Summary

Remove error labels from metrics to mitigate potential high cardinality.

## Issue

- #638 

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified telemetry event counters by removing error label appending logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->