### PR TITLE
[Tiltfile] Add rest to TiltFile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -49,6 +49,9 @@ localnet_config_defaults = {
         "enabled": False,
         "model": "qwen:0.5b",
     },
+    "rest": {
+        "enabled": False,
+    },
     # By default, we use the `helm_repo` function below to point to the remote repository
     # but can update it to the locally cloned repo for testing & development
     "helm_chart_local_repo": {"enabled": False, "path": "../helm-charts"},
@@ -193,11 +196,9 @@ WORKDIR /
 )
 
 # Run data nodes & validators
-k8s_yaml([
-    "localnet/kubernetes/anvil.yaml",
-    "localnet/kubernetes/rest.yaml",
-    "localnet/kubernetes/validator-volume.yaml"
-])
+k8s_yaml(
+    ["localnet/kubernetes/anvil.yaml", "localnet/kubernetes/rest.yaml", "localnet/kubernetes/validator-volume.yaml"]
+)
 
 # Provision validator
 helm_resource(

--- a/x/tokenomics/types/tx.pb.go
+++ b/x/tokenomics/types/tx.pb.go
@@ -133,7 +133,6 @@ type MsgUpdateParam struct {
 	// specified in the `Params` message in `proof/params.proto.`
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	// Types that are valid to be assigned to AsType:
-	//
 	//	*MsgUpdateParam_AsString
 	//	*MsgUpdateParam_AsInt64
 	//	*MsgUpdateParam_AsBytes


### PR DESCRIPTION
## Summary

`Tiltfile` was missing `rest` when preparing `localnet_config.yaml`

## Issue

Preparing to send out Alpha TestNet #3 Announcement.

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

**Documentation changes** (only if making doc changes)
- [ ] `make docusaurus_start`; only needed if you make doc changes

**Local Testing** (only if making code changes)
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- See [quickstart guide](https://dev.poktroll.com/developer_guide/quickstart) for instructions

**PR Testing** (only if making code changes)
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.
    - **THIS IS VERY EXPENSIVE**, so only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for local network setup, allowing for future integration of REST services.

- **Refactor**
	- Improved readability and maintainability of the configuration by refactoring the `k8s_yaml` function to use a list format.

- **Bug Fixes**
	- Preserved existing logic for deploying the REST service, ensuring consistent functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->