### PR TITLE
[Tooling] chore: re-organize params.mk targets

### DIFF
--- a/makefiles/params.mk
+++ b/makefiles/params.mk
@@ -10,18 +10,6 @@ PARAM_FLAGS = --home=$(POKTROLLD_HOME) --keyring-backend test --from $(PNF_ADDRE
 params_get_tokenomics: ## Get the tokenomics module params
 	poktrolld query tokenomics params --node $(POCKET_NODE)
 
-.PHONY: params_get_proof
-params_get_proof: ## Get the proof module params
-	poktrolld query proof params --node $(POCKET_NODE)
-
-.PHONY: params_get_shared
-params_get_shared: ## Get the shared module params
-	poktrolld query shared params --node $(POCKET_NODE)
-
-.PHONY: params_get_service
-params_get_service: ## Get the service module params
-	poktrolld query service params --node $(POCKET_NODE)
-
 .PHONY: update_tokenomics_params_all
 params_update_tokenomics_all: ## Update the tokenomics module params
 	poktrolld tx authz exec ./tools/scripts/params/tokenomics_all.json $(PARAM_FLAGS)
@@ -30,7 +18,24 @@ params_update_tokenomics_all: ## Update the tokenomics module params
 params_update_tokenomics_compute_units_to_tokens_multiplier: ## Update the tokenomics module compute_units_to_tokens_multiplier param
 	poktrolld tx authz exec ./tools/scripts/params/tokenomics_compute_units_to_tokens_multiplier.json $(PARAM_FLAGS)
 
+### Service Module Params ###
+.PHONY: params_get_service
+params_get_service: ## Get the service module params
+	poktrolld query service params --node $(POCKET_NODE)
+
+.PHONY: params_update_service_all
+params_update_service_all: ## Update the service module params
+	poktrolld tx authz exec ./tools/scripts/params/service_all.json $(PARAM_FLAGS)
+
+.PHONY: params_update_service_add_service_fee
+params_update_service_add_service_fee: ## Update the service module add_service_fee param
+	poktrolld tx authz exec ./tools/scripts/params/service_add_service_fee.json $(PARAM_FLAGS)
+
 ### Proof Module Params ###
+.PHONY: params_get_proof
+params_get_proof: ## Get the proof module params
+	poktrolld query proof params --node $(POCKET_NODE)
+
 .PHONY: params_update_proof_all
 params_update_proof_all: ## Update the proof module params
 	poktrolld tx authz exec ./tools/scripts/params/proof_all.json $(PARAM_FLAGS)
@@ -56,6 +61,10 @@ params_update_proof_proof_submission_fee: ## Update the proof module proof_submi
 	poktrolld tx authz exec ./tools/scripts/params/proof_proof_submission_fee.json $(PARAM_FLAGS)
 
 ### Shared Module Params ###
+.PHONY: params_get_shared
+params_get_shared: ## Get the shared module params
+	poktrolld query shared params --node $(POCKET_NODE)
+
 .PHONY: params_update_shared_all
 params_update_shared_all: ## Update the session module params
 	poktrolld tx authz exec ./tools/scripts/params/shared_all.json $(PARAM_FLAGS)
@@ -84,9 +93,9 @@ params_update_shared_proof_window_open_offset_blocks: ## Update the shared modul
 params_update_shared_proof_window_close_offset_blocks: ## Update the shared module proof_window_close_offset_blocks param
 	poktrolld tx authz exec ./tools/scripts/params/shared_proof_window_close_offset_blocks.json $(PARAM_FLAGS)
 
-.PHONY: params_update_service_add_service_fee
-params_update_service_add_service_fee: ## Update the service module add_service_fee param
-	poktrolld tx authz exec ./tools/scripts/params/service_add_service_fee.json $(PARAM_FLAGS)
+.PHONY: params_update_shared_compute_units_to_tokens_multiplier
+params_update_shared_compute_units_to_tokens_multiplier: ## Update the shared module compute_units_to_tokens_multiplier param
+	poktrolld tx authz exec ./tools/scripts/params/shared_compute_units_to_tokens_multiplier.json $(PARAM_FLAGS)
 
 
 .PHONY: params_query_all

--- a/tools/scripts/params/shared_compute_units_to_tokens_multiplier.json
+++ b/tools/scripts/params/shared_compute_units_to_tokens_multiplier.json
@@ -1,0 +1,12 @@
+{
+  "body": {
+    "messages": [
+      {
+        "@type": "/poktroll.shared.MsgUpdateParam",
+        "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+        "name": "compute_units_to_tokens_multiplier",
+        "as_int64": "42"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Groups the param related make targets in params.mk by module and fills in gaps.

## Issue

- N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
