### PR TITLE
[CI] Add consensus breaking warning

### DIFF
--- a/.github/workflows/consensuswarn.yml
+++ b/.github/workflows/consensuswarn.yml
@@ -1,0 +1,21 @@
+name: "Consensus Warn"
+
+permissions: read-all
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    permissions:
+      pull-requests: write # For reading the PR and posting comment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: orijtech/consensuswarn@main
+        with:
+          roots: "github.com/cosmos/cosmos-sdk/baseapp.BaseApp.DeliverTx,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.BeginBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.EndBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.Commit"

--- a/.github/workflows/consensuswarn.yml
+++ b/.github/workflows/consensuswarn.yml
@@ -36,14 +36,6 @@ jobs:
           #   Commits the application state after the block has been processed.
           #   Any changes here could impact state transitions and consensus.
           #
-          # BeginBlock:
-          #   Executes logic at the start of a new block.
-          #   Changes here can influence the block initialization and its validity.
-          #
-          # EndBlock:
-          #   Executes logic at the end of the block before committing.
-          #   Can be crucial for final state updates that ensure consensus.
-          #
           # VerifyVoteExtension:
           #   Verifies extended votes in the consensus process (Tendermint).
           #   Any changes could directly impact vote verification in consensus.
@@ -72,4 +64,4 @@ jobs:
           # SimTxFinalizeBlock:
           #   Simulates a finalized block for testing and debugging purposes.
           #   Less critical, but could be monitored for changes that may affect testing and simulation behavior.
-          roots: github.com/cosmos/cosmos-sdk/baseapp.BaseApp.PrepareProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ProcessProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.FinalizeBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.Commit,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.BeginBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.EndBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.VerifyVoteExtension,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ExtendVote,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.CheckTx,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.InitChain,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.StoreConsensusParams,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.SimDeliver,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.SimTxFinalizeBlock
+          roots: github.com/cosmos/cosmos-sdk/baseapp.BaseApp.PrepareProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ProcessProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.FinalizeBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.Commit,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.VerifyVoteExtension,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ExtendVote,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.CheckTx,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.InitChain,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.StoreConsensusParams,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.SimDeliver,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.SimTxFinalizeBlock

--- a/.github/workflows/consensuswarn.yml
+++ b/.github/workflows/consensuswarn.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: orijtech/consensuswarn@main
         with:
-          # Available BaseApp roots: `go doc github.com/cosmos/cosmos-sdk/baseapp.BaseApp`
+          # Available BaseApp roots: `go doc github.com/pokt-network/poktroll/app.App`
           #
           # TODO_CONSIDER: CURRENTLY MAY BE TOO VERBOSE. Consider removing functions that cause excessive noise or false positives.
           #
@@ -64,4 +64,4 @@ jobs:
           # SimTxFinalizeBlock:
           #   Simulates a finalized block for testing and debugging purposes.
           #   Less critical, but could be monitored for changes that may affect testing and simulation behavior.
-          roots: github.com/cosmos/cosmos-sdk/baseapp.BaseApp.PrepareProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ProcessProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.FinalizeBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.Commit,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.VerifyVoteExtension,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ExtendVote,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.CheckTx,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.InitChain,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.StoreConsensusParams,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.SimDeliver,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.SimTxFinalizeBlock
+          roots: github.com/pokt-network/poktroll/app.App.PrepareProposal,github.com/pokt-network/poktroll/app.App.ProcessProposal,github.com/pokt-network/poktroll/app.App.FinalizeBlock,github.com/pokt-network/poktroll/app.App.Commit,github.com/pokt-network/poktroll/app.App.VerifyVoteExtension,github.com/pokt-network/poktroll/app.App.ExtendVote,github.com/pokt-network/poktroll/app.App.CheckTx,github.com/pokt-network/poktroll/app.App.InitChain,github.com/pokt-network/poktroll/app.App.StoreConsensusParams,github.com/pokt-network/poktroll/app.App.SimDeliver,github.com/pokt-network/poktroll/app.App.SimTxFinalizeBlock

