### PR TITLE
[LoadTest] Passing non-existing plans variable

### DIFF
--- a/load-testing/tests/relays_stress_helpers_test.go
+++ b/load-testing/tests/relays_stress_helpers_test.go
@@ -407,12 +407,10 @@ func (plan *actorLoadTestIncrementPlan) blocksToFinalIncrementEnd() int64 {
 // & gateways but only funds new applications as they can't be delegated to until after the respective
 // gateway stake tx has been committed. It receives at the same frequency as committed blocks (i.e. 1:1)
 // but only sends conditionally as described here.
-func (s *relaysSuite) mapSessionInfoWhenStakingNewSuppliersAndGatewaysFn(
-	plans *actorLoadTestIncrementPlans,
-) channel.MapFn[*sessionInfoNotif, *stakingInfoNotif] {
-	appsPlan := plans.apps
-	gatewaysPlan := plans.gateways
-	suppliersPlan := plans.suppliers
+func (s *relaysSuite) mapSessionInfoWhenStakingNewSuppliersAndGatewaysFn() channel.MapFn[*sessionInfoNotif, *stakingInfoNotif] {
+	appsPlan := s.plans.apps
+	gatewaysPlan := s.plans.gateways
+	suppliersPlan := s.plans.suppliers
 
 	// Check if any new actors need to be staked **for use in the next session**
 	// and send the appropriate stake transactions if so.
@@ -490,9 +488,7 @@ func (s *relaysSuite) mapStakingInfoWhenStakingAndDelegatingNewApps(
 
 // sendFundAvailableActorsTx uses the funding account to generate bank.SendMsg
 // messages and sends a unique transaction to fund the initial actors.
-func (s *relaysSuite) sendFundAvailableActorsTx(
-	plans *actorLoadTestIncrementPlans,
-) (suppliers, gateways, applications []*accountInfo) {
+func (s *relaysSuite) sendFundAvailableActorsTx() (suppliers, gateways, applications []*accountInfo) {
 	// Send all the funding account's pending messages in a single transaction.
 	// This is done to avoid sending multiple transactions to fund the initial actors.
 	// pendingMsgs is reset after the transaction is sent.
@@ -521,7 +517,7 @@ func (s *relaysSuite) sendFundAvailableActorsTx(
 	// Fund accounts for **all** suppliers that will be used over the duration of the test.
 	suppliersAdded := int64(0)
 	for _, supplierAddress := range s.availableSupplierAddresses {
-		if suppliersAdded >= plans.suppliers.maxActorCount {
+		if suppliersAdded >= s.plans.suppliers.maxActorCount {
 			break
 		}
 
@@ -537,7 +533,7 @@ func (s *relaysSuite) sendFundAvailableActorsTx(
 	// Fund accounts for **all** gateways that will be used over the duration of the test.
 	gatewaysAdded := int64(0)
 	for _, gatewayAddress := range s.availableGatewayAddresses {
-		if gatewaysAdded >= plans.gateways.maxActorCount {
+		if gatewaysAdded >= s.plans.gateways.maxActorCount {
 			break
 		}
 		gateway := s.addActor(gatewayAddress, gatewayStakeAmount)
@@ -1467,12 +1463,10 @@ func (s *relaysSuite) logAndAbortTest(txResults []*types.TxResult, errorMsg stri
 // populateWithKnownApplications creates a list of gateways based on the gatewayUrls
 // provided in the test manifest. It is used in non-ephemeral chain tests where the
 // gateways are not under the test's control and are expected to be already staked.
-func (s *relaysSuite) populateWithKnownGateways(
-	plans *actorLoadTestIncrementPlans,
-) (gateways []*accountInfo) {
+func (s *relaysSuite) populateWithKnownGateways() (gateways []*accountInfo) {
 	s.gatewayInitialCount = int64(len(s.gatewayUrls))
-	plans.gateways.maxActorCount = s.gatewayInitialCount
-	plans.gateways.initialActorCount = s.gatewayInitialCount
+	s.plans.gateways.maxActorCount = s.gatewayInitialCount
+	s.plans.gateways.initialActorCount = s.gatewayInitialCount
 	for gwAddress := range s.gatewayUrls {
 		gateway := &accountInfo{
 			address: gwAddress,

--- a/load-testing/tests/relays_stress_test.go
+++ b/load-testing/tests/relays_stress_test.go
@@ -409,7 +409,7 @@ func (s *relaysSuite) MoreActorsAreStakedAsFollows(table gocuke.DataTable) {
 	// Fund all the provisioned suppliers and gateways since their addresses are
 	// known and they are not created on the fly, while funding only the initially
 	// created applications.
-	fundedSuppliers, fundedGateways, fundedApplications := s.sendFundAvailableActorsTx(plans)
+	fundedSuppliers, fundedGateways, fundedApplications := s.sendFundAvailableActorsTx()
 	// Funding messages are sent in a single transaction by the funding account,
 	// only one transaction is expected to be committed.
 	txResults := s.waitForTxsToBeCommitted()
@@ -439,7 +439,7 @@ func (s *relaysSuite) MoreActorsAreStakedAsFollows(table gocuke.DataTable) {
 	// not incrementally staked, but are already staked and delegated to, add all
 	// of them to the list of active gateways at the beginning of the test.
 	if !s.isEphemeralChain {
-		gateways = s.populateWithKnownGateways(plans)
+		gateways = s.populateWithKnownGateways()
 	}
 
 	// Delegate the initial applications to the initial gateways
@@ -471,7 +471,7 @@ func (s *relaysSuite) MoreActorsAreStakedAsFollows(table gocuke.DataTable) {
 	stakingSuppliersAndGatewaysObs := channel.Map(
 		s.ctx,
 		s.sessionInfoObs,
-		s.mapSessionInfoWhenStakingNewSuppliersAndGatewaysFn(plans),
+		s.mapSessionInfoWhenStakingNewSuppliersAndGatewaysFn(),
 	)
 
 	// stakedAndDelegatingObs notifies when staking and delegation transactions are sent.


### PR DESCRIPTION
## Summary

Remove non existing `plans` variable and use the `actorLoadTestIncrementPlans` (`s.plans`) property

## Issue

The load testing no longer compiles due to a non-existing `plans` variable
![image](https://github.com/pokt-network/poktroll/assets/231488/8ee0812a-a5ca-48c2-94ac-7c131ae4ca26)

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified function calls by removing redundant parameters for improved code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->