### PR TITLE
[Container image] Change base image for release

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,13 +1,10 @@
 # This Dockerfile is used to build container image for production workloads.
-# It relies on the binaries produced by `cosmovisor_cross_compile`, `ignite_release` and `ignite_release_extract_binaries` make targets.
-FROM alpine:3.19
+# The image depends on `cosmovisor_cross_compile`, `ignite_release` and `ignite_release_extract_binaries` make targets.
+FROM debian:bookworm
 ARG TARGETARCH
 
 # Use `1025` G/UID so users can switch between this and `heighliner` image without a need to chown the files.
-RUN addgroup --gid 1025 -S pocket && adduser --uid 1025 -S pocket -G pocket
-
-# Install gcompat to provide compatibility with glibc binary on amd64
-RUN apk add --no-cache gcompat
+RUN groupadd -g 1025 pocket && useradd -u 1025 -g pocket -M -s /sbin/nologin pocket
 
 COPY --chown=pocket:pocket release_binaries/poktroll_linux_$TARGETARCH /bin/poktrolld
 COPY --chown=pocket:pocket tmp/cosmovisor-linux-$TARGETARCH /bin/cosmovisor

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -4,7 +4,7 @@ FROM debian:bookworm
 ARG TARGETARCH
 
 # Use `1025` G/UID so users can switch between this and `heighliner` image without a need to chown the files.
-RUN groupadd -g 1025 pocket && useradd -u 1025 -g pocket -M -s /sbin/nologin pocket
+RUN groupadd -g 1025 pocket && useradd -u 1025 -g pocket -m -s /sbin/nologin pocket
 
 COPY --chown=pocket:pocket release_binaries/poktroll_linux_$TARGETARCH /bin/poktrolld
 COPY --chown=pocket:pocket tmp/cosmovisor-linux-$TARGETARCH /bin/cosmovisor


### PR DESCRIPTION
## Summary

Changes the base image from alpine to debian.
Potentially unblocks `heighliner`. 

## Issue

Removes the need for `gcompat` - `glibc` compatibility layer for `musl`.

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

Executed build targets, built image, checked `poktrolld`.

Steps to reproduce:

```
make proto_regen
make cosmovisor_cross_compile
make ignite_release
make ignite_release_extract_binaries
docker build --no-cache --progress=plain --platform linux/amd64,linux/arm64 -t poktrolldebian -f Dockerfile.release .
docker run -it --rm --entrypoint poktrolld poktrolldebian
```


## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
