### PR TITLE
[Code Health] chore: log unused error when updating relay mining difficulty

### DIFF
--- a/x/tokenomics/keeper/update_relay_mining_difficulty.go
+++ b/x/tokenomics/keeper/update_relay_mining_difficulty.go
@@ -45,7 +45,11 @@ func (k Keeper) UpdateRelayMiningDifficulty(
 	for serviceId, numRelays := range relaysPerServiceMap {
 		prevDifficulty, found := k.GetRelayMiningDifficulty(ctx, serviceId)
 		if !found {
-			types.ErrTokenomicsMissingRelayMiningDifficulty.Wrapf("No previous relay mining difficulty found for service %s. Initializing with default difficulty %v", serviceId, prevDifficulty.TargetHash)
+			logger.Warn(types.ErrTokenomicsMissingRelayMiningDifficulty.Wrapf(
+				"No previous relay mining difficulty found for service %s. Initializing with default difficulty %v",
+				serviceId, prevDifficulty.TargetHash,
+			).Error())
+
 			// If a previous difficulty for the service is not found, we initialize
 			// it with a default.
 			prevDifficulty = types.RelayMiningDifficulty{


### PR DESCRIPTION
## Summary

Log previously unused error when updating relay mining difficulty where no previous difficulty was found.

## Issue

N/A

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Added a warning log when no previous relay mining difficulty is found, ensuring users are informed before initializing with default difficulty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->