### PR TITLE
[C&P] Fix Unbonding slashed suppliers

### DIFF
--- a/api/poktroll/application/event.pulsar.go
+++ b/api/poktroll/application/event.pulsar.go
@@ -3,11 +3,11 @@ package application
 
 import (
 	_ "cosmossdk.io/api/cosmos/base/v1beta1"
+	_ "github.com/pokt-network/poktroll/api/poktroll/shared"
 	fmt "fmt"
 	_ "github.com/cosmos/cosmos-proto"
 	runtime "github.com/cosmos/cosmos-proto/runtime"
 	_ "github.com/cosmos/gogoproto/gogoproto"
-	_ "github.com/pokt-network/poktroll/api/poktroll/shared"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoiface "google.golang.org/protobuf/runtime/protoiface"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"

--- a/pkg/relayer/session/sessiontree.go
+++ b/pkg/relayer/session/sessiontree.go
@@ -273,8 +273,10 @@ func (st *sessionTree) Delete() error {
 	// This was intentionally removed to lower the IO load.
 	// When the database is closed, it is deleted it from disk right away.
 
-	if err := st.treeStore.Stop(); err != nil {
-		return err
+	if st.treeStore != nil {
+		if err := st.treeStore.Stop(); err != nil {
+			return err
+		}
 	}
 
 	// Delete the KVStore from disk

--- a/x/proof/keeper/msg_server_submit_proof.go
+++ b/x/proof/keeper/msg_server_submit_proof.go
@@ -318,5 +318,5 @@ func (k Keeper) getEarliestSupplierProofCommitBlockHash(
 		supplierOperatorAddress,
 	)
 
-	return k.sessionKeeper.GetBlockHash(ctx, earliestSupplierProofCommitHeight), nil
+	return k.sessionKeeper.GetBlockHash(ctx, earliestSupplierProofCommitHeight-1), nil
 }

--- a/x/tokenomics/types/tx.pb.go
+++ b/x/tokenomics/types/tx.pb.go
@@ -125,7 +125,6 @@ type MsgUpdateParam struct {
 	// specified in the `Params` message in `proof/params.proto.`
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	// Types that are valid to be assigned to AsType:
-	//
 	//	*MsgUpdateParam_AsString
 	//	*MsgUpdateParam_AsInt64
 	//	*MsgUpdateParam_AsBytes


### PR DESCRIPTION
## Summary

This PR fixes a few bugs that were dependent to each other:
1. Gracefully unbond suppliers that have 0upokt due to off-stake slashing.
2. Fix access to an expired session tree on the realy miner
3. Fix proof block hash seed used on chain.

@okdas , One case I didn't manage to reproduce is having the application module account go to `0`. Please tell me if you encounter it again.

## Issue

- #841 

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
