### PR TITLE
[SDK] Update shannon sdk dependency

### DIFF
--- a/cmd/poktrolld/cmd/config.go
+++ b/cmd/poktrolld/cmd/config.go
@@ -18,6 +18,10 @@ func InitSDKConfig() {
 	})
 }
 
+// checkOrInitSDKConfig updates the prefixes for all account types and seals the config.
+// DEV_NOTE: Due to the separation of this repo and the SDK, where the config is also sealed,
+// we have an added check to return early in case the config has already been set to the expected
+// value.
 func checkOrInitSDKConfig() {
 	config := sdk.GetConfig()
 

--- a/cmd/poktrolld/cmd/config.go
+++ b/cmd/poktrolld/cmd/config.go
@@ -14,11 +14,19 @@ var once sync.Once
 
 func InitSDKConfig() {
 	once.Do(func() {
-		initSDKConfig()
+		checkOrInitSDKConfig()
 	})
 }
 
-func initSDKConfig() {
+func checkOrInitSDKConfig() {
+	config := sdk.GetConfig()
+
+	// Check if the config is already set with the correct prefixes
+	if config.GetBech32AccountAddrPrefix() == app.AccountAddressPrefix {
+		// Config is already initialized, return early
+		return
+	}
+
 	// Set prefixes
 	accountPubKeyPrefix := app.AccountAddressPrefix + "pub"
 	validatorAddressPrefix := app.AccountAddressPrefix + "valoper"
@@ -27,7 +35,6 @@ func initSDKConfig() {
 	consNodePubKeyPrefix := app.AccountAddressPrefix + "valconspub"
 
 	// Set and seal config
-	config := sdk.GetConfig()
 	config.SetBech32PrefixForAccount(app.AccountAddressPrefix, accountPubKeyPrefix)
 	config.SetBech32PrefixForValidator(validatorAddressPrefix, validatorPubKeyPrefix)
 	config.SetBech32PrefixForConsensusNode(consNodeAddressPrefix, consNodePubKeyPrefix)

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	// This is creating a circular dependency whereby exporting the protobufs into a separate
 	// repo is the first obvious idea, but has to be carefully considered, automated, and is not
 	// a hard blocker.
-	github.com/pokt-network/shannon-sdk v0.0.0-20240814144717-dfa95b525d46
+	github.com/pokt-network/shannon-sdk v0.0.0-20240829123247-30d71ae84f4f
 	github.com/pokt-network/smt v0.13.0
 	github.com/pokt-network/smt/kvstore/pebble v0.0.0-20240822175047-21ea8639c188
 	github.com/prometheus/client_golang v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -1001,8 +1001,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pokt-network/ring-go v0.1.0 h1:hF7mDR4VVCIqqDAsrloP8azM9y1mprc99YgnTjKSSwk=
 github.com/pokt-network/ring-go v0.1.0/go.mod h1:8NHPH7H3EwrPX3XHfpyRI6bz4gApkE3+fd0XZRbMWP0=
-github.com/pokt-network/shannon-sdk v0.0.0-20240814144717-dfa95b525d46 h1:rkJa3LGPN+f/k2Vv9t09UWtgbpkMA0NLHRZDiGKPqo4=
-github.com/pokt-network/shannon-sdk v0.0.0-20240814144717-dfa95b525d46/go.mod h1:Jql/lobckajY8BVHDRkQPf6zYraompTK1et78jKVi68=
+github.com/pokt-network/shannon-sdk v0.0.0-20240829123247-30d71ae84f4f h1:rS954qvNS61SVyDqwtJ6Dla4kc7Cjb/hsMpAFFqKJds=
+github.com/pokt-network/shannon-sdk v0.0.0-20240829123247-30d71ae84f4f/go.mod h1:zLQZCtErH+bPOrFZ1PpYgcp+EfS+zMg/6JqG53apaWw=
 github.com/pokt-network/smt v0.13.0 h1:C2F8FlJh34aU+DVeRU/Bt8BOkFXn4QjWMK+nbT9PUj4=
 github.com/pokt-network/smt v0.13.0/go.mod h1:S4Ho4OPkK2v2vUCHNtA49XDjqUC/OFYpBbynRVYmxvA=
 github.com/pokt-network/smt/kvstore/pebble v0.0.0-20240822175047-21ea8639c188 h1:QK1WmFKQ/OzNVob/br55Brh+EFbWhcdq41WGC8UMihM=


### PR DESCRIPTION
## Summary

* Update `ShannonSDK` dependency.
* Fix `InitSDKConfig` already being sealed by `ShannonSDK`

## Issue

![image](https://github.com/user-attachments/assets/6ef7d7e4-af61-4f1d-ad36-1e8e14bef067)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
