### PR TITLE
[Tokenomics] Prevent GMR to produce zero values

### DIFF
--- a/x/tokenomics/keeper/token_logic_modules.go
+++ b/x/tokenomics/keeper/token_logic_modules.go
@@ -635,6 +635,11 @@ func calculateGlobalPerClaimMintInflationFromSettlementAmount(settlementCoin sdk
 	// TODO_MAINNET: Consider using fixed point arithmetic for deterministic results.
 	settlementAmtFloat := new(big.Float).SetUint64(settlementCoin.Amount.Uint64())
 	newMintAmtFloat := new(big.Float).Mul(settlementAmtFloat, big.NewFloat(MintPerClaimedTokenGlobalInflation))
+	// DEV_NOTE: If new mint is less than 1 and more than 0, ceil it to 1 so that
+	// we never expect to process a claim with 0 minted tokens.
+	if newMintAmtFloat.Cmp(big.NewFloat(1)) < 0 && newMintAmtFloat.Cmp(big.NewFloat(0)) > 0 {
+		newMintAmtFloat = big.NewFloat(1)
+	}
 	newMintAmtInt, _ := newMintAmtFloat.Int64()
 	mintAmtCoin := cosmostypes.NewCoin(volatile.DenomuPOKT, math.NewInt(newMintAmtInt))
 	return mintAmtCoin, *newMintAmtFloat


### PR DESCRIPTION
## Summary

This PR handles the case where non zero claimed rewards produce zero GMR rewards when the claimed rewards are too low.

## Issue

When claimed rewards are too low, they might produce a global mint reward that is non-zero but less that 1. Since the TLM does not exepect a zero value, this might lead to a chain halt like below.

```
ERR error processing token logic modules for claim "af85b9dd2d49f1d5b133347eac2b65e7cd7a1a555fea742adba778f711207c6b": TLM "TLMGlobalMint": mint amount cannot be zero: failed to process TLM [/go/pkg/mod/cosmossdk.io/errors@v1.0.1/errors.go:155] module=server num_claim_compute_units=2 num_relays_in_session_tree=2 proof_requirement=NOT_REQUIRED session_id=af85b9dd2d49f1d5b133347eac2b65e7cd7a1a555fea742adba778f711207c6b supplier_operator_address=pokt1ytsx06dfxrp7cgt7t95jkxuyu2m97563zqz5pn
ERR could not settle pending claims due to error TLM "TLMGlobalMint": mint amount cannot be zero: failed to process TLM [/go/pkg/mod/cosmossdk.io/errors@v1.0.1/errors.go:155] method=EndBlocker module=x/tokenomics
```

https://gist.github.com/okdas/013df312354ca0e7877a41290d94fad2

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