--- a/.github/workflows/consensuswarn.yml
+++ b/.github/workflows/consensuswarn.yml
@@ -14,4 +14,62 @@ jobs:
       - uses: actions/checkout@v4
       - uses: orijtech/consensuswarn@main
         with:
-          roots: "github.com/cosmos/cosmos-sdk/baseapp.BaseApp.PrepareProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ProcessProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.FinalizeBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.BeginBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.EndBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.Commit,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.VerifyVoteExtension"
+          # Available BaseApp roots: `go doc github.com/cosmos/cosmos-sdk/baseapp.BaseApp`
+          #
+          # TODO_CONSIDER: CURRENTLY MAY BE TOO VERBOSE. Consider removing functions that cause excessive noise or false positives.
+          #
+          # Critical consensus-related functions to monitor:
+          #
+          # PrepareProposal:
+          #   Prepares a block proposal by selecting transactions to include in the block.
+          #   A change here could affect what transactions are included in a block.
+          #
+          # ProcessProposal:
+          #   Validates block proposals against consensus rules.
+          #   Changes in this function could lead to consensus validation issues.
+          #
+          # FinalizeBlock:
+          #   Finalizes the block by applying the transactions.
+          #   This function is critical in ensuring that the block reaches consensus.
+          #
+          # Commit:
+          #   Commits the application state after the block has been processed.
+          #   Any changes here could impact state transitions and consensus.
+          #
+          # BeginBlock:
+          #   Executes logic at the start of a new block.
+          #   Changes here can influence the block initialization and its validity.
+          #
+          # EndBlock:
+          #   Executes logic at the end of the block before committing.
+          #   Can be crucial for final state updates that ensure consensus.
+          #
+          # VerifyVoteExtension:
+          #   Verifies extended votes in the consensus process (Tendermint).
+          #   Any changes could directly impact vote verification in consensus.
+          #
+          # ExtendVote:
+          #   Adds vote extensions in the consensus process (Tendermint).
+          #   Modifies how votes are extended, critical in consensus mechanics.
+          #
+          # Less-critical but related functions to monitor:
+          #
+          # CheckTx:
+          #   Validates transactions in the mempool. While not part of the core consensus,
+          #   changes here can affect what gets included in blocks, which indirectly impacts consensus.
+          #
+          # InitChain:
+          #   Called during chain initialization. Important for network upgrades or starting a new chain.
+          #
+          # StoreConsensusParams:
+          #   Stores consensus parameters in the chain state.
+          #   Changes here could affect how consensus parameters are handled or updated.
+          #
+          # SimDeliver:
+          #   Simulates transaction delivery for gas estimation and simulation. Not directly involved in consensus,
+          #   but changes here could affect how transactions are simulated and processed before being included in a block.
+          #
+          # SimTxFinalizeBlock:
+          #   Simulates a finalized block for testing and debugging purposes.
+          #   Less critical, but could be monitored for changes that may affect testing and simulation behavior.
+          roots: github.com/cosmos/cosmos-sdk/baseapp.BaseApp.PrepareProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ProcessProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.FinalizeBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.Commit,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.BeginBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.EndBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.VerifyVoteExtension,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ExtendVote,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.CheckTx,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.InitChain,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.StoreConsensusParams,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.SimDeliver,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.SimTxFinalizeBlock

--- a/.github/workflows/consensuswarn.yml
+++ b/.github/workflows/consensuswarn.yml
@@ -3,11 +3,7 @@ name: "Consensus Warn"
 permissions: read-all
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
+  pull_request:
 
 jobs:
   main:
@@ -18,4 +14,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: orijtech/consensuswarn@main
         with:
