### PR TITLE
[CI] Add cosmos/gosec

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -49,7 +49,7 @@ jobs:
         run: make go_lint
 
       - name: Run Gosec Security Scanner
-        uses: cosmos/gosec@master
+        uses: okdas/gosec@bump-tools # custom branch with fixes as official repo is quite outdated
         with:
           args: ./...
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Generate mocks
         run: make go_mockgen
 
+      - name: Verify all proto files have stable marshaler configured
+        run: make check_proto_unstable_marshalers
+
       - name: Run golangci-lint
         run: make go_lint
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,5 +48,10 @@ jobs:
       - name: Run golangci-lint
         run: make go_lint
 
+      - name: Run Gosec Security Scanner
+        uses: cosmos/gosec@master
+        with:
+          args: ./...
+
       - name: Test
         run: make test_all


### PR DESCRIPTION
## Summary

Adds https://github.com/cosmos/gosec linter as CI check


## Issue

- #777

## Type of change

Select one or more:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
