### PR TITLE
[Tilt] Enable rest service by default in Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -53,7 +53,7 @@ localnet_config_defaults = {
         "model": "qwen:0.5b",
     },
     "rest": {
-        "enabled": False,
+        "enabled": True,
     },
     # By default, we use the `helm_repo` function below to point to the remote repository
     # but can update it to the locally cloned repo for testing & development


### PR DESCRIPTION
## Summary

Enable the `rest` service by default in Tilt

## Issue

Since the `rest` service is used in E2E tests, it should be enabled by default to avoid non-edited `localnet_config.yaml` files to succeed E2E tests.

![image](https://github.com/user-attachments/assets/88ac37ca-bf9f-4146-83f1-2eafc2f3c829)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