-          roots: "github.com/cosmos/cosmos-sdk/baseapp.BaseApp.DeliverTx,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.BeginBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.EndBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.Commit"
+          roots: "github.com/cosmos/cosmos-sdk/baseapp.BaseApp.PrepareProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ProcessProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.FinalizeBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.BeginBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.EndBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.Commit,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.VerifyVoteExtension"

--- a/.github/workflows/consensuswarn.yml
+++ b/.github/workflows/consensuswarn.yml
@@ -14,8 +14,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: orijtech/consensuswarn@main
         with:
-          # Available BaseApp roots: `go doc github.com/cosmos/cosmos-sdk/baseapp.BaseApp`
+          # Available BaseApp roots:
+          # - `go doc github.com/cosmos/cosmos-sdk/baseapp.BaseApp`
+          # - `go doc github.com/cosmos/cosmos-sdk/runtime.App`
           #
+          # TODO_IN_THIS_PR: test. Does this even work with an app that uses `depinject`?
           # TODO_CONSIDER: CURRENTLY MAY BE TOO VERBOSE. Consider removing functions that cause excessive noise or false positives.
           #
           # Critical consensus-related functions to monitor:
@@ -35,6 +38,14 @@ jobs:
           # Commit:
           #   Commits the application state after the block has been processed.
           #   Any changes here could impact state transitions and consensus.
+          #
+          # BeginBlock:
+          #   Executes logic at the start of a new block.
+          #   Changes here can influence the block initialization and its validity.
+          #
+          # EndBlock:
+          #   Executes logic at the end of the block before committing.
+          #   Can be crucial for final state updates that ensure consensus.
           #
           # VerifyVoteExtension:
           #   Verifies extended votes in the consensus process (Tendermint).
@@ -64,5 +75,4 @@ jobs:
           # SimTxFinalizeBlock:
           #   Simulates a finalized block for testing and debugging purposes.
           #   Less critical, but could be monitored for changes that may affect testing and simulation behavior.
-          roots: github.com/cosmos/cosmos-sdk/runtime.App.BeginBlocker,github.com/cosmos/cosmos-sdk/runtime.App.EndBlocker,github.com/cosmos/cosmos-sdk/runtime.App.PreBlocker,github.com/cosmos/cosmos-sdk/runtime.App.Precommiter
-          # roots: github.com/cosmos/cosmos-sdk/baseapp.BaseApp.PrepareProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ProcessProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.FinalizeBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.Commit,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.VerifyVoteExtension,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ExtendVote,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.CheckTx,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.InitChain,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.StoreConsensusParams,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.SimDeliver,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.SimTxFinalizeBlock
+          roots: github.com/cosmos/cosmos-sdk/baseapp.BaseApp.PrepareProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ProcessProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.FinalizeBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.Commit,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.VerifyVoteExtension,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ExtendVote,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.CheckTx,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.InitChain,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.StoreConsensusParams,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.SimDeliver,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.SimTxFinalizeBlock,github.com/cosmos/cosmos-sdk/runtime.App.BeginBlocker,github.com/cosmos/cosmos-sdk/runtime.App.EndBlocker,github.com/cosmos/cosmos-sdk/runtime.App.PreBlocker,github.com/cosmos/cosmos-sdk/runtime.App.Precommiter

--- a/.github/workflows/consensuswarn.yml
+++ b/.github/workflows/consensuswarn.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: orijtech/consensuswarn@main
         with:
-          # Available BaseApp roots: `go doc github.com/pokt-network/poktroll/app.App`
+          # Available BaseApp roots: `go doc github.com/cosmos/cosmos-sdk/baseapp.BaseApp`
           #
           # TODO_CONSIDER: CURRENTLY MAY BE TOO VERBOSE. Consider removing functions that cause excessive noise or false positives.
           #
@@ -64,4 +64,5 @@ jobs:
           # SimTxFinalizeBlock:
           #   Simulates a finalized block for testing and debugging purposes.
           #   Less critical, but could be monitored for changes that may affect testing and simulation behavior.
