### PR TITLE
[Supplier] Deny supplier staking with unknown services

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -183,6 +183,9 @@ genesis:
     service:
       params:
         add_service_fee: "1000000000"
+      serviceList:
+        - id: anvil
+          name: ""
     proof:
       params:
         proof_request_probability: "0.25"

--- a/localnet/poktrolld/config/supplier1_stake_config.yaml
+++ b/localnet/poktrolld/config/supplier1_stake_config.yaml
@@ -2,10 +2,6 @@
 # so that the stake command causes a state change.
 stake_amount: 1000069upokt
 services:
-  - service_id: svc1
-    endpoints:
-      - publicly_exposed_url: http://localhost:8081
-        rpc_type: JSON_RPC
   # The endpoint URL for the Anvil service is provided via the RelayMiner.
   # The RelayMiner acts as a proxy, forwarding requests to the actual Anvil data node behind it.
   # This setup allows for flexible and dynamic service provisioning within the network.

--- a/testutil/integration/app.go
+++ b/testutil/integration/app.go
@@ -338,12 +338,14 @@ func NewCompleteIntegrationApp(t *testing.T) *App {
 		logger,
 		authority.String(),
 		bankKeeper,
+		serviceKeeper,
 	)
 	supplierModule := supplier.NewAppModule(
 		cdc,
 		supplierKeeper,
 		accountKeeper,
 		bankKeeper,
+		serviceKeeper,
 	)
 
 	// Prepare the session keeper and module

