### PR TITLE
[Tooling] fix and add makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,6 +394,18 @@ send_relay_sovereign_app_REST: # Send a REST relay through the AppGateServer as 
 cosmovisor_start_node: # Starts the node using cosmovisor that waits for an upgrade plan
 	bash tools/scripts/upgrades/cosmovisor-start-node.sh
 
+.PHONY: query_tx
+query_tx: ## Query for a transaction by hash and output as YAML (default).
+	poktrolld --home=$(POKTROLLD_HOME) query tx $(HASH) --node $(POCKET_NODE)
+
+.PHONY: query_tx_json
+query_tx_json: ## Query for a transaction by hash and output as JSON.
+	poktrolld --home=$(POKTROLLD_HOME) query tx $(HASH) --output json --node $(POCKET_NODE)
+
+.PHONY: query_tx_log
+query_tx_log: ## Query for a transaction and print its raw log.
+	$(MAKE) -s query_tx_json | jq .raw_log
+
 ###############
 ### Linting ###
 ###############

--- a/Makefile
+++ b/Makefile
@@ -740,15 +740,19 @@ supplier_unstake: ## Unstake an supplier (must specify the SUPPLIER env var)
 
 .PHONY: supplier1_unstake
 supplier1_unstake: ## Unstake supplier1
-	SUPPLIER=supplier1 make supplier_unstake
+	SUPPLIER1=$$(make -s poktrolld_addr ACC_NAME=supplier1) && \
+	SUPPLIER=$$SUPPLIER1 make supplier_unstake
 
 .PHONY: supplier2_unstake
 supplier2_unstake: ## Unstake supplier2
-	SUPPLIER=supplier2 make supplier_unstake
+	SUPPLIER2=$$(make -s poktrolld_addr ACC_NAME=supplier2) && \
+	SUPPLIER=$$SUPPLIER2 make supplier_unstake
+
 
 .PHONY: supplier3_unstake
 supplier3_unstake: ## Unstake supplier3
-	SUPPLIER=supplier3 make supplier_unstake
+	SUPPLIER3=$$(make -s poktrolld_addr ACC_NAME=supplier3) && \
+	SUPPLIER=$$SUPPLIER3 make supplier_unstake
 
 ###############
 ### Session ###

--- a/Makefile
+++ b/Makefile
@@ -962,6 +962,22 @@ claim_list_session: ## List all the claims ending at a specific session (specifi
 PARAM_FLAGS = --home=$(POKTROLLD_HOME) --keyring-backend test --from $(PNF_ADDRESS) --node $(POCKET_NODE)
 
 ### Tokenomics Module Params ###
+.PHONY: params_get_tokenomics
+params_get_tokenomics: ## Get the tokenomics module params
+	poktrolld query tokenomics params --node $(POCKET_NODE)
+
+.PHONY: params_get_proof
+params_get_proof: ## Get the proof module params
+	poktrolld query proof params --node $(POCKET_NODE)
+
+.PHONY: params_get_shared
+params_get_shared: ## Get the shared module params
+	poktrolld query shared params --node $(POCKET_NODE)
+
+.PHONY: params_get_service
+params_get_service: ## Get the service module params
+	poktrolld query service params --node $(POCKET_NODE)
+
 .PHONY: update_tokenomics_params_all
 params_update_tokenomics_all: ## Update the tokenomics module params
 	poktrolld tx authz exec ./tools/scripts/params/tokenomics_all.json $(PARAM_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -394,6 +394,9 @@ send_relay_sovereign_app_REST: # Send a REST relay through the AppGateServer as 
 cosmovisor_start_node: # Starts the node using cosmovisor that waits for an upgrade plan
 	bash tools/scripts/upgrades/cosmovisor-start-node.sh
 
+#####################
+### Query Helpers ###
+#####################
 .PHONY: query_tx
 query_tx: ## Query for a transaction by hash and output as YAML (default).
 	poktrolld --home=$(POKTROLLD_HOME) query tx $(HASH) --node $(POCKET_NODE)

--- a/x/shared/types/params.go
+++ b/x/shared/types/params.go
@@ -4,7 +4,6 @@ import (
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
-// TODO_DISCUSS: Should these defaults be updated to match the current config.yml?
 const (
 	DefaultNumBlocksPerSession                = 4
 	ParamNumBlocksPerSession                  = "num_blocks_per_session"

--- a/x/shared/types/params.go
+++ b/x/shared/types/params.go
@@ -4,6 +4,7 @@ import (
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
+// TODO_DISCUSS: Should these defaults be updated to match the current config.yml?
 const (
 	DefaultNumBlocksPerSession                = 4
 	ParamNumBlocksPerSession                  = "num_blocks_per_session"


### PR DESCRIPTION
## Summary

- Adds the following make targets:
  - `query_tx`
  - `query_tx_json`
  - `query_tx_log`
  - `params_get_tokenomics`
  - `params_get_proof`
  - `params_get_shared`
  - `params_get_service`
- Fixes the following make targets:
  - `supplier1_unstake`
  - `supplier2_unstake`
  - `supplier3_unstake`

## Issue

- Observations while working on #799

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