-          roots: github.com/pokt-network/poktroll/app.App.PrepareProposal,github.com/pokt-network/poktroll/app.App.ProcessProposal,github.com/pokt-network/poktroll/app.App.FinalizeBlock,github.com/pokt-network/poktroll/app.App.Commit,github.com/pokt-network/poktroll/app.App.VerifyVoteExtension,github.com/pokt-network/poktroll/app.App.ExtendVote,github.com/pokt-network/poktroll/app.App.CheckTx,github.com/pokt-network/poktroll/app.App.InitChain,github.com/pokt-network/poktroll/app.App.StoreConsensusParams,github.com/pokt-network/poktroll/app.App.SimDeliver,github.com/pokt-network/poktroll/app.App.SimTxFinalizeBlock
+          roots: github.com/cosmos/cosmos-sdk/runtime.App.BeginBlocker,github.com/cosmos/cosmos-sdk/runtime.App.EndBlocker,github.com/cosmos/cosmos-sdk/runtime.App.PreBlocker,github.com/cosmos/cosmos-sdk/runtime.App.Precommiter
+          # roots: github.com/cosmos/cosmos-sdk/baseapp.BaseApp.PrepareProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ProcessProposal,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.FinalizeBlock,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.Commit,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.VerifyVoteExtension,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.ExtendVote,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.CheckTx,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.InitChain,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.StoreConsensusParams,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.SimDeliver,github.com/cosmos/cosmos-sdk/baseapp.BaseApp.SimTxFinalizeBlock

--- a/x/tokenomics/keeper/token_logic_modules.go
+++ b/x/tokenomics/keeper/token_logic_modules.go
@@ -138,6 +138,10 @@ func (k Keeper) ProcessTokenLogicModules(
 	claimSettlementCoin := cosmostypes.NewCoin("upokt", math.NewInt(0))
 	isSuccessful := false
 
+	if 2 > 1 {
+		fmt.Println("can this trigger consensuswarn?")
+	}
+
 	// This is emitted only when the function returns (successful or not)
 	defer telemetry.EventSuccessCounter(
 		"process_token_logic_modules",

--- a/x/tokenomics/keeper/token_logic_modules.go
+++ b/x/tokenomics/keeper/token_logic_modules.go
@@ -661,11 +661,12 @@ func calculateGlobalPerClaimMintInflationFromSettlementAmount(settlementCoin sdk
 	// TODO_MAINNET: Consider using fixed point arithmetic for deterministic results.
 	settlementAmtFloat := new(big.Float).SetUint64(settlementCoin.Amount.Uint64())
 	newMintAmtFloat := new(big.Float).Mul(settlementAmtFloat, big.NewFloat(MintPerClaimedTokenGlobalInflation))
-	// DEV_NOTE: If new mint is less than 1 and more than 0, ceil it to 1 so that
-	// we never expect to process a claim with 0 minted tokens.
-	if newMintAmtFloat.Cmp(big.NewFloat(1)) < 0 && newMintAmtFloat.Cmp(big.NewFloat(0)) > 0 {
-		newMintAmtFloat = big.NewFloat(1)
-	}
+	// See if this triggers consensuswarn
+	// // DEV_NOTE: If new mint is less than 1 and more than 0, ceil it to 1 so that
+	// // we never expect to process a claim with 0 minted tokens.
+	// if newMintAmtFloat.Cmp(big.NewFloat(1)) < 0 && newMintAmtFloat.Cmp(big.NewFloat(0)) > 0 {
+	// 	newMintAmtFloat = big.NewFloat(1)
+	// }
 	newMintAmtInt, _ := newMintAmtFloat.Int64()
 	mintAmtCoin := cosmostypes.NewCoin(volatile.DenomuPOKT, math.NewInt(newMintAmtInt))
 	return mintAmtCoin, *newMintAmtFloat


### PR DESCRIPTION
## Summary

Notify when there's a consensus-breaking change.

## Issue

-  #791 (though doesn't add label yet)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
