### PR TITLE
A few corrections on quickstart.md doc

### DIFF
--- a/docusaurus/docs/develop/developer_guide/quickstart.md
+++ b/docusaurus/docs/develop/developer_guide/quickstart.md
@@ -403,11 +403,11 @@ The following is an example config to get you started:
 
 ```bash
 cat <<EOF >> shannon_relayminer_config.yaml
-default_signing_key_names: [ "keybase-key-name" ]
+default_signing_key_names: [ "shannon_supplier" ]
 smt_store_path: smt_stores
 metrics:
   enabled: true
-  addr: :9090
+  addr: :9999 # you may need to change the metrics server port due to port conflicts.
 pocket_node:
   query_node_rpc_url: tcp://127.0.0.1:26657
   query_node_grpc_url: tcp://127.0.0.1:9090
@@ -651,7 +651,7 @@ Given that we just staked a few suppliers, you customize the query to look for
 
 ## 6. Dynamically Scaling LocalNet
 
-We went through a low of steps above just so you can get a feel for how things work.
+We went through a flow of steps above just so you can get a feel for how things work.
 
 That said, you can dynamically scale the number of any actors in LocalNet by ony changing one line!
 


### PR DESCRIPTION
## Summary

Make corrections to the `quickstart.md` file:

Two errors in relay miner configuration file step:
     - The keybase name needs to be valid
     - The specified metrics port is already taken by the LocalNet components.

Corrected a typo in the text.

## Issue

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [x] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Changed the default signing key from "keybase-key-name" to "shannon_supplier."
	- Updated the metrics server port from 9090 to 9999 to avoid potential conflicts. 

- **Documentation Enhancements**
	- Corrected a textual error in the documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->