### PR TITLE
[Tests] Improve & Skip Flaky Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,6 @@
 
 SHELL = /bin/sh
 
-# TODO_IMPROVE: Look into how we can we source `.env.dev` and have everything
-# here work.
-
-# ifneq (,$(wildcard .env))
-# include .env
-# export $(shell sed 's/=.*//' .env)
-# endif
-
 POKTROLLD_HOME ?= ./localnet/poktrolld
 POCKET_NODE ?= tcp://127.0.0.1:26657 # The pocket node (validator in the localnet context)
 TESTNET_RPC ?= https://testnet-validated-validator-rpc.poktroll.com/ # TestNet RPC endpoint for validator maintained by Grove. Needs to be update if there's another "primary" testnet.
@@ -432,6 +424,10 @@ test_all: warn_flaky_tests check_go_version ## Run all go tests showing detailed
 .PHONY: test_all_with_integration
 test_all_with_integration: check_go_version ## Run all go tests, including those with the integration
 	go test -count=1 -v -race -tags test,integration ./...
+
+.PHONY: test_all_with_integration_and_flaky
+test_all_with_integration_and_flaky: check_go_version ## Run all go tests, including those with the integration and flaky tests
+	INCLUDE_FLAKY_TESTS=true go test -count=1 -v -race -tags test,integration ./...
 
 .PHONY: test_integration
 test_integration: check_go_version ## Run only the in-memory integration "unit" tests

--- a/Makefile
+++ b/Makefile
@@ -425,6 +425,9 @@ test_all: warn_flaky_tests check_go_version ## Run all go tests showing detailed
 test_all_with_integration: check_go_version ## Run all go tests, including those with the integration
 	go test -count=1 -v -race -tags test,integration ./...
 
+# We are explicitly using an env variable rather than a build tag to keep flaky
+# tests in line with non flaky tests and use it as a way to easily turn them
+# on and off without maintaining extra files.
 .PHONY: test_all_with_integration_and_flaky
 test_all_with_integration_and_flaky: check_go_version ## Run all go tests, including those with the integration and flaky tests
 	INCLUDE_FLAKY_TESTS=true go test -count=1 -v -race -tags test,integration ./...

--- a/Tiltfile
+++ b/Tiltfile
@@ -63,9 +63,7 @@ merge_dicts(localnet_config, localnet_config_defaults)
 # Then merge file contents over defaults
 merge_dicts(localnet_config, localnet_config_file)
 # Check if there are differences or if the file doesn't exist
-if (localnet_config_file != localnet_config) or (
-    not os.path.exists(localnet_config_path)
-):
+if (localnet_config_file != localnet_config) or (not os.path.exists(localnet_config_path)):
     print("Updating " + localnet_config_path + " with defaults")
     local("cat - > " + localnet_config_path, stdin=encode_yaml(localnet_config))
 
@@ -82,9 +80,7 @@ if localnet_config["helm_chart_local_repo"]["enabled"]:
 # Observability
 print("Observability enabled: " + str(localnet_config["observability"]["enabled"]))
 if localnet_config["observability"]["enabled"]:
-    helm_repo(
-        "prometheus-community", "https://prometheus-community.github.io/helm-charts"
-    )
+    helm_repo("prometheus-community", "https://prometheus-community.github.io/helm-charts")
     helm_repo("grafana-helm-repo", "https://grafana.github.io/helm-charts")
 
     # Increase timeout for building the image
@@ -96,9 +92,7 @@ if localnet_config["observability"]["enabled"]:
         flags=[
             "--values=./localnet/kubernetes/observability-prometheus-stack.yaml",
             "--set=grafana.defaultDashboardsEnabled="
-            + str(
-                localnet_config["observability"]["grafana"]["defaultDashboardsEnabled"]
-            ),
+            + str(localnet_config["observability"]["grafana"]["defaultDashboardsEnabled"]),
         ],
         resource_deps=["prometheus-community"],
     )
@@ -130,9 +124,7 @@ if localnet_config["observability"]["enabled"]:
     )
 
     # Import our custom grafana dashboards into Kubernetes ConfigMap
-    configmap_create(
-        "protocol-dashboards", from_file=listdir("localnet/grafana-dashboards/")
-    )
+    configmap_create("protocol-dashboards", from_file=listdir("localnet/grafana-dashboards/"))
 
     # Grafana discovers dashboards to "import" via a label
     local_resource(
@@ -142,14 +134,10 @@ if localnet_config["observability"]["enabled"]:
     )
 
 # Import keyring/keybase files into Kubernetes ConfigMap
-configmap_create(
-    "poktrolld-keys", from_file=listdir("localnet/poktrolld/keyring-test/")
-)
+configmap_create("poktrolld-keys", from_file=listdir("localnet/poktrolld/keyring-test/"))
 
 # Import keyring/keybase files into Kubernetes Secret
