### PR TITLE
[Docs] Docker-compose guide: also cleanup cosmovisor history

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -3,6 +3,12 @@
 FROM debian:bookworm
 ARG TARGETARCH
 
+# Install necessary packages.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+
 # Use `1025` G/UID so users can switch between this and `heighliner` image without a need to chown the files.
 RUN groupadd -g 1025 pocket && useradd -u 1025 -g pocket -m -s /sbin/nologin pocket
 

--- a/docusaurus/docs/operate/quickstart/docker_compose_debian_cheatsheet.md
+++ b/docusaurus/docs/operate/quickstart/docker_compose_debian_cheatsheet.md
@@ -264,7 +264,7 @@ docker compose down
 docker rm $(docker ps -aq) -f
 
 # Remove existing data
-rm -rf poktrolld-data/config/addrbook.json poktrolld-data/config/genesis.json poktrolld-data/config/genesis.seeds poktrolld-data/data/ poktrolld-data/config/node_key.json poktrolld-data/config/priv_validator_key.json
+rm -rf poktrolld-data/config/addrbook.json poktrolld-data/config/genesis.json poktrolld-data/config/genesis.seeds poktrolld-data/data/ poktrolld-data/cosmovisor/ poktrolld-data/config/node_key.json poktrolld-data/config/priv_validator_key.json
 ```
 
 Update `POKTROLLD_IMAGE_TAG` in `.env` based on the releases [here](https://github.com/pokt-network/poktroll/releases).

--- a/docusaurus/docs/operate/quickstart/docker_compose_walkthrough.md
+++ b/docusaurus/docs/operate/quickstart/docker_compose_walkthrough.md
@@ -245,7 +245,7 @@ docker-compose down
 docker rm $(docker ps -aq) -f
 
 # Remove existing data and renew genesis
-rm -rf poktrolld-data/config/addrbook.json poktrolld-data/config/genesis.json poktrolld-data/config/genesis.seeds poktrolld-data/data/ poktrolld-data/config/node_key.json poktrolld-data/config/priv_validator_key.json
+rm -rf poktrolld-data/config/addrbook.json poktrolld-data/config/genesis.json poktrolld-data/config/genesis.seeds poktrolld-data/data/ poktrolld-data/cosmovisor/ poktrolld-data/config/node_key.json poktrolld-data/config/priv_validator_key.json
 
 # Re-start the node
 docker-compose up -d


### PR DESCRIPTION
## Summary

Now that we also have cosmovisor on docker-compose set-up, we need to delete different poktroll versions it downloads - in case of re-genesis. We also need to supply ca-certificates on our images.

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
