### PR TITLE
[Code Health] refactor: simplify `testevents.FilterEvents()`

### DIFF
--- a/tests/integration/service/relay_mining_difficulty_test.go
+++ b/tests/integration/service/relay_mining_difficulty_test.go
@@ -108,8 +108,7 @@ func TestUpdateRelayMiningDifficulty_NewServiceSeenForTheFirstTime(t *testing.T)
 
 	// Check that the expected events are emitted
 	events := sdkCtx.EventManager().Events()
-	relayMiningEvents := testutilevents.FilterEvents[*servicetypes.EventRelayMiningDifficultyUpdated](t,
-		events, "poktroll.service.EventRelayMiningDifficultyUpdated")
+	relayMiningEvents := testutilevents.FilterEvents[*servicetypes.EventRelayMiningDifficultyUpdated](t, events)
 	require.Len(t, relayMiningEvents, 1, "unexpected number of relay mining difficulty updated events")
 	relayMiningEvent := relayMiningEvents[0]
 	require.Equal(t, "svc1", relayMiningEvent.ServiceId)

--- a/testutil/events/filter.go
+++ b/testutil/events/filter.go
@@ -15,12 +15,12 @@ import (
 func FilterEvents[T proto.Message](
 	t *testing.T,
 	allEvents cosmostypes.Events,
-	protoType string,
 ) (parsedEvents []T) {
 	t.Helper()
 
+	messageTypeURL := proto.MessageName(*new(T))
 	for _, event := range allEvents.ToABCIEvents() {
-		if event.Type != strings.Trim(protoType, "/") {
+		if event.Type != strings.Trim(messageTypeURL, "/") {
 			continue
 		}
 		QuoteEventMode(&event)

--- a/x/application/keeper/msg_server_transfer_application_test.go
+++ b/x/application/keeper/msg_server_transfer_application_test.go
@@ -3,7 +3,6 @@ package keeper_test
 import (
 	"testing"
 
-	"github.com/cosmos/cosmos-sdk/codec/types"
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
@@ -74,8 +73,7 @@ func TestMsgServer_TransferApplication_Success(t *testing.T) {
 
 	// Assert that the transfer end event was emitted.
 	events := cosmostypes.UnwrapSDKContext(ctx).EventManager().Events()
-	transferBeginEventTypeURL := types.MsgTypeURL(&apptypes.EventTransferBegin{})
-	transferBeginEvents := events2.FilterEvents[*apptypes.EventTransferBegin](t, events, transferBeginEventTypeURL)
+	transferBeginEvents := events2.FilterEvents[*apptypes.EventTransferBegin](t, events)
 	require.Equal(t, 1, len(transferBeginEvents), "expected 1 transfer begin event")
 	require.Equal(t, srcBech32, transferBeginEvents[0].GetSourceAddress())
 	require.Equal(t, dstBech32, transferBeginEvents[0].GetDestinationAddress())
@@ -117,8 +115,7 @@ func TestMsgServer_TransferApplication_Success(t *testing.T) {
 
 	// Assert that the transfer end event was emitted.
 	events = cosmostypes.UnwrapSDKContext(ctx).EventManager().Events()
-	transferEndEventTypeURL := types.MsgTypeURL(&apptypes.EventTransferEnd{})
-	transferEndEvents := events2.FilterEvents[*apptypes.EventTransferEnd](t, events, transferEndEventTypeURL)
+	transferEndEvents := events2.FilterEvents[*apptypes.EventTransferEnd](t, events)
 	require.Equal(t, 1, len(transferEndEvents), "expected 1 transfer end event")
 	require.Equal(t, srcBech32, transferEndEvents[0].GetSourceAddress())
 	require.Equal(t, dstBech32, transferEndEvents[0].GetDestinationAddress())

--- a/x/application/keeper/msg_server_transfer_application_test.go
+++ b/x/application/keeper/msg_server_transfer_application_test.go
@@ -6,7 +6,7 @@ import (
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 
-	events2 "github.com/pokt-network/poktroll/testutil/events"
+	testutilevents "github.com/pokt-network/poktroll/testutil/events"
 	keepertest "github.com/pokt-network/poktroll/testutil/keeper"
 	"github.com/pokt-network/poktroll/testutil/sample"
 	appkeeper "github.com/pokt-network/poktroll/x/application/keeper"
@@ -73,7 +73,7 @@ func TestMsgServer_TransferApplication_Success(t *testing.T) {
 
 	// Assert that the transfer end event was emitted.
 	events := cosmostypes.UnwrapSDKContext(ctx).EventManager().Events()
-	transferBeginEvents := events2.FilterEvents[*apptypes.EventTransferBegin](t, events)
+	transferBeginEvents := testutilevents.FilterEvents[*apptypes.EventTransferBegin](t, events)
 	require.Equal(t, 1, len(transferBeginEvents), "expected 1 transfer begin event")
 	require.Equal(t, srcBech32, transferBeginEvents[0].GetSourceAddress())
 	require.Equal(t, dstBech32, transferBeginEvents[0].GetDestinationAddress())
@@ -115,7 +115,7 @@ func TestMsgServer_TransferApplication_Success(t *testing.T) {
 
 	// Assert that the transfer end event was emitted.
 	events = cosmostypes.UnwrapSDKContext(ctx).EventManager().Events()
-	transferEndEvents := events2.FilterEvents[*apptypes.EventTransferEnd](t, events)
+	transferEndEvents := testutilevents.FilterEvents[*apptypes.EventTransferEnd](t, events)
 	require.Equal(t, 1, len(transferEndEvents), "expected 1 transfer end event")
 	require.Equal(t, srcBech32, transferEndEvents[0].GetSourceAddress())
 	require.Equal(t, dstBech32, transferEndEvents[0].GetDestinationAddress())

--- a/x/proof/keeper/msg_server_create_claim_test.go
+++ b/x/proof/keeper/msg_server_create_claim_test.go
@@ -170,7 +170,7 @@ func TestMsgServer_CreateClaim_Success(t *testing.T) {
 
 			events := sdkCtx.EventManager().Events()
 
-			claimCreatedEvents := testutilevents.FilterEvents[*prooftypes.EventClaimCreated](t, events, "poktroll.proof.EventClaimCreated")
+			claimCreatedEvents := testutilevents.FilterEvents[*prooftypes.EventClaimCreated](t, events)
 			require.Len(t, claimCreatedEvents, 1)
 
 			require.EqualValues(t, &claim, claimCreatedEvents[0].GetClaim())
@@ -301,7 +301,7 @@ func TestMsgServer_CreateClaim_Error_OutsideOfWindow(t *testing.T) {
 
 			// Assert that no events were emitted.
 			events := sdkCtx.EventManager().Events()
-			claimCreatedEvents := testutilevents.FilterEvents[*prooftypes.EventClaimCreated](t, events, "poktroll.proof.EventClaimCreated")
+			claimCreatedEvents := testutilevents.FilterEvents[*prooftypes.EventClaimCreated](t, events)
 			require.Len(t, claimCreatedEvents, 0)
 		})
 	}
@@ -514,7 +514,7 @@ func TestMsgServer_CreateClaim_Error(t *testing.T) {
 			// Assert that no events were emitted.
 			sdkCtx := cosmostypes.UnwrapSDKContext(ctx)
 			events := sdkCtx.EventManager().Events()
-			claimCreatedEvents := testutilevents.FilterEvents[*prooftypes.EventClaimCreated](t, events, "poktroll.proof.EventClaimCreated")
+			claimCreatedEvents := testutilevents.FilterEvents[*prooftypes.EventClaimCreated](t, events)
 			require.Len(t, claimCreatedEvents, 0)
 		})
 	}
@@ -625,7 +625,7 @@ func TestMsgServer_CreateClaim_Error_ComputeUnitsMismatch(t *testing.T) {
 	// Assert that no events were emitted.
 	sdkCtx = cosmostypes.UnwrapSDKContext(ctx)
 	events := sdkCtx.EventManager().Events()
-	claimCreatedEvents := testutilevents.FilterEvents[*prooftypes.EventClaimCreated](t, events, "poktroll.proof.EventClaimCreated")
+	claimCreatedEvents := testutilevents.FilterEvents[*prooftypes.EventClaimCreated](t, events)
 	require.Len(t, claimCreatedEvents, 0)
 }
 

--- a/x/proof/keeper/msg_server_submit_proof_test.go
+++ b/x/proof/keeper/msg_server_submit_proof_test.go
@@ -226,10 +226,10 @@ func TestMsgServer_SubmitProof_Success(t *testing.T) {
 
 			events := sdkCtx.EventManager().Events()
 
-			claimCreatedEvents := testutilevents.FilterEvents[*prooftypes.EventClaimCreated](t, events, "poktroll.proof.EventClaimCreated")
+			claimCreatedEvents := testutilevents.FilterEvents[*prooftypes.EventClaimCreated](t, events)
 			require.Len(t, claimCreatedEvents, 1)
 
-			proofSubmittedEvents := testutilevents.FilterEvents[*prooftypes.EventProofSubmitted](t, events, "poktroll.proof.EventProofSubmitted")
+			proofSubmittedEvents := testutilevents.FilterEvents[*prooftypes.EventProofSubmitted](t, events)
 			require.Len(t, proofSubmittedEvents, 1)
 
 			proofSubmittedEvent := proofSubmittedEvents[0]
@@ -410,10 +410,10 @@ func TestMsgServer_SubmitProof_Error_OutsideOfWindow(t *testing.T) {
 			// Assert that only the create claim event was emitted.
 			events := sdkCtx.EventManager().Events()
 
-			claimCreatedEvents := testutilevents.FilterEvents[*prooftypes.EventClaimCreated](t, events, "poktroll.proof.EventClaimCreated")
+			claimCreatedEvents := testutilevents.FilterEvents[*prooftypes.EventClaimCreated](t, events)
 			require.Len(t, claimCreatedEvents, 1)
 
-			proofSubmittedEvents := testutilevents.FilterEvents[*prooftypes.EventProofSubmitted](t, events, "poktroll.proof.EventProofSubmitted")
+			proofSubmittedEvents := testutilevents.FilterEvents[*prooftypes.EventProofSubmitted](t, events)
 			require.Len(t, proofSubmittedEvents, 0)
 		})
 	}
@@ -683,7 +683,7 @@ func TestMsgServer_SubmitProof_Error(t *testing.T) {
 
 			// Assert that no proof submitted events were emitted.
 			events := sdkCtx.EventManager().Events()
-			proofSubmittedEvents := testutilevents.FilterEvents[*prooftypes.EventProofSubmitted](t, events, "poktroll.proof.EventProofSubmitted")
+			proofSubmittedEvents := testutilevents.FilterEvents[*prooftypes.EventProofSubmitted](t, events)
 			require.Equal(t, 0, len(proofSubmittedEvents))
 		})
 	}

--- a/x/service/keeper/update_relay_mining_difficulty_test.go
+++ b/x/service/keeper/update_relay_mining_difficulty_test.go
@@ -160,8 +160,7 @@ func TestUpdateRelayMiningDifficulty_Base(t *testing.T) {
 
 	// Confirm a relay mining difficulty update event was emitted
 	events := sdkCtx.EventManager().Events()
-	expectedEvents := testutilevents.FilterEvents[*servicetypes.EventRelayMiningDifficultyUpdated](t,
-		events, "poktroll.service.EventRelayMiningDifficultyUpdated")
+	expectedEvents := testutilevents.FilterEvents[*servicetypes.EventRelayMiningDifficultyUpdated](t, events)
 	require.Len(t, expectedEvents, 6) // 3 for svc1, 2 for svc2, 1 for svc3
 }
 

--- a/x/tokenomics/keeper/keeper_settle_pending_claims_test.go
+++ b/x/tokenomics/keeper/keeper_settle_pending_claims_test.go
@@ -309,7 +309,7 @@ func (s *TestSuite) TestSettlePendingClaims_ClaimExpired_ProofRequiredAndNotProv
 	require.Len(t, events, 10) // asserting on the length of events so the developer must consciously update it upon changes
 
 	// Confirm an expiration event was emitted
-	expectedClaimExpiredEvents := testutilevents.FilterEvents[*tokenomicstypes.EventClaimExpired](t, events, "poktroll.tokenomics.EventClaimExpired")
+	expectedClaimExpiredEvents := testutilevents.FilterEvents[*tokenomicstypes.EventClaimExpired](t, events)
 	require.Len(t, expectedClaimExpiredEvents, 1)
 
 	// Validate the claim expired event
@@ -321,7 +321,7 @@ func (s *TestSuite) TestSettlePendingClaims_ClaimExpired_ProofRequiredAndNotProv
 	require.Equal(t, s.claimedUpokt, *expectedClaimExpiredEvent.GetClaimedUpokt())
 
 	// Confirm that a slashing event was emitted
-	expectedSlashingEvents := testutilevents.FilterEvents[*tokenomicstypes.EventSupplierSlashed](t, events, "poktroll.tokenomics.EventSupplierSlashed")
+	expectedSlashingEvents := testutilevents.FilterEvents[*tokenomicstypes.EventSupplierSlashed](t, events)
 	require.Len(t, expectedSlashingEvents, 1)
 
 	// Validate the slashing event
@@ -375,7 +375,7 @@ func (s *TestSuite) TestSettlePendingClaims_ClaimSettled_ProofRequiredAndProvide
 
 	// Confirm an settlement event was emitted
 	events := sdkCtx.EventManager().Events()
-	expectedEvents := testutilevents.FilterEvents[*tokenomicstypes.EventClaimSettled](t, events, "poktroll.tokenomics.EventClaimSettled")
+	expectedEvents := testutilevents.FilterEvents[*tokenomicstypes.EventClaimSettled](t, events)
 	require.Len(t, expectedEvents, 1)
 
 	// Validate the event
@@ -442,7 +442,7 @@ func (s *TestSuite) TestSettlePendingClaims_ClaimExpired_ProofRequired_InvalidOn
 	// Confirm an expiration event was emitted
 	events := sdkCtx.EventManager().Events()
 	require.Len(t, events, 10) // minting, burning, settling, etc..
-	expectedClaimExpiredEvents := testutilevents.FilterEvents[*tokenomicstypes.EventClaimExpired](t, events, "poktroll.tokenomics.EventClaimExpired")
+	expectedClaimExpiredEvents := testutilevents.FilterEvents[*tokenomicstypes.EventClaimExpired](t, events)
 	require.Len(t, expectedClaimExpiredEvents, 1)
 
 	// Validate the event
@@ -454,7 +454,7 @@ func (s *TestSuite) TestSettlePendingClaims_ClaimExpired_ProofRequired_InvalidOn
 	require.Equal(t, s.claimedUpokt, *expectedClaimExpiredEvent.GetClaimedUpokt())
 
 	// Confirm that a slashing event was emitted
-	expectedSlashingEvents := testutilevents.FilterEvents[*tokenomicstypes.EventSupplierSlashed](t, events, "poktroll.tokenomics.EventSupplierSlashed")
+	expectedSlashingEvents := testutilevents.FilterEvents[*tokenomicstypes.EventSupplierSlashed](t, events)
 	require.Len(t, expectedSlashingEvents, 1)
 
 	// Validate the slashing event
@@ -508,7 +508,7 @@ func (s *TestSuite) TestClaimSettlement_ClaimSettled_ProofRequiredAndProvided_Vi
 
 	// Confirm an settlement event was emitted
 	events := sdkCtx.EventManager().Events()
-	expectedEvents := testutilevents.FilterEvents[*tokenomicstypes.EventClaimSettled](t, events, "poktroll.tokenomics.EventClaimSettled")
+	expectedEvents := testutilevents.FilterEvents[*tokenomicstypes.EventClaimSettled](t, events)
 	require.Len(t, expectedEvents, 1)
 
 	// Validate the settlement event
@@ -563,7 +563,7 @@ func (s *TestSuite) TestSettlePendingClaims_Settles_WhenAProofIsNotRequired() {
 
 	// Confirm a settlement event was emitted
 	events := sdkCtx.EventManager().Events()
-	expectedEvents := testutilevents.FilterEvents[*tokenomicstypes.EventClaimSettled](t, events, "poktroll.tokenomics.EventClaimSettled")
+	expectedEvents := testutilevents.FilterEvents[*tokenomicstypes.EventClaimSettled](t, events)
 	require.Len(t, expectedEvents, 1)
 
 	// Validate the settlement event
@@ -726,7 +726,7 @@ func (s *TestSuite) TestSettlePendingClaims_ClaimExpired_SupplierUnstaked() {
 	events := sdkCtx.EventManager().Events()
 
 	// Confirm that a slashing event was emitted
-	expectedSlashingEvents := testutilevents.FilterEvents[*tokenomicstypes.EventSupplierSlashed](t, events, "poktroll.tokenomics.EventSupplierSlashed")
+	expectedSlashingEvents := testutilevents.FilterEvents[*tokenomicstypes.EventSupplierSlashed](t, events)
 	require.Len(t, expectedSlashingEvents, 1)
 
 	// Validate the slashing event

--- a/x/tokenomics/keeper/token_logic_modules_test.go
+++ b/x/tokenomics/keeper/token_logic_modules_test.go
@@ -300,8 +300,7 @@ func TestProcessTokenLogicModules_TLMBurnEqualsMint_Invalid_SupplierExceedsMaxCl
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	events := sdkCtx.EventManager().Events()
-	appOverservicedEvents := testutilevents.FilterEvents[*tokenomicstypes.EventApplicationOverserviced](t,
-		events, "poktroll.tokenomics.EventApplicationOverserviced")
+	appOverservicedEvents := testutilevents.FilterEvents[*tokenomicstypes.EventApplicationOverserviced](t, events)
 	require.Len(t, appOverservicedEvents, 1, "unexpected number of event overserviced events")
 	appOverservicedEvent := appOverservicedEvents[0]
 


### PR DESCRIPTION
## Summary

Remove unnecessary message type URL argument from `testutilevents.FilterEvents()`.

## Issue

N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
