### PR TITLE
[Bug] Prevent commit txs to be submitted outside close windows

### DIFF
--- a/x/proof/keeper/session.go
+++ b/x/proof/keeper/session.go
@@ -109,6 +109,8 @@ func (k Keeper) validateClaimWindow(
 	// TODO_BLOCKER(@bryanchriswhite, @red-0ne): Enforce an additional "latest
 	// supplier claim/proof commit offset" such that all suppliers have the same
 	// "supplier claim/proof commit window" size.
+	// This also prevent suppliers to end-up with only 1 block window to submit claims
+	// when EarliestSupplierClaimCommitHeight is too close to ClaimWindowCloseHeight.
 	// See: https://github.com/pokt-network/poktroll/pull/620/files#r1656548473.
 	if currentHeight < earliestClaimCommitHeight {
 		return types.ErrProofClaimOutsideOfWindow.Wrapf(

--- a/x/shared/session.go
+++ b/x/shared/session.go
@@ -5,6 +5,10 @@ import (
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
 
+// closeBlockOffset is the offset to subtract from the earliest supplier commit
+// height to ensure that the supplier has enough time to commit the claim/proof.
+const closeBlockOffset = 1
+
 // TODO_DOCUMENT(@bryanchriswhite): Move this into the documentation: https://github.com/pokt-network/poktroll/pull/571#discussion_r1630923625
 
 // GetSessionStartHeight returns the block height at which the session containing
@@ -118,7 +122,7 @@ func GetEarliestSupplierClaimCommitHeight(
 	// window open block hash and the supplier address.
 	randomNumber := poktrand.SeededInt63(claimWindowOpenBlockHash, []byte(supplierAddr))
 
-	distributionWindowSizeBlocks := sharedParams.GetClaimWindowCloseOffsetBlocks()
+	distributionWindowSizeBlocks := sharedParams.GetClaimWindowCloseOffsetBlocks() - closeBlockOffset
 	randCreateClaimHeightOffset := randomNumber % int64(distributionWindowSizeBlocks)
 
 	return claimWindowOpenHeight + randCreateClaimHeightOffset
@@ -139,7 +143,7 @@ func GetEarliestSupplierProofCommitHeight(
 	// window open block hash and the supplier address.
 	randomNumber := poktrand.SeededInt63(proofWindowOpenBlockHash, []byte(supplierAddr))
 
-	distributionWindowSizeBlocks := sharedParams.GetProofWindowCloseOffsetBlocks()
+	distributionWindowSizeBlocks := sharedParams.GetProofWindowCloseOffsetBlocks() - closeBlockOffset
 	randCreateProofHeightOffset := randomNumber % int64(distributionWindowSizeBlocks)
 
 	return proofWindowOpenHeight + randCreateProofHeightOffset

--- a/x/shared/session.go
+++ b/x/shared/session.go
@@ -122,8 +122,8 @@ func GetEarliestSupplierClaimCommitHeight(
 	// window open block hash and the supplier address.
 	randomNumber := poktrand.SeededInt63(claimWindowOpenBlockHash, []byte(supplierAddr))
 
-	distributionWindowSizeBlocks := sharedParams.GetClaimWindowCloseOffsetBlocks() - closeBlockOffset
-	randCreateClaimHeightOffset := randomNumber % int64(distributionWindowSizeBlocks)
+	claimWindowNumBlocks := sharedParams.GetClaimWindowCloseOffsetBlocks() - closeBlockOffset
+	randCreateClaimHeightOffset := randomNumber % int64(claimWindowNumBlocks)
 
 	return claimWindowOpenHeight + randCreateClaimHeightOffset
 }
@@ -143,8 +143,8 @@ func GetEarliestSupplierProofCommitHeight(
 	// window open block hash and the supplier address.
 	randomNumber := poktrand.SeededInt63(proofWindowOpenBlockHash, []byte(supplierAddr))
 
-	distributionWindowSizeBlocks := sharedParams.GetProofWindowCloseOffsetBlocks() - closeBlockOffset
-	randCreateProofHeightOffset := randomNumber % int64(distributionWindowSizeBlocks)
+	proofWindowNumBlocks := sharedParams.GetProofWindowCloseOffsetBlocks() - closeBlockOffset
+	randCreateProofHeightOffset := randomNumber % int64(proofWindowNumBlocks)
 
 	return proofWindowOpenHeight + randCreateProofHeightOffset
 }

--- a/x/shared/session_test.go
+++ b/x/shared/session_test.go
@@ -168,9 +168,9 @@ func TestClaimProofWindows(t *testing.T) {
 			sharedParams: sharedtypes.Params{
 				NumBlocksPerSession:          1,
 				ClaimWindowOpenOffsetBlocks:  0,
-				ClaimWindowCloseOffsetBlocks: 1,
+				ClaimWindowCloseOffsetBlocks: 2,
 				ProofWindowOpenOffsetBlocks:  0,
-				ProofWindowCloseOffsetBlocks: 1,
+				ProofWindowCloseOffsetBlocks: 2,
 			},
 			queryHeight: int64(1),
 		},


### PR DESCRIPTION
## Summary

This PR reduces `distributionWindowSizeBlocks` by `closeOffsetBlocks` to prevent `Supplier`s to have their `EarliestSupplier{Claim/Proof}CommitHeight` to be committed too late such that the `windowVerification` rejects it due to `ErrProof{Claim/Proof}OutsideOfWindow`.

## Issue

![image](https://github.com/user-attachments/assets/c476aea3-f7b6-4388-a552-2540045c3593)

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a buffer mechanism for supplier claim and proof submission windows to enhance reliability.
	- Added a constant to improve the calculation of distribution window sizes, allowing suppliers more time for submissions.

- **Bug Fixes**
	- Adjusted parameters in testing to extend the duration of claim and proof windows, potentially improving outcomes related to supplier commitments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->