-secret_create_generic(
-    "poktrolld-keys", from_file=listdir("localnet/poktrolld/keyring-test/")
-)
+secret_create_generic("poktrolld-keys", from_file=listdir("localnet/poktrolld/keyring-test/"))
 
 # Import validator keys for the poktrolld helm chart to consume
 secret_create_generic(
@@ -161,9 +149,7 @@ secret_create_generic(
 )
 
 # Import configuration files into Kubernetes ConfigMap
-configmap_create(
-    "poktrolld-configs", from_file=listdir("localnet/poktrolld/config/"), watch=True
-)
+configmap_create("poktrolld-configs", from_file=listdir("localnet/poktrolld/config/"), watch=True)
 
 # Hot reload protobuf changes
 local_resource(
@@ -207,9 +193,7 @@ WORKDIR /
 )
 
 # Run data nodes & validators
-k8s_yaml(
-    ["localnet/kubernetes/anvil.yaml", "localnet/kubernetes/validator-volume.yaml"]
-)
+k8s_yaml(["localnet/kubernetes/anvil.yaml", "localnet/kubernetes/validator-volume.yaml"])
 
 # Provision validator
 helm_resource(
@@ -218,14 +202,11 @@ helm_resource(
     flags=[
         "--values=./localnet/kubernetes/values-common.yaml",
         "--values=./localnet/kubernetes/values-validator.yaml",
-        "--set=persistence.cleanupBeforeEachStart="
-        + str(localnet_config["validator"]["cleanupBeforeEachStart"]),
+        "--set=persistence.cleanupBeforeEachStart=" + str(localnet_config["validator"]["cleanupBeforeEachStart"]),
         "--set=logs.level=" + str(localnet_config["validator"]["logs"]["level"]),
         "--set=logs.format=" + str(localnet_config["validator"]["logs"]["format"]),
-        "--set=serviceMonitor.enabled="
-        + str(localnet_config["observability"]["enabled"]),
-        "--set=development.delve.enabled="
-        + str(localnet_config["validator"]["delve"]["enabled"]),
+        "--set=serviceMonitor.enabled=" + str(localnet_config["observability"]["enabled"]),
+        "--set=development.delve.enabled=" + str(localnet_config["validator"]["delve"]["enabled"]),
     ],
     image_deps=["poktrolld"],
     image_keys=[("image.repository", "image.tag")],
@@ -241,31 +222,25 @@ for x in range(localnet_config["relayminers"]["count"]):
         flags=[
             "--values=./localnet/kubernetes/values-common.yaml",
             "--values=./localnet/kubernetes/values-relayminer-common.yaml",
-            "--values=./localnet/kubernetes/values-relayminer-"
-            + str(actor_number)
-            + ".yaml",
-            "--set=metrics.serviceMonitor.enabled="
-            + str(localnet_config["observability"]["enabled"]),
-            "--set=development.delve.enabled="
-            + str(localnet_config["relayminers"]["delve"]["enabled"]),
+            "--values=./localnet/kubernetes/values-relayminer-" + str(actor_number) + ".yaml",
+            "--set=metrics.serviceMonitor.enabled=" + str(localnet_config["observability"]["enabled"]),
+            "--set=development.delve.enabled=" + str(localnet_config["relayminers"]["delve"]["enabled"]),
         ],
         image_deps=["poktrolld"],
         image_keys=[("image.repository", "image.tag")],
     )
     k8s_resource(
         "relayminer" + str(actor_number),
-        labels=["supplier_nodes"],
+        labels=["suppliers"],
         resource_deps=["validator"],
         links=[
             link(
-                "http://localhost:3003/d/relayminer/relayminer?orgId=1&var-relayminer=relayminer"
-                + str(actor_number),
+                "http://localhost:3003/d/relayminer/relayminer?orgId=1&var-relayminer=relayminer" + str(actor_number),
                 "Grafana dashboard",
             ),
         ],
         port_forwards=[
-            str(8084 + actor_number)
-            + ":8545",  # relayminer1 - exposes 8545, relayminer2 exposes 8546, etc.
+            str(8084 + actor_number) + ":8545",  # relayminer1 - exposes 8545, relayminer2 exposes 8546, etc.
             str(40044 + actor_number)
             + ":40004",  # DLV port. relayminer1 - exposes 40045, relayminer2 exposes 40046, etc.
             # Run `curl localhost:PORT` to see the current snapshot of relayminer metrics.
@@ -288,17 +263,15 @@ for x in range(localnet_config["appgateservers"]["count"]):
             "--values=./localnet/kubernetes/values-common.yaml",
             "--values=./localnet/kubernetes/values-appgateserver.yaml",
             "--set=config.signing_key=app" + str(actor_number),
-            "--set=metrics.serviceMonitor.enabled="
-            + str(localnet_config["observability"]["enabled"]),
-            "--set=development.delve.enabled="
-            + str(localnet_config["appgateservers"]["delve"]["enabled"]),
+            "--set=metrics.serviceMonitor.enabled=" + str(localnet_config["observability"]["enabled"]),
+            "--set=development.delve.enabled=" + str(localnet_config["appgateservers"]["delve"]["enabled"]),
         ],
         image_deps=["poktrolld"],
         image_keys=[("image.repository", "image.tag")],
     )
     k8s_resource(
         "appgateserver" + str(actor_number),
-        labels=["applications"],
+        labels=["gateways"],
         resource_deps=["validator"],
         links=[
             link(
@@ -308,8 +281,7 @@ for x in range(localnet_config["appgateservers"]["count"]):
             ),
         ],
         port_forwards=[
-            str(42068 + actor_number)
-            + ":42069",  # appgateserver1 - exposes 42069, appgateserver2 exposes 42070, etc.
+            str(42068 + actor_number) + ":42069",  # appgateserver1 - exposes 42069, appgateserver2 exposes 42070, etc.
             str(40054 + actor_number)
             + ":40004",  # DLV port. appgateserver1 - exposes 40055, appgateserver2 exposes 40056, etc.
             # Run `curl localhost:PORT` to see the current snapshot of appgateserver metrics.
@@ -332,10 +304,8 @@ for x in range(localnet_config["gateways"]["count"]):
             "--values=./localnet/kubernetes/values-common.yaml",
             "--values=./localnet/kubernetes/values-gateway.yaml",
             "--set=config.signing_key=gateway" + str(actor_number),
-            "--set=metrics.serviceMonitor.enabled="
-            + str(localnet_config["observability"]["enabled"]),
-            "--set=development.delve.enabled="
-            + str(localnet_config["gateways"]["delve"]["enabled"]),
+            "--set=metrics.serviceMonitor.enabled=" + str(localnet_config["observability"]["enabled"]),
+            "--set=development.delve.enabled=" + str(localnet_config["gateways"]["delve"]["enabled"]),
         ],
         image_deps=["poktrolld"],
         image_keys=[("image.repository", "image.tag")],
@@ -352,10 +322,8 @@ for x in range(localnet_config["gateways"]["count"]):
             ),
         ],
         port_forwards=[
-            str(42078 + actor_number)
-            + ":42069",  # gateway1 - exposes 42079, gateway2 exposes 42080, etc.
-            str(40064 + actor_number)
-            + ":40004",  # DLV port. gateway1 - exposes 40065, gateway2 exposes 40066, etc.
+            str(42078 + actor_number) + ":42069",  # gateway1 - exposes 42079, gateway2 exposes 42080, etc.
+            str(40064 + actor_number) + ":40004",  # DLV port. gateway1 - exposes 40065, gateway2 exposes 40066, etc.
             # Run `curl localhost:PORT` to see the current snapshot of gateway metrics.
             str(9059 + actor_number)
             + ":9090",  # gateway metrics port. gateway1 - exposes 9060, gateway2 exposes 9061, etc.
@@ -399,8 +367,6 @@ if localnet_config["ollama"]["enabled"]:
 
     local_resource(
         name="ollama-pull-model",
-        cmd=execute_in_pod(
-            "ollama", "ollama pull " + localnet_config["ollama"]["model"]
-        ),
+        cmd=execute_in_pod("ollama", "ollama pull " + localnet_config["ollama"]["model"]),
         resource_deps=["ollama"],
     )

--- a/config.yml
+++ b/config.yml
@@ -199,7 +199,7 @@ genesis:
           denom: upokt
     shared:
       params:
-        num_blocks_per_session: 4
+        num_blocks_per_session: 10
         grace_period_end_offset_blocks: 1
         claim_window_open_offset_blocks: 1
         claim_window_close_offset_blocks: 4

--- a/e2e/tests/0_settlement.feature
+++ b/e2e/tests/0_settlement.feature
@@ -8,16 +8,21 @@
 Feature: Tokenomics Namespace
 
     Scenario: Emissions equals burn when a claim is created and a valid proof is submitted and required
+        # Baseline
         Given the user has the pocketd binary installed
+        # Network preparation
         And an account exists for "supplier1"
         And the "supplier" account for "supplier1" is staked
         And an account exists for "app1"
         And the "application" account for "app1" is staked
         And the service "anvil" registered for application "app1" has a compute units per relay of "1"
+        # Start servicing
         When the supplier "supplier1" has serviced a session with "10" relays for service "anvil" for application "app1"
+        # Wait for the Claim & Proof lifecycle
         And the user should wait for the "proof" module "CreateClaim" Message to be submitted
         And the user should wait for the "proof" module "SubmitProof" Message to be submitted
         And the user should wait for the "tokenomics" module "ClaimSettled" end block event to be broadcast
+        # Validate the results
         Then the account balance of "supplier1" should be "420" uPOKT "more" than before
         And the "application" stake of "app1" should be "420" uPOKT "less" than before
 

--- a/e2e/tests/init_test.go
+++ b/e2e/tests/init_test.go
@@ -428,15 +428,21 @@ func (s *suite) TheApplicationSendsTheSupplierASuccessfulRequestForServiceWithPa
 	jsonMap, err := jsonToMap(jsonContent)
 	require.NoError(s, err, "error converting JSON to map")
 
-	// Print the JSON response for reference since we're about to fail the test
-	if jsonMap["error"] != nil || jsonMap["result"] == nil {
-		prettyJson, err := jsonPrettyPrint(jsonContent)
-		require.NoError(s, err, "error pretty printing JSON")
-		s.Log(prettyJson)
-	}
+	prettyJson, err := jsonPrettyPrint(jsonContent)
+	require.NoError(s, err, "error pretty printing JSON")
+	s.Log(prettyJson)
 
-	require.Nil(s, jsonMap["error"], "error in relay response")
-	require.NotNil(s, jsonMap["result"], "no result in relay response")
+	// TODO_IMPROVE: This is a minimalistic first approach to request validation in E2E tests.
+	// Consider leveraging the shannon-sdk or path here.
+	switch path {
+	case "":
+		// Validate JSON-RPC request where the path is empty
+		require.Nil(s, jsonMap["error"], "error in relay response")
+		require.NotNil(s, jsonMap["result"], "no result in relay response")
+	default:
+		// Validate REST request where the path is non-empty
+		require.Nil(s, jsonMap["error"], "error in relay response")
+	}
 }
 
 func (s *suite) AModuleEndBlockEventIsBroadcast(module, eventType string) {

--- a/e2e/tests/init_test.go
+++ b/e2e/tests/init_test.go
@@ -464,7 +464,7 @@ func (s *suite) TheUserWaitsForUnbondingPeriodToFinish(accName string) {
 	require.True(s, ok, "supplier %s not found", accName)
 
 	unbondingHeight := s.getSupplierUnbondingHeight(accName)
-	s.waitForBlockHeight(unbondingHeight)
+	s.waitForBlockHeight(unbondingHeight + 1) // Add 1 to ensure the unbonding block has been committed
 }
 
 func (s *suite) getStakedAmount(actorType, accName string) (int, bool) {

--- a/e2e/tests/init_test.go
+++ b/e2e/tests/init_test.go
@@ -298,6 +298,7 @@ func (s *suite) TheUserStakesAWithUpoktForServiceFromTheAccount(actorType string
 		"-y",
 	}
 	res, err := s.pocketd.RunCommandOnHost("", args...)
+	require.NoError(s, err, "error staking %s for service %s", actorType, serviceId)
 
 	// Remove the temporary config file
 	err = os.Remove(configFile.Name())

--- a/e2e/tests/node.go
+++ b/e2e/tests/node.go
@@ -165,7 +165,7 @@ func (p *pocketdBin) runPocketCmd(args ...string) (*commandResult, error) {
 }
 
 // runCurlPostCmd is a helper to run a command using the local pocketd binary with the flags provided
-func (p *pocketdBin) runCurlPostCmd(rpcUrl, service, path, jsonRpcData string, args ...string) (*commandResult, error) {
+func (p *pocketdBin) runCurlPostCmd(rpcUrl, service, path, data string, args ...string) (*commandResult, error) {
 	// Ensure that if a path is provided, it starts with a "/".
 	// This is required for RESTful APIs that use a path to identify resources.
 	// For JSON-RPC APIs, the resource path should be empty, so empty paths are allowed.
@@ -178,7 +178,7 @@ func (p *pocketdBin) runCurlPostCmd(rpcUrl, service, path, jsonRpcData string, a
 		"-sS",        // silent with error
 		"-X", "POST", // HTTP method
 		"-H", "Content-Type: application/json", // HTTP headers
-		"--data", jsonRpcData, urlStr, // POST data
+		"--data", data, urlStr, // POST data
 	}
 	args = append(base, args...)
 	commandStr := "curl " + strings.Join(args, " ") // Create a string representation of the command

--- a/e2e/tests/node.go
+++ b/e2e/tests/node.go
@@ -121,7 +121,8 @@ func (p *pocketdBin) RunCurlWithRetry(rpcUrl, service, path, data string, numRet
 		"internal error: upstream error",
 	}
 	for _, ephemeralError := range ephemeralEndToEndErrors {
-		if strings.Contains(res.Stderr, ephemeralError) {
+		if strings.Contains(res.Stdout, ephemeralError) {
+			fmt.Println("Retrying due to ephemeral error:", res.Stdout)
 			time.Sleep(10 * time.Millisecond)
 			return p.RunCurlWithRetry(rpcUrl, service, path, data, numRetries-1, args...)
 		}

--- a/e2e/tests/node.go
+++ b/e2e/tests/node.go
@@ -134,8 +134,7 @@ func (p *pocketdBin) runPocketCmd(args ...string) (*commandResult, error) {
 }
 
 // runCurlPostCmd is a helper to run a command using the local pocketd binary with the flags provided
-func (p *pocketdBin) runCurlPostCmd(rpcUrl, service, path, data string, args ...string) (*commandResult, error) {
-	dataStr := fmt.Sprintf("%s", data)
+func (p *pocketdBin) runCurlPostCmd(rpcUrl, service, path, jsonRpcData string, args ...string) (*commandResult, error) {
 	// Ensure that if a path is provided, it starts with a "/".
 	// This is required for RESTful APIs that use a path to identify resources.
 	// For JSON-RPC APIs, the resource path should be empty, so empty paths are allowed.
@@ -148,7 +147,7 @@ func (p *pocketdBin) runCurlPostCmd(rpcUrl, service, path, data string, args ...
 		"-sS",        // silent with error
 		"-X", "POST", // HTTP method
 		"-H", "Content-Type: application/json", // HTTP headers
-		"--data", dataStr, urlStr, // POST data
+		"--data", jsonRpcData, urlStr, // POST data
 	}
 	args = append(base, args...)
 	commandStr := "curl " + strings.Join(args, " ") // Create a string representation of the command

--- a/e2e/tests/relay.feature
+++ b/e2e/tests/relay.feature
@@ -6,16 +6,14 @@ Feature: Relay Namespace
         And the application "app1" is staked for service "anvil"
         And the supplier "supplier1" is staked for service "anvil"
         And the session for application "app1" and service "anvil" contains the supplier "supplier1"
-        When the application "app1" sends the supplier "supplier1" a request for service "anvil" with path "" and data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
-        Then the application "app1" receives a successful relay response signed by "supplier1" for data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+        Then the application "app1" sends the supplier "supplier1" a successful request for service "anvil" with path "" and data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
 
     Scenario: App can send a REST relay to Supplier
         Given the user has the pocketd binary installed
         And the application "app1" is staked for service "ollama"
         And the supplier "supplier1" is staked for service "ollama"
         And the session for application "app1" and service "ollama" contains the supplier "supplier1"
-        When the application "app1" sends the supplier "supplier1" a request for service "ollama" with path "/api/chat" and data '{"model": "qwen:0.5b", "stream": false, "messages": [{"role": "user", "content":"count from 1 to 10"}]}'
-        Then the application "app1" receives a successful relay response signed by "supplier1" for data data '{"model": "qwen:0.5b", "stream": false, "messages": [{"role": "user", "content":"count from 1 to 10"}]}'
+        When the application "app1" sends the supplier "supplier1" a successful request for service "ollama" with path "/api/chat" and data '{"model": "qwen:0.5b", "stream": false, "messages": [{"role": "user", "content":"count from 1 to 10"}]}'
         And a "tokenomics" module "ClaimSettled" end block event is broadcast
 
     # TODO_TEST(@Olshansk):

--- a/e2e/tests/relay.feature
+++ b/e2e/tests/relay.feature
@@ -7,7 +7,7 @@ Feature: Relay Namespace
         And the supplier "supplier1" is staked for service "anvil"
         And the session for application "app1" and service "anvil" contains the supplier "supplier1"
         When the application "app1" sends the supplier "supplier1" a request for service "anvil" with path "" and data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
-        Then the application "app1" receives a successful relay response signed by "supplier1"
+        Then the application "app1" receives a successful relay response signed by "supplier1" for data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
 
     Scenario: App can send a REST relay to Supplier
         Given the user has the pocketd binary installed
@@ -15,7 +15,7 @@ Feature: Relay Namespace
         And the supplier "supplier1" is staked for service "ollama"
         And the session for application "app1" and service "ollama" contains the supplier "supplier1"
         When the application "app1" sends the supplier "supplier1" a request for service "ollama" with path "/api/chat" and data '{"model": "qwen:0.5b", "stream": false, "messages": [{"role": "user", "content":"count from 1 to 10"}]}'
-        Then the application "app1" receives a successful relay response signed by "supplier1"
+        Then the application "app1" receives a successful relay response signed by "supplier1" for data data '{"model": "qwen:0.5b", "stream": false, "messages": [{"role": "user", "content":"count from 1 to 10"}]}'
         And a "tokenomics" module "ClaimSettled" end block event is broadcast
 
     # TODO_TEST(@Olshansk):

--- a/e2e/tests/session_steps_test.go
+++ b/e2e/tests/session_steps_test.go
@@ -167,10 +167,7 @@ func (s *suite) sendRelaysForSession(
 	for i := 0; i < relayLimit; i++ {
 		payload := fmt.Sprintf(payload_fmt, i+1) // i+1 to avoid id=0 which is invalid
 
-		s.TheApplicationSendsTheSupplierARequestForServiceWithPathAndData(appName, supplierName, serviceId, defaultJSONPRCPath, payload)
-		time.Sleep(10 * time.Millisecond)
-
-		s.TheApplicationReceivesASuccessfulRelayResponseSignedByForData(appName, supplierName, payload)
+		s.TheApplicationSendsTheSupplierASuccessfulRequestForServiceWithPathAndData(appName, supplierName, serviceId, defaultJSONPRCPath, payload)
 		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/e2e/tests/session_steps_test.go
+++ b/e2e/tests/session_steps_test.go
@@ -174,12 +174,17 @@ func (s *suite) sendRelaysForSession(
 	s.TheSupplierIsStakedForService(supplierName, serviceId)
 	s.TheSessionForApplicationAndServiceContainsTheSupplier(appName, serviceId, supplierName)
 
-	// TODO_IMPROVE/TODO_COMMUNITY: hard-code a default set of RPC calls to iterate over for coverage.
-	data := `{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}`
+	// TODO_IMPROVE: hard-code a default set of RPC calls to iterate over for coverage.
+	payload_fmt := `{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":%d}`
 
 	for i := 0; i < relayLimit; i++ {
-		s.TheApplicationSendsTheSupplierARequestForServiceWithPathAndData(appName, supplierName, serviceId, defaultJSONPRCPath, data)
-		s.TheApplicationReceivesASuccessfulRelayResponseSignedBy(appName, supplierName)
+		payload := fmt.Sprintf(payload_fmt, i+1) // i+1 to avoid id=0 which is invalid
+
+		s.TheApplicationSendsTheSupplierARequestForServiceWithPathAndData(appName, supplierName, serviceId, defaultJSONPRCPath, payload)
+		time.Sleep(1000 * time.Millisecond)
+
+		s.TheApplicationReceivesASuccessfulRelayResponseSignedByForData(appName, supplierName, payload)
+		time.Sleep(1000 * time.Millisecond)
 	}
 }
 

--- a/e2e/tests/session_steps_test.go
+++ b/e2e/tests/session_steps_test.go
@@ -29,22 +29,9 @@ const (
 	// defaultJSONPRCPath is the default path used for sending JSON-RPC relay requests.
 	defaultJSONPRCPath = ""
 
-	// txSenderEventSubscriptionQueryFmt is the format string which yields the
-	// cosmos-sdk event subscription "query" string for a given sender address.
-	// This is used by an events replay client to subscribe to tx events from the supplier.
-	// See: https://docs.cosmos.network/v0.47/learn/advanced/events#subscribing-to-events
-	txSenderEventSubscriptionQueryFmt = "tm.event='Tx' AND message.sender='%s'"
-
 	// eventsReplayClientBufferSize is the buffer size for the events replay client
 	// for the subscriptions above.
 	eventsReplayClientBufferSize = 100
-
-	// txResultEventsReplayClientKey is the suite#scenarioState key for the events replay client
-	// which is subscribed to tx events where the tx sender is the scenario's supplier.
-	txResultEventsReplayClientKey = "txResultEventsReplayClientKey"
-	// newBlockEventReplayClientKey is the suite#scenarioState key for the events replay client
-	// which is subscribed to claim settlement or expiration events on-chain.
-	newBlockEventReplayClientKey = "newBlockEventReplayClientKey"
 
 	// preExistingClaimsKey is the suite#scenarioState key for any pre-existing
 	// claims when querying for all claims prior to running the scenario.
@@ -181,10 +168,10 @@ func (s *suite) sendRelaysForSession(
 		payload := fmt.Sprintf(payload_fmt, i+1) // i+1 to avoid id=0 which is invalid
 
 		s.TheApplicationSendsTheSupplierARequestForServiceWithPathAndData(appName, supplierName, serviceId, defaultJSONPRCPath, payload)
-		time.Sleep(1000 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 
 		s.TheApplicationReceivesASuccessfulRelayResponseSignedByForData(appName, supplierName, payload)
-		time.Sleep(1000 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/pkg/appgateserver/endpoint_selector.go
+++ b/pkg/appgateserver/endpoint_selector.go
@@ -1,7 +1,6 @@
 package appgateserver
 
 import (
-	"fmt"
 	"net/url"
 	"strconv"
 
@@ -42,11 +41,6 @@ func (app *appGateServer) getRelayerUrl(
 			}
 		}
 	}
-
-	fmt.Println("-----------------")
-	fmt.Println("OLSH", requestUrlStr)
-	fmt.Println("OLSH", rpcType, endpoints)
-	fmt.Println("-----------------")
 
 	// Return an error if no relayer endpoints were found.
 	if len(matchingRPCTypeEndpoints) == 0 {

--- a/pkg/appgateserver/endpoint_selector.go
+++ b/pkg/appgateserver/endpoint_selector.go
@@ -1,6 +1,7 @@
 package appgateserver
 
 import (
+	"fmt"
 	"net/url"
 	"strconv"
 
@@ -41,6 +42,11 @@ func (app *appGateServer) getRelayerUrl(
 			}
 		}
 	}
+
+	fmt.Println("-----------------")
+	fmt.Println("OLSH", requestUrlStr)
+	fmt.Println("OLSH", rpcType, endpoints)
+	fmt.Println("-----------------")
 
 	// Return an error if no relayer endpoints were found.
 	if len(matchingRPCTypeEndpoints) == 0 {

--- a/pkg/client/tx/client_test.go
+++ b/pkg/client/tx/client_test.go
@@ -293,7 +293,7 @@ func TestTxClient_SignAndBroadcast_CheckTxError(t *testing.T) {
 	if os.Getenv("INCLUDE_FLAKY_TESTS") != "true" {
 		t.Skip("Skipping known flaky test: 'TestTxClient_SignAndBroadcast_CheckTxError'")
 	} else {
-		t.Log(`TODO_FLAKY: Skipping known flaky test: 'TestTxClient_SignAndBroadcast_CheckTxError'
+		t.Log(`TODO_FLAKY: Running known flaky test: 'TestTxClient_SignAndBroadcast_CheckTxError'
 
 Run the following command a few times to verify it passes at least once:
 

--- a/pkg/client/tx/client_test.go
+++ b/pkg/client/tx/client_test.go
@@ -3,6 +3,7 @@ package tx_test
 import (
 	"context"
 	"crypto/sha256"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -289,11 +290,15 @@ func TestTxClient_SignAndBroadcast_CheckTxError(t *testing.T) {
 		ctx                  = context.Background()
 	)
 
-	t.Log(`TODO_FLAKY: Known flaky test: 'TestTxClient_SignAndBroadcast_CheckTxError'
+	if os.Getenv("INCLUDE_FLAKY_TESTS") != "true" {
+		t.Skip("Skipping known flaky test: 'TestTxClient_SignAndBroadcast_CheckTxError'")
+	} else {
+		t.Log(`TODO_FLAKY: Skipping known flaky test: 'TestTxClient_SignAndBroadcast_CheckTxError'
 
 Run the following command a few times to verify it passes at least once:
 
 $ go test -v -count=1 -run TestTxClient_SignAndBroadcast_CheckTxError ./pkg/client/tx/...`)
+	}
 
 	keyring, signingKey := testkeyring.NewTestKeyringWithKey(t, testSigningKeyName)
 

--- a/pkg/observable/channel/replay_test.go
+++ b/pkg/observable/channel/replay_test.go
@@ -2,6 +2,7 @@ package channel_test
 
 import (
 	"context"
+	"os"
 	"slices"
 	"testing"
 	"time"
@@ -15,6 +16,16 @@ import (
 )
 
 func TestReplayObservable_Overflow(t *testing.T) {
+	if os.Getenv("INCLUDE_FLAKY_TESTS") != "true" {
+		t.Skip("Skipping known flaky test: 'TestReplayObservable_Overflow'")
+	} else {
+		t.Log(`TODO_FLAKY: Skipping known flaky test: 'TestReplayObservable_Overflow'
+
+Run the following command a few times to verify it passes at least once:
+
+$ go test -v -count=1 -run TestReplayObservable_Overflow ./pkg/observable/channel/...`)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 

--- a/pkg/observable/channel/replay_test.go
+++ b/pkg/observable/channel/replay_test.go
@@ -19,7 +19,7 @@ func TestReplayObservable_Overflow(t *testing.T) {
 	if os.Getenv("INCLUDE_FLAKY_TESTS") != "true" {
 		t.Skip("Skipping known flaky test: 'TestReplayObservable_Overflow'")
 	} else {
-		t.Log(`TODO_FLAKY: Skipping known flaky test: 'TestReplayObservable_Overflow'
+		t.Log(`TODO_FLAKY: Running known flaky test: 'TestReplayObservable_Overflow'
 
 Run the following command a few times to verify it passes at least once:
 

--- a/pkg/relayer/interface.go
+++ b/pkg/relayer/interface.go
@@ -8,7 +8,6 @@ import (
 	"context"
 
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/pokt-network/smt"
 
 	"github.com/pokt-network/poktroll/pkg/observable"
@@ -158,5 +157,6 @@ type SessionTree interface {
 	// It returns an error if it has already been marked as such.
 	StartClaiming() error
 
+	// GetSupplierAddress returns the supplier address building this tree.
 	GetSupplierAddress() *cosmostypes.AccAddress
 }

--- a/pkg/relayer/session/errors.go
+++ b/pkg/relayer/session/errors.go
@@ -10,5 +10,6 @@ var (
 	ErrSessionTreeProofPathMismatch        = sdkerrors.Register(codespace, 4, "session tree proof path mismatch")
 	ErrSessionTreeUndefinedStoresDirectory = sdkerrors.Register(codespace, 5, "session tree key-value store directory undefined for where they will be saved on disk")
 	ErrSessionTreeAlreadyMarkedAsClaimed   = sdkerrors.Register(codespace, 6, "session tree already marked as claimed")
-	ErrSupplierClientNotFound              = sdkerrors.Register(codespace, 7, "supplier client not found")
+	ErrSessionSupplierClientNotFound       = sdkerrors.Register(codespace, 7, "supplier client not found")
+	ErrSessionUpdatingTree                 = sdkerrors.Register(codespace, 8, "error updating session SMST")
 )

--- a/pkg/relayer/session/session.go
+++ b/pkg/relayer/session/session.go
@@ -414,11 +414,18 @@ func (rs *relayerSessionsManager) mapAddMinedRelayToSessionTree(
 		return err, false
 	}
 
+	logger := rs.logger.
+		With("session_id", smst.GetSessionHeader().GetSessionId()).
+		With("application", smst.GetSessionHeader().GetApplicationAddress()).
+		With("supplier_address", smst.GetSupplierAddress().String())
+
 	if err := smst.Update(relay.Hash, relay.Bytes, 1); err != nil {
 		// TODO_IMPROVE: log additional info?
-		rs.logger.Error().Err(err).Msg("failed to update smt")
+		logger.Error().Err(err).Msg("failed to update smt")
 		return err, false
 	}
+
+	logger.Debug().Msg("added relay to session tree")
 
 	// Skip because this map function only outputs errors.
 	return nil, true

--- a/pkg/relayer/session/sessiontree.go
+++ b/pkg/relayer/session/sessiontree.go
@@ -3,7 +3,6 @@ package session
 import (
 	"bytes"
 	"crypto/sha256"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -125,9 +124,10 @@ func (st *sessionTree) Update(key, value []byte, weight uint64) error {
 
 	}
 
-	count := st.sessionSMT.MustCount()
-	sum := st.sessionSMT.MustSum()
-	fmt.Printf("Count: %d, Sum: %d\n", count, sum)
+	// DO NOT DELETE: Uncomment this for debugging and change to .Debug logs post MainNet.
+	// count := st.sessionSMT.MustCount()
+	// sum := st.sessionSMT.MustSum()
+	// fmt.Printf("Count: %d, Sum: %d\n", count, sum)
 
 	return nil
 }

--- a/pkg/relayer/session/sessiontree.go
+++ b/pkg/relayer/session/sessiontree.go
@@ -3,6 +3,7 @@ package session
 import (
 	"bytes"
 	"crypto/sha256"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -118,7 +119,17 @@ func (st *sessionTree) Update(key, value []byte, weight uint64) error {
 		return ErrSessionTreeClosed
 	}
 
-	return st.sessionSMT.Update(key, value, weight)
+	err := st.sessionSMT.Update(key, value, weight)
+	if err != nil {
+		return ErrSessionUpdatingTree.Wrapf("error: %v", err)
+
+	}
+
+	count := st.sessionSMT.MustCount()
+	sum := st.sessionSMT.MustSum()
+	fmt.Printf("Count: %d, Sum: %d\n", count, sum)
+
+	return nil
 }
 
 // ProveClosest is a wrapper for the SMST's ProveClosest function. It returns a proof for the given path.

--- a/pkg/relayer/session/sessiontree.go
+++ b/pkg/relayer/session/sessiontree.go
@@ -121,7 +121,6 @@ func (st *sessionTree) Update(key, value []byte, weight uint64) error {
 	err := st.sessionSMT.Update(key, value, weight)
 	if err != nil {
 		return ErrSessionUpdatingTree.Wrapf("error: %v", err)
-
 	}
 
 	// DO NOT DELETE: Uncomment this for debugging and change to .Debug logs post MainNet.

--- a/testutil/testproxy/relayerproxy.go
+++ b/testutil/testproxy/relayerproxy.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"testing"
 
 	"cosmossdk.io/depinject"
@@ -146,6 +147,15 @@ func WithServicesConfigMap(
 	servicesConfigMap map[string]*config.RelayMinerServerConfig,
 ) func(*TestBehavior) {
 	return func(test *TestBehavior) {
+		if os.Getenv("INCLUDE_FLAKY_TESTS") != "true" {
+			test.t.Skip("Skipping known flaky test: 'TestRelayerProxy'")
+		} else {
+			test.t.Log(`TODO_FLAKY: Running known flaky test: 'TestRelayerProxy'
+
+Run the following command a few times to verify it passes at least once:
+
+$ go test -v -count=1 -run TestRelayerProxy ./pkg/relayer/...`)
+		}
 		for _, serviceConfig := range servicesConfigMap {
 			for serviceId, supplierConfig := range serviceConfig.SupplierConfigsMap {
 				server := &http.Server{Addr: supplierConfig.ServiceConfig.BackendUrl.Host}
@@ -156,12 +166,7 @@ func WithServicesConfigMap(
 				go func() {
 					err := server.ListenAndServe()
 					if err != nil && !errors.Is(err, http.ErrServerClosed) {
-						require.NoError(test.t, err, `
-TODO_FLAKY: Known flaky test: 'TestRelayerProxy'
-
-Run the following command a few times to verify it passes at least once:
-
-$ go test -v -count=1 -run TestRelayerProxy ./pkg/relayer/proxy/...`)
+						require.NoError(test.t, err)
 					}
 				}()
 

--- a/testutil/testproxy/relayerproxy.go
+++ b/testutil/testproxy/relayerproxy.go
@@ -304,7 +304,6 @@ func MarshalAndSend(
 	require.NoError(test.t, err)
 	reader := io.NopCloser(bytes.NewReader(reqBz))
 	req := &http.Request{
-
 		Method: http.MethodPost,
 		Header: http.Header{
 			"Content-Type": []string{"application/json"},

--- a/x/application/module/tx_delegate_to_gateway_test.go
+++ b/x/application/module/tx_delegate_to_gateway_test.go
@@ -111,7 +111,8 @@ func TestCLI_DelegateToGateway(t *testing.T) {
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(delegateOutput.Bytes(), &resp))
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.TxHash)
-			require.Equal(t, uint32(0), resp.Code)
+			// You can reference Cosmos SDK error codes here: https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go
+			require.Equal(t, uint32(0), resp.Code, "tx response failed: %v", resp)
 		})
 	}
 }

--- a/x/application/module/tx_stake_application_test.go
+++ b/x/application/module/tx_stake_application_test.go
@@ -229,7 +229,8 @@ func TestCLI_StakeApplication(t *testing.T) {
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(outStake.Bytes(), &resp))
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.TxHash)
-			require.Equal(t, uint32(0), resp.Code)
+			// You can reference Cosmos SDK error codes here: https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go
+			require.Equal(t, uint32(0), resp.Code, "tx response failed: %v", resp)
 		})
 	}
 }

--- a/x/application/module/tx_undelegate_from_gateway_test.go
+++ b/x/application/module/tx_undelegate_from_gateway_test.go
@@ -111,7 +111,8 @@ func TestCLI_UndelegateFromGateway(t *testing.T) {
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(undelegateOutput.Bytes(), &resp))
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.TxHash)
-			require.Equal(t, uint32(0), resp.Code)
+			// You can reference Cosmos SDK error codes here: https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go
+			require.Equal(t, uint32(0), resp.Code, "tx response failed: %v", resp)
 		})
 	}
 }

--- a/x/application/module/tx_unstake_application_test.go
+++ b/x/application/module/tx_unstake_application_test.go
@@ -91,7 +91,8 @@ func TestCLI_UnstakeApplication(t *testing.T) {
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(outUnstake.Bytes(), &resp))
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.TxHash)
-			require.Equal(t, uint32(0), resp.Code)
+			// You can reference Cosmos SDK error codes here: https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go
+			require.Equal(t, uint32(0), resp.Code, "tx response failed: %v", resp)
 		})
 	}
 }

--- a/x/gateway/module/tx_stake_gateway_test.go
+++ b/x/gateway/module/tx_stake_gateway_test.go
@@ -144,7 +144,8 @@ func TestCLI_StakeGateway(t *testing.T) {
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(outStake.Bytes(), &resp))
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.TxHash)
-			require.Equal(t, uint32(0), resp.Code)
+			// You can reference Cosmos SDK error codes here: https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go
+			require.Equal(t, uint32(0), resp.Code, "tx response failed: %v", resp)
 		})
 	}
 }

--- a/x/gateway/module/tx_unstake_gateway_test.go
+++ b/x/gateway/module/tx_unstake_gateway_test.go
@@ -91,7 +91,8 @@ func TestCLI_UnstakeGateway(t *testing.T) {
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(outUnstake.Bytes(), &resp))
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.TxHash)
-			require.Equal(t, uint32(0), resp.Code)
+			// You can reference Cosmos SDK error codes here: https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go
+			require.Equal(t, uint32(0), resp.Code, "tx response failed: %v", resp)
 		})
 	}
 }

--- a/x/proof/module/query_claim_test.go
+++ b/x/proof/module/query_claim_test.go
@@ -135,10 +135,16 @@ func TestClaim_List(t *testing.T) {
 	numClaimsPerSession := sharedtypes.DefaultNumBlocksPerSession
 	totalClaims := numSessions * numClaimsPerSession
 
-	// TODO_FLAKY(@bryanchriswhite): Ths following line in this test is flaky because test configuration
-	// and management is hard (see details above). To verify if it's functioning
-	// independently, please run:
-	// $ make itest 2 5 ./x/proof/module -- -run TestClaim_List
+	// TODO_FLAKY(@bryanchriswhite): The `networkWithClaimObjects is flaky because
+	// test configuration and management is hard (see details above). To verify if
+	// it's functioning independently, please run:
+	// 		$ make itest 2 5 ./x/proof/module -- -run TestClaim_List
+	// NB: Adding the call to recover seemed to have mitigated the flakiness.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Test panicked: %s", r)
+		}
+	}()
 	net, claims, clientCtx := networkWithClaimObjects(t, numSessions, numSuppliers, numApps)
 
 	prepareArgs := func(next []byte, offset, limit uint64, total bool) []string {

--- a/x/proof/module/query_proof_test.go
+++ b/x/proof/module/query_proof_test.go
@@ -21,6 +21,7 @@ import (
 
 func networkWithProofObjects(t *testing.T, n int) (*network.Network, []types.Proof) {
 	t.Helper()
+
 	cfg := network.DefaultConfig()
 	state := types.GenesisState{}
 	for i := 0; i < n; i++ {
@@ -30,7 +31,7 @@ func networkWithProofObjects(t *testing.T, n int) (*network.Network, []types.Pro
 				SessionId: "mock_session_id",
 				// Other fields omitted and unused for these tests.
 			},
-			// CloseseMerkleProof not required for these tests.
+			// ClosestMerkleProof not required for these tests.
 			ClosestMerkleProof: nil,
 		}
 		nullify.Fill(&proof)

--- a/x/service/module/tx_add_service_test.go
+++ b/x/service/module/tx_add_service_test.go
@@ -155,7 +155,7 @@ func TestCLI_AddService(t *testing.T) {
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(addServiceOutput.Bytes(), &resp))
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.TxHash)
-			require.Equal(t, uint32(0), resp.Code)
+			require.Equal(t, uint32(0), resp.Code, "tx response failed: %v", resp)
 		})
 	}
 }

--- a/x/service/module/tx_add_service_test.go
+++ b/x/service/module/tx_add_service_test.go
@@ -155,6 +155,7 @@ func TestCLI_AddService(t *testing.T) {
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(addServiceOutput.Bytes(), &resp))
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.TxHash)
+			// You can reference Cosmos SDK error codes here: https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go
 			require.Equal(t, uint32(0), resp.Code, "tx response failed: %v", resp)
 		})
 	}

--- a/x/session/module/query_get_session_test.go
+++ b/x/session/module/query_get_session_test.go
@@ -2,6 +2,7 @@ package session_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -16,6 +17,16 @@ import (
 )
 
 func TestCLI_GetSession(t *testing.T) {
+	if os.Getenv("INCLUDE_FLAKY_TESTS") != "true" {
+		t.Skip("Skipping known flaky test: 'TestRelayerProxy'")
+	} else {
+		t.Log(`TODO_FLAKY: Skipping known flaky test: 'TestCLI_GetSession'
+
+Run the following command a few times to verify it passes at least once:
+
+$ go test -v -count=1 -run TestCLI_GetSession ./x/session/module/...`)
+	}
+
 	// Prepare the network
 	net, suppliers, applications := networkWithApplicationsAndSupplier(t, 2)
 	_, err := net.WaitForHeightWithTimeout(10, 30*time.Second) // Wait for a sufficiently high block height to ensure the staking transactions have been processed
@@ -179,7 +190,7 @@ func TestCLI_GetSession(t *testing.T) {
 				require.Contains(t, stat.Message(), test.expectedErr.Error())
 				return
 			}
-			require.NoError(t, err, "TODO_FLAKY: Try re-running with 'go test -v -count=1 -run TestCLI_GetSession/valid_-_block_height_specified_and_is_greater_than_zero ./x/session/module/...'")
+			require.NoError(t, err)
 
 			var getSessionRes sessiontypes.QueryGetSessionResponse
 			err = net.Config.Codec.UnmarshalJSON(getSessionOut.Bytes(), &getSessionRes)

--- a/x/session/module/query_get_session_test.go
+++ b/x/session/module/query_get_session_test.go
@@ -20,7 +20,7 @@ func TestCLI_GetSession(t *testing.T) {
 	if os.Getenv("INCLUDE_FLAKY_TESTS") != "true" {
 		t.Skip("Skipping known flaky test: 'TestRelayerProxy'")
 	} else {
-		t.Log(`TODO_FLAKY: Skipping known flaky test: 'TestCLI_GetSession'
+		t.Log(`TODO_FLAKY: Running known flaky test: 'TestCLI_GetSession'
 
 Run the following command a few times to verify it passes at least once:
 

--- a/x/supplier/module/tx_stake_supplier_test.go
+++ b/x/supplier/module/tx_stake_supplier_test.go
@@ -292,7 +292,8 @@ func TestCLI_StakeSupplier(t *testing.T) {
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(outStake.Bytes(), &resp))
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.TxHash)
-			require.Equal(t, uint32(0), resp.Code)
+			// You can reference Cosmos SDK error codes here: https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go
+			require.Equal(t, uint32(0), resp.Code, "tx response failed: %v", resp)
 		})
 	}
 }

--- a/x/supplier/module/tx_unstake_supplier_test.go
+++ b/x/supplier/module/tx_unstake_supplier_test.go
@@ -92,7 +92,8 @@ func TestCLI_UnstakeSupplier(t *testing.T) {
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(outUnstake.Bytes(), &resp))
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.TxHash)
-			require.Equal(t, uint32(0), resp.Code)
+			// You can reference Cosmos SDK error codes here: https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go
+			require.Equal(t, uint32(0), resp.Code, "tx response failed: %v", resp)
 		})
 	}
 }

--- a/x/tokenomics/keeper/proof_requirement_test.go
+++ b/x/tokenomics/keeper/proof_requirement_test.go
@@ -24,8 +24,10 @@ func TestKeeper_IsProofRequired(t *testing.T) {
 
 	var (
 		probability = prooftypes.DefaultProofRequestProbability
-		tolerance   = 0.01
-		confidence  = 0.99
+		// This was empirically determined to avoid false negatives in unit tests.
+		// As a maintainer of the codebase, you may need to adjust these.
+		tolerance  = 0.02
+		confidence = 0.98
 
 		numTrueSamples atomic.Int64
 	)
@@ -50,6 +52,6 @@ func TestKeeper_IsProofRequired(t *testing.T) {
 
 	// Check that the number of samples for each outcome is within the expected range.
 	numFalseSamples := sampleSize - numTrueSamples.Load()
-	require.InDeltaf(t, expectedNumTrueSamples, numTrueSamples.Load(), toleranceSamples, "true samples")
-	require.InDeltaf(t, expectedNumFalseSamples, numFalseSamples, toleranceSamples, "false samples")
+	require.InDeltaf(t, expectedNumTrueSamples, numTrueSamples.Load(), toleranceSamples, "true samples not in range")
+	require.InDeltaf(t, expectedNumFalseSamples, numFalseSamples, toleranceSamples, "false samples not in range")
 }

--- a/x/tokenomics/keeper/proof_requirement_test.go
+++ b/x/tokenomics/keeper/proof_requirement_test.go
@@ -27,7 +27,7 @@ func TestKeeper_IsProofRequired(t *testing.T) {
 		// This was empirically determined to avoid false negatives in unit tests.
 		// As a maintainer of the codebase, you may need to adjust these.
 		tolerance  = 0.05
-		confidence = 0.95
+		confidence = 0.98
 
 		numTrueSamples atomic.Int64
 	)

--- a/x/tokenomics/keeper/proof_requirement_test.go
+++ b/x/tokenomics/keeper/proof_requirement_test.go
@@ -26,8 +26,8 @@ func TestKeeper_IsProofRequired(t *testing.T) {
 		probability = prooftypes.DefaultProofRequestProbability
 		// This was empirically determined to avoid false negatives in unit tests.
 		// As a maintainer of the codebase, you may need to adjust these.
-		tolerance  = 0.02
-		confidence = 0.98
+		tolerance  = 0.05
+		confidence = 0.95
 
 		numTrueSamples atomic.Int64
 	)

--- a/x/tokenomics/keeper/settle_session_accounting_test.go
+++ b/x/tokenomics/keeper/settle_session_accounting_test.go
@@ -495,13 +495,6 @@ func TestSettleSessionAccounting_InvalidClaim(t *testing.T) {
 	// Iterate over each test case
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			// Use defer-recover to catch any panic
-			defer func() {
-				if r := recover(); r != nil {
-					t.Errorf("Test panicked: %s", r)
-				}
-			}()
-
 			// Execute test function
 			err := func() (err error) {
 				defer func() {

--- a/x/tokenomics/module/tx_update_params_test.go
+++ b/x/tokenomics/module/tx_update_params_test.go
@@ -62,7 +62,8 @@ func TestCLI_UpdateParams(t *testing.T) {
 				require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 				require.NotNil(t, resp)
 				require.NotNil(t, resp.TxHash)
-				require.Equal(t, uint32(0), resp.Code)
+				// You can reference Cosmos SDK error codes here: https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go
+				require.Equal(t, uint32(0), resp.Code, "tx response failed: %v", resp)
 			}
 		})
 	}

--- a/x/tokenomics/types/tx.pb.go
+++ b/x/tokenomics/types/tx.pb.go
@@ -130,10 +130,9 @@ type MsgUpdateParam struct {
 	// authority is the address that controls the module (defaults to x/gov unless overwritten).
 	Authority string `protobuf:"bytes,1,opt,name=authority,proto3" json:"authority,omitempty"`
 	// The (name, as_type) tuple must match the corresponding name and type as
-	// specified in the `Params“ message in `proof/params.proto.`
+	// specified in the `Params`` message in `proof/params.proto.`
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	// Types that are valid to be assigned to AsType:
-	//
 	//	*MsgUpdateParam_AsString
 	//	*MsgUpdateParam_AsInt64
 	//	*MsgUpdateParam_AsBytes


### PR DESCRIPTION
## Summary

- Add the `INCLUDE_FLAKY_TESTS` flag
- Skip a handful of flaky unit tests using the flag above
- Increase `num_blocks_per_session` from `4 -> 10` to avoid E2E tests sending claims mid-session
- Consolidate the request validation in E2E tests to one step
- Verify the response data (not just if it exists) in E2E curl commands
- Add a `RunCurlWithRetr` to account for some ephemeral `no host` issues on the kind cluster
- Calling `recover` in some unit tests that have a `panic: leveldb: closed` errors
- Removed some unused fields
- Improved some failure messages

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new testing target to manage flaky tests more effectively.
  - Added a method for retrieving supplier addresses in session management.

- **Bug Fixes**
  - Enhanced error handling and logging in various test functions to improve clarity on failures.
  - Adjusted configuration for session management to optimize performance.

- **Documentation**
  - Improved comments and clarifications in test scenarios to enhance readability and understanding.

- **Chores**
  - Removed unused constants and cleaned up commented-out code to streamline the codebase.
  - Standardized error messages across various test assertions for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->