--- a/testutil/keeper/proof.go
+++ b/testutil/keeper/proof.go
@@ -28,6 +28,7 @@ import (
 	applicationmocks "github.com/pokt-network/poktroll/testutil/application/mocks"
 	gatewaymocks "github.com/pokt-network/poktroll/testutil/gateway/mocks"
 	"github.com/pokt-network/poktroll/testutil/proof/mocks"
+	servicemocks "github.com/pokt-network/poktroll/testutil/service/mocks"
 	sessionmocks "github.com/pokt-network/poktroll/testutil/session/mocks"
 	suppliermocks "github.com/pokt-network/poktroll/testutil/supplier/mocks"
 	appkeeper "github.com/pokt-network/poktroll/x/application/keeper"
@@ -37,6 +38,8 @@ import (
 	"github.com/pokt-network/poktroll/x/proof/keeper"
 	"github.com/pokt-network/poktroll/x/proof/types"
 	prooftypes "github.com/pokt-network/poktroll/x/proof/types"
+	servicekeeper "github.com/pokt-network/poktroll/x/service/keeper"
+	servicetypes "github.com/pokt-network/poktroll/x/service/types"
 	sessionkeeper "github.com/pokt-network/poktroll/x/session/keeper"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 	sharedkeeper "github.com/pokt-network/poktroll/x/shared/keeper"
@@ -118,6 +121,7 @@ func NewProofModuleKeepers(t testing.TB, opts ...ProofKeepersOpt) (_ *ProofModul
 		gatewaytypes.StoreKey,
 		authtypes.StoreKey,
 		sharedtypes.StoreKey,
+		servicetypes.StoreKey,
 	)
 
 	// Construct a multistore & mount store keys for each keeper that will interact with the state store.
@@ -179,6 +183,15 @@ func NewProofModuleKeepers(t testing.TB, opts ...ProofKeepersOpt) (_ *ProofModul
 	)
 	require.NoError(t, appKeeper.SetParams(ctx, apptypes.DefaultParams()))
 
+	// Construct a service keeper need by the supplier keeper.
+	serviceKeeper := servicekeeper.NewKeeper(
+		cdc,
+		runtime.NewKVStoreService(keys[types.StoreKey]),
+		log.NewNopLogger(),
+		authority.String(),
+		servicemocks.NewMockBankKeeper(ctrl),
+	)
+
 	// Construct a real supplier keeper to add suppliers to sessions.
 	supplierKeeper := supplierkeeper.NewKeeper(
 		cdc,
@@ -186,6 +199,7 @@ func NewProofModuleKeepers(t testing.TB, opts ...ProofKeepersOpt) (_ *ProofModul
 		log.NewNopLogger(),
 		authority.String(),
 		suppliermocks.NewMockBankKeeper(ctrl),
+		serviceKeeper,
 	)
 	require.NoError(t, supplierKeeper.SetParams(ctx, suppliertypes.DefaultParams()))
 

--- a/testutil/keeper/tokenomics.go
+++ b/testutil/keeper/tokenomics.go
@@ -36,6 +36,8 @@ import (
 	gatewaytypes "github.com/pokt-network/poktroll/x/gateway/types"
 	proofkeeper "github.com/pokt-network/poktroll/x/proof/keeper"
 	prooftypes "github.com/pokt-network/poktroll/x/proof/types"
+	servicekeeper "github.com/pokt-network/poktroll/x/service/keeper"
+	servicetypes "github.com/pokt-network/poktroll/x/service/types"
 	sessionkeeper "github.com/pokt-network/poktroll/x/session/keeper"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 	sharedkeeper "github.com/pokt-network/poktroll/x/shared/keeper"
@@ -283,6 +285,15 @@ func NewTokenomicsModuleKeepers(
 	)
 	require.NoError(t, appKeeper.SetParams(ctx, apptypes.DefaultParams()))
 
+	// Construct a service keeper need by the supplier keeper.
+	serviceKeeper := servicekeeper.NewKeeper(
+		cdc,
+		runtime.NewKVStoreService(keys[servicetypes.StoreKey]),
+		log.NewNopLogger(),
+		authority.String(),
+		bankKeeper,
+	)
+
 	// Construct a real supplier keeper to add suppliers to sessions.
 	supplierKeeper := supplierkeeper.NewKeeper(
 		cdc,
@@ -290,6 +301,7 @@ func NewTokenomicsModuleKeepers(
 		log.NewNopLogger(),
 		authority.String(),
 		bankKeeper,
+		serviceKeeper,
 	)
 	require.NoError(t, supplierKeeper.SetParams(ctx, suppliertypes.DefaultParams()))
 

--- a/testutil/keeper/tokenomics.go
+++ b/testutil/keeper/tokenomics.go
@@ -285,7 +285,7 @@ func NewTokenomicsModuleKeepers(
 	)
 	require.NoError(t, appKeeper.SetParams(ctx, apptypes.DefaultParams()))
 
-	// Construct a service keeper need by the supplier keeper.
+	// Construct a service keeper needed by the supplier keeper.
 	serviceKeeper := servicekeeper.NewKeeper(
 		cdc,
 		runtime.NewKVStoreService(keys[servicetypes.StoreKey]),

--- a/x/service/keeper/service.go
+++ b/x/service/keeper/service.go
@@ -46,8 +46,8 @@ func (k Keeper) RemoveService(
 	store.Delete(types.ServiceKey(serviceId))
 }
 
-// GetAllService returns all service
-func (k Keeper) GetAllService(ctx context.Context) (services []sharedtypes.Service) {
+// GetAllServices returns all services
+func (k Keeper) GetAllServices(ctx context.Context) (services []sharedtypes.Service) {
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.ServiceKeyPrefix))
 	iterator := storetypes.KVStorePrefixIterator(store, []byte{})

--- a/x/service/keeper/service_test.go
+++ b/x/service/keeper/service_test.go
@@ -69,6 +69,6 @@ func TestServiceGetAll(t *testing.T) {
 	services := createNServices(keeper, ctx, 10)
 	require.ElementsMatch(t,
 		nullify.Fill(services),
-		nullify.Fill(keeper.GetAllService(ctx)),
+		nullify.Fill(keeper.GetAllServices(ctx)),
 	)
 }

--- a/x/service/module/genesis.go
+++ b/x/service/module/genesis.go
@@ -24,7 +24,7 @@ func ExportGenesis(ctx context.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
 	genesis.Params = k.GetParams(ctx)
 
-	genesis.ServiceList = k.GetAllService(ctx)
+	genesis.ServiceList = k.GetAllServices(ctx)
 	// this line is used by starport scaffolding # genesis/module/export
 
 	return genesis

--- a/x/service/types/expected_keepers.go
+++ b/x/service/types/expected_keepers.go
@@ -22,4 +22,5 @@ type BankKeeper interface {
 	// than "delegate" funds from one account to another which is more closely
 	// linked to staking.
 	SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 }

--- a/x/supplier/keeper/keeper.go
+++ b/x/supplier/keeper/keeper.go
@@ -21,7 +21,8 @@ type (
 		// should be the x/gov module account.
 		authority string
 
-		bankKeeper types.BankKeeper
+		bankKeeper    types.BankKeeper
+		serviceKeeper types.ServiceKeeper
 	}
 )
 
@@ -32,6 +33,7 @@ func NewKeeper(
 	authority string,
 
 	bankKeeper types.BankKeeper,
+	serviceKeeper types.ServiceKeeper,
 ) Keeper {
 	if _, err := sdk.AccAddressFromBech32(authority); err != nil {
 		panic(fmt.Sprintf("invalid authority address: %s", authority))
@@ -43,7 +45,8 @@ func NewKeeper(
 		authority:    authority,
 		logger:       logger,
 
-		bankKeeper: bankKeeper,
+		bankKeeper:    bankKeeper,
+		serviceKeeper: serviceKeeper,
 	}
 }
 

--- a/x/supplier/keeper/msg_server_stake_supplier.go
+++ b/x/supplier/keeper/msg_server_stake_supplier.go
@@ -27,6 +27,14 @@ func (k msgServer) StakeSupplier(ctx context.Context, msg *types.MsgStakeSupplie
 		return nil, err
 	}
 
+	// Check if the services the supplier is staking for exist
+	for _, serviceConfig := range msg.Services {
+		if _, serviceFound := k.serviceKeeper.GetService(ctx, serviceConfig.Service.Id); !serviceFound {
+			logger.Error(fmt.Sprintf("service %q does not exist", serviceConfig.Service.Id))
+			return nil, types.ErrSupplierServiceNotFound.Wrapf("service %q does not exist", serviceConfig.Service.Id)
+		}
+	}
+
 	// Check if the supplier already exists or not
 	var err error
 	var coinsToEscrow sdk.Coin

--- a/x/supplier/module/module.go
+++ b/x/supplier/module/module.go
@@ -98,6 +98,7 @@ type AppModule struct {
 	keeper        keeper.Keeper
 	accountKeeper types.AccountKeeper
 	bankKeeper    types.BankKeeper
+	serviceKeeper types.ServiceKeeper
 }
 
 func NewAppModule(
@@ -105,12 +106,14 @@ func NewAppModule(
 	keeper keeper.Keeper,
 	accountKeeper types.AccountKeeper,
 	bankKeeper types.BankKeeper,
+	serviceKeeper types.ServiceKeeper,
 ) AppModule {
 	return AppModule{
 		AppModuleBasic: NewAppModuleBasic(cdc),
 		keeper:         keeper,
 		accountKeeper:  accountKeeper,
 		bankKeeper:     bankKeeper,
+		serviceKeeper:  serviceKeeper,
 	}
 }
 
@@ -179,6 +182,7 @@ type ModuleInputs struct {
 
 	AccountKeeper types.AccountKeeper
 	BankKeeper    types.BankKeeper
+	ServiceKeeper types.ServiceKeeper
 }
 
 type ModuleOutputs struct {
@@ -200,12 +204,14 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		in.Logger,
 		authority.String(),
 		in.BankKeeper,
+		in.ServiceKeeper,
 	)
 	m := NewAppModule(
 		in.Cdc,
 		k,
 		in.AccountKeeper,
 		in.BankKeeper,
+		in.ServiceKeeper,
 	)
 
 	return ModuleOutputs{SupplierKeeper: k, Module: m}

--- a/x/supplier/types/errors.go
+++ b/x/supplier/types/errors.go
@@ -16,4 +16,5 @@ var (
 	ErrSupplierInvalidSessionId          = sdkerrors.Register(ModuleName, 1107, "invalid session ID")
 	ErrSupplierInvalidService            = sdkerrors.Register(ModuleName, 1108, "invalid service in supplier")
 	ErrSupplierInvalidSessionEndHeight   = sdkerrors.Register(ModuleName, 1109, "invalid session ending height")
+	ErrSupplierServiceNotFound           = sdkerrors.Register(ModuleName, 1110, "service not found")
 )

--- a/x/supplier/types/expected_keepers.go
+++ b/x/supplier/types/expected_keepers.go
@@ -6,6 +6,8 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
 
 // AccountKeeper defines the expected interface for the Account module.
@@ -16,6 +18,12 @@ type AccountKeeper interface {
 
 // BankKeeper defines the expected interface for the Bank module.
 type BankKeeper interface {
+	SpendableCoins(context.Context, sdk.AccAddress) sdk.Coins
 	SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+}
+
+// ServiceKeeper defines the expected interface for the Service module.
+type ServiceKeeper interface {
+	GetService(ctx context.Context, serviceId string) (sharedtypes.Service, bool)
 }


### PR DESCRIPTION
## Summary

Prevent `Supplier`s from staking with non-existing services.

This PR does not enforce/restrict the `Service` creation.

## Issue

- #598 

## Type of change

Select one or more:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed issue where staking a supplier with a non-existing service did not return an error.

- **New Features**
  - Added service integration with new `serviceKeeper` and `supplierKeeper` functionality.
  - Introduced method to send coins from a module to an account in `BankKeeper`.

- **Improvements**
  - Updated `GetAllService` to `GetAllServices` for clarity.
  - Enhanced error handling with the new `ErrSupplierServiceNotFound` error code.

- **Tests**
  - Added tests to ensure error handling when staking with non-existing services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->