### PR TITLE
[TODO_BLOCKER] chore: Remove stale TODO_BLOCKERs

### DIFF
--- a/testutil/testproxy/relayerproxy.go
+++ b/testutil/testproxy/relayerproxy.go
@@ -258,11 +258,6 @@ func WithSuccessiveSessions(
 	}
 }
 
-// TODO_BLOCKER(@red-0ne): This function only supports JSON-RPC requests and
-// needs to have its http.Request "Content-Type" header passed-in as a parameter
-// and take out the GetRelayResponseError function which parses JSON-RPC responses
-// to make it RPC-type agnostic.
-
 // MarshalAndSend marshals the request and sends it to the provided service.
 func MarshalAndSend(
 	test *TestBehavior,

--- a/x/proof/keeper/msg_server_submit_proof.go
+++ b/x/proof/keeper/msg_server_submit_proof.go
@@ -192,7 +192,6 @@ func (k msgServer) SubmitProof(
 	logger.Debug("successfully compared relay response session header")
 
 	// Verify the relay request's signature.
-	// TODO_BLOCKER(@red-0ne): Fetch the correct ring for the session this relay is from.
 	if err = k.ringClient.VerifyRelayRequestSignature(ctx, relayReq); err != nil {
 		return nil, status.Error(codes.FailedPrecondition, err.Error())
 	}

--- a/x/supplier/config/supplier_configs_reader.go
+++ b/x/supplier/config/supplier_configs_reader.go
@@ -179,8 +179,6 @@ func parseEndpointRPCType(endpoint YAMLServiceEndpoint) (sharedtypes.RPCType, er
 	switch strings.ToLower(endpoint.RPCType) {
 	case "json_rpc":
 		return sharedtypes.RPCType_JSON_RPC, nil
-	// TODO_BLOCKER(@red-0ne): This hasn't been implemented yet but is part of the
-	// configurations, which is why we're not returning an error here.
 	case "rest":
 		return sharedtypes.RPCType_REST, nil
 	default:


### PR DESCRIPTION
## Summary

Remove resolved `TODO_BLOCKER`s.

## Issue

- #572 

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed obsolete comments and functions to improve code clarity and maintainability.

- **Chores**
  - Cleaned up TODO comments related to unimplemented features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->