### PR TITLE
[Code Health] Harden settlement (part 2: (non-)halting settlement error alignment)

### DIFF
--- a/tests/integration/application/min_stake_test.go
+++ b/tests/integration/application/min_stake_test.go
@@ -51,7 +51,7 @@ func TestApplicationMinStakeTestSuite(t *testing.T) {
 }
 
 func (s *applicationMinStakeTestSuite) SetupTest() {
-	s.keepers, s.ctx = keeper.NewTokenomicsModuleKeepers(s.T(), cosmoslog.NewNopLogger(), keeper.WithProofRequirement(false))
+	s.keepers, s.ctx = keeper.NewTokenomicsModuleKeepers(s.T(), cosmoslog.NewNopLogger(), keeper.WithProofRequirement(prooftypes.ProofRequirementReason_NOT_REQUIRED))
 
 	proofParams := prooftypes.DefaultParams()
 	proofParams.ProofRequestProbability = 0

--- a/tests/integration/tokenomics/relay_mining_integration_test.go
+++ b/tests/integration/tokenomics/relay_mining_integration_test.go
@@ -83,7 +83,7 @@ func TestComputeNewDifficultyHash_RewardsReflectWorkCompleted(t *testing.T) {
 		testutils.WithService(service),
 		testutils.WithApplication(application),
 		testutils.WithSupplier(supplier),
-		testutils.WithProofRequirement(false),
+		testutils.WithProofRequirement(prooftypes.ProofRequirementReason_NOT_REQUIRED),
 	)
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	sdkCtx = sdkCtx.WithBlockHeight(1)

--- a/tests/integration/tokenomics/token_logic_modules/tlm_suite_test.go
+++ b/tests/integration/tokenomics/token_logic_modules/tlm_suite_test.go
@@ -5,15 +5,26 @@ import (
 	"math"
 	"testing"
 
+	"cosmossdk.io/depinject"
+	cosmoslog "cosmossdk.io/log"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/pokt-network/poktroll/app/volatile"
 	"github.com/pokt-network/poktroll/cmd/poktrolld/cmd"
+	"github.com/pokt-network/poktroll/pkg/crypto"
+	"github.com/pokt-network/poktroll/pkg/crypto/protocol"
+	"github.com/pokt-network/poktroll/pkg/crypto/rings"
+	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
 	testkeeper "github.com/pokt-network/poktroll/testutil/keeper"
 	"github.com/pokt-network/poktroll/testutil/proof"
 	"github.com/pokt-network/poktroll/testutil/sample"
+	"github.com/pokt-network/poktroll/testutil/testkeyring"
+	"github.com/pokt-network/poktroll/testutil/testtree"
 	apptypes "github.com/pokt-network/poktroll/x/application/types"
 	prooftypes "github.com/pokt-network/poktroll/x/proof/types"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
@@ -22,11 +33,6 @@ import (
 	tlm "github.com/pokt-network/poktroll/x/tokenomics/token_logic_module"
 	tokenomicstypes "github.com/pokt-network/poktroll/x/tokenomics/types"
 )
-
-// daoRewardAddr is a random address intended for use in tests.
-// In the commutativity test, the dao_reward_address is set to this
-// address and MUST remain unchanged between permutations.
-var daoRewardAddr = sample.AccAddress()
 
 type tokenLogicModuleTestSuite struct {
 	suite.Suite
@@ -39,8 +45,19 @@ type tokenLogicModuleTestSuite struct {
 	supplier *sharedtypes.Supplier
 
 	proposerConsAddr cosmostypes.ConsAddress
-	sourceOwnerBech32,
+	sourceOwnerAddr,
 	daoRewardAddr string
+
+	daoRewardAcct,
+	proposerAcct,
+	supplierAcct,
+	appAcct *testkeyring.PreGeneratedAccount
+
+	merkleProofPathSeed []byte
+	supplierOperatorUid string
+	keyRing             keyring.Keyring
+	preGeneratedAccts   *testkeyring.PreGeneratedAccountIterator
+	ringClient          crypto.RingClient
 
 	expectedSettledResults,
 	expectedExpiredResults tlm.SettlementResults
@@ -64,43 +81,95 @@ func init() {
 	cmd.InitSDKConfig()
 }
 
-func TestTLMProcessorTestSuite(t *testing.T) {
+func TestTokenLogicModuleTestSuite(t *testing.T) {
 	suite.Run(t, new(tokenLogicModuleTestSuite))
 }
 
 // SetupTest generates and sets all rewardee addresses on the suite, and
 // set a service, application, and supplier on the suite.
 func (s *tokenLogicModuleTestSuite) SetupTest() {
-	s.daoRewardAddr = daoRewardAddr
-	s.sourceOwnerBech32 = sample.AccAddress()
-	s.proposerConsAddr = sample.ConsAddress()
+	s.supplierOperatorUid = "supplier-operator"
+	s.merkleProofPathSeed = []byte("mock-merkle-proof-path-seed-block-hash")
+}
 
+// setupKeepers initializes a new instance of TokenomicsModuleKeepers and context
+// with the given options, and creates the suite's service, application, and supplier
+// from SetupTest(). It also sets the block height to 1 and the proposer address to
+// the proposer address from SetupTest().
+func (s *tokenLogicModuleTestSuite) setupKeepers(t *testing.T, opts ...testkeeper.TokenomicsModuleKeepersOptFn) {
+	t.Helper()
+
+	registry := codectypes.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(registry)
+
+	s.keyRing = keyring.NewInMemory(cdc)
+	s.preGeneratedAccts = testkeyring.PreGeneratedAccounts()
+
+	s.sourceOwnerAddr = s.preGeneratedAccts.MustNext().Address.String()
 	s.service = &sharedtypes.Service{
 		Id:                   "svc1",
 		ComputeUnitsPerRelay: 1,
-		OwnerAddress:         s.sourceOwnerBech32,
+		OwnerAddress:         s.sourceOwnerAddr,
 	}
 
-	appStake := cosmostypes.NewInt64Coin(volatile.DenomuPOKT, math.MaxInt64)
-	s.app = &apptypes.Application{
-		Address: sample.AccAddress(),
-		Stake:   &appStake,
-		ServiceConfigs: []*sharedtypes.ApplicationServiceConfig{
-			{ServiceId: s.service.GetId()},
-		},
-	}
+	s.setupActors(t)
+	s.setupKeyRing(t)
 
-	supplierBech32 := sample.AccAddress()
+	s.keepers, s.ctx = testkeeper.NewTokenomicsModuleKeepers(
+		t, cosmoslog.NewTestLogger(t),
+		append([]testkeeper.TokenomicsModuleKeepersOptFn{
+			testkeeper.WithRegistry(registry),
+			testkeeper.WithProposerAddr(s.proposerConsAddr.String()),
+			testkeeper.WithService(*s.service),
+			testkeeper.WithSupplier(*s.supplier),
+			testkeeper.WithApplication(*s.app),
+		}, opts...)...,
+	)
+
+	tokenomicsParams := tokenomicstypes.DefaultParams()
+	tokenomicsParams.DaoRewardAddress = s.daoRewardAddr
+	err := s.keepers.Keeper.SetParams(s.ctx, tokenomicsParams)
+	require.NoError(t, err)
+
+	// Increment the block height to 1; valid session height.
+	s.setBlockHeight(1)
+
+	// On-chain accounts MUST be created after keeper construction.
+	s.setupOnChainAccounts(t)
+
+	ringClientDeps := depinject.Supply(
+		polyzero.NewLogger(polyzero.WithLevel(polyzero.DebugLevel)),
+		prooftypes.NewAppKeeperQueryClient(s.keepers),
+		prooftypes.NewAccountKeeperQueryClient(s.keepers),
+		prooftypes.NewSharedKeeperQueryClient(s.keepers.SharedKeeper, s.keepers),
+	)
+	s.ringClient, err = rings.NewRingClient(ringClientDeps)
+	require.NoError(s.T(), err)
+}
+
+// TODO_IH_THIS_COMMIT: move & godoc...
+func (s *tokenLogicModuleTestSuite) setupActors(t *testing.T) {
+	t.Helper()
+
+	// TODO_IN_THIS_COMMIT: comment... must be 1st account...
+	s.daoRewardAcct = s.preGeneratedAccts.MustNext()
+	s.daoRewardAddr = s.daoRewardAcct.Address.String()
+
+	s.proposerAcct = s.preGeneratedAccts.MustNext()
+	s.proposerConsAddr = sample.ConsAddrFromAccBech32(s.proposerAcct.Address.String())
+
+	s.supplierAcct = s.preGeneratedAccts.MustNext()
+	supplierAddr := s.supplierAcct.Address.String()
 	s.supplier = &sharedtypes.Supplier{
-		OwnerAddress:    supplierBech32,
-		OperatorAddress: supplierBech32,
+		OwnerAddress:    supplierAddr,
+		OperatorAddress: supplierAddr,
 		Stake:           &suppliertypes.DefaultMinStake,
 		Services: []*sharedtypes.SupplierServiceConfig{
 			{
 				ServiceId: s.service.GetId(),
 				RevShare: []*sharedtypes.ServiceRevenueShare{
 					{
-						Address:            supplierBech32,
+						Address:            supplierAddr,
 						RevSharePercentage: 100,
 					},
 				},
@@ -110,6 +179,57 @@ func (s *tokenLogicModuleTestSuite) SetupTest() {
 			s.service.GetId(): 0,
 		},
 	}
+
+	s.appAcct = s.preGeneratedAccts.MustNext()
+	s.app = &apptypes.Application{
+		Address: s.appAcct.Address.String(),
+		Stake:   &apptypes.DefaultMinStake,
+		ServiceConfigs: []*sharedtypes.ApplicationServiceConfig{
+			{ServiceId: s.service.GetId()},
+		},
+	}
+}
+
+// TODO_IH_THIS_COMMIT: move & godoc...
+func (s *tokenLogicModuleTestSuite) setupKeyRing(t *testing.T) {
+	t.Helper()
+
+	// Add the dao reward account to the keyring.
+	err := s.daoRewardAcct.AddToKeyring(s.keyRing, "dao-reward")
+	require.NoError(s.T(), err)
+
+	// Add the proposer account to the keyring.
+	err = s.proposerAcct.AddToKeyring(s.keyRing, "proposer")
+	require.NoError(s.T(), err)
+
+	// Add the supplier account to the keyring.
+	err = s.supplierAcct.AddToKeyring(s.keyRing, s.supplierOperatorUid)
+	require.NoError(s.T(), err)
+
+	// Add the application account to the keyring.
+	err = s.appAcct.AddToKeyring(s.keyRing, "app")
+	require.NoError(s.T(), err)
+}
+
+// TODO_IH_THIS_COMMIT: move & godoc...
+func (s *tokenLogicModuleTestSuite) setupOnChainAccounts(t *testing.T) {
+	t.Helper()
+
+	// Create an on-chain dao reward account.
+	err := s.daoRewardAcct.AddToAccountKeeper(s.ctx, s.keepers)
+	require.NoError(t, err)
+
+	// Create an on-chain proposer account.
+	err = s.proposerAcct.AddToAccountKeeper(s.ctx, s.keepers)
+	require.NoError(t, err)
+
+	// Create an on-chain supplier account.
+	err = s.supplierAcct.AddToAccountKeeper(s.ctx, s.keepers)
+	require.NoError(t, err)
+
+	// Create an on-chain application account.
+	err = s.appAcct.AddToAccountKeeper(s.ctx, s.keepers)
+	require.NoError(t, err)
 }
 
 // getProofParams returns the default proof params with a high proof requirement threshold
@@ -140,39 +260,23 @@ func (s *tokenLogicModuleTestSuite) getTokenomicsParams() *tokenomicstypes.Param
 // the suites service, application, and supplier.
 // DEV_NOTE: The sum/count must be large enough to avoid a proposer reward
 // (or other small proportion rewards) from being truncated to zero (> 1upokt).
-func (s *tokenLogicModuleTestSuite) createClaims(
-	keepers *testkeeper.TokenomicsModuleKeepers,
-	numClaims int,
-) {
+func (s *tokenLogicModuleTestSuite) createClaims(numClaims int) {
 	s.T().Helper()
 
-	session, err := s.keepers.GetSession(s.ctx, &sessiontypes.QueryGetSessionRequest{
-		ServiceId:          s.service.GetId(),
-		ApplicationAddress: s.app.GetAddress(),
-		BlockHeight:        1,
-	})
+	session, err := s.getSession()
 	require.NoError(s.T(), err)
 
 	// Create claims (no proof requirements)
 	for i := 0; i < numClaims; i++ {
-		claim := prooftypes.Claim{
-			SupplierOperatorAddress: s.supplier.GetOperatorAddress(),
-			SessionHeader:           session.GetSession().GetHeader(),
-			RootHash:                proof.SmstRootWithSumAndCount(1000, 1000),
-		}
-
-		keepers.ProofKeeper.UpsertClaim(s.ctx, claim)
+		claim := s.newClaim(session)
+		s.keepers.UpsertClaim(s.ctx, *claim)
 	}
 }
 
 // settleClaims sets the block height to the settlement height for the current
 // session and triggers the settlement of all pending claims.
 func (s *tokenLogicModuleTestSuite) settleClaims(t *testing.T) (settledResults, expiredResults tlm.SettlementResults) {
-	// Increment the block height to the settlement height.
-	settlementHeight := sharedtypes.GetSettlementSessionEndHeight(s.getSharedParams(), 1)
-	s.setBlockHeight(settlementHeight)
-
-	settledPendingResults, expiredPendingResults, err := s.keepers.SettlePendingClaims(cosmostypes.UnwrapSDKContext(s.ctx))
+	settledPendingResults, expiredPendingResults, err := s.trySettleClaims()
 	require.NoError(t, err)
 
 	require.NotZero(t, len(settledPendingResults))
@@ -180,6 +284,15 @@ func (s *tokenLogicModuleTestSuite) settleClaims(t *testing.T) (settledResults, 
 	require.Zero(t, len(expiredPendingResults))
 
 	return settledPendingResults, expiredPendingResults
+}
+
+// TODO_IN_THIS_COMMIT: move & godoc...
+func (s *tokenLogicModuleTestSuite) trySettleClaims() (settledResults, expiredResults tlm.SettlementResults, err error) {
+	// Increment the block height to the settlement height.
+	settlementHeight := sharedtypes.GetSettlementSessionEndHeight(s.getSharedParams(), 1)
+	s.setBlockHeight(settlementHeight)
+
+	return s.keepers.SettlePendingClaims(cosmostypes.UnwrapSDKContext(s.ctx))
 }
 
 // setBlockHeight sets the block height of the suite's context to height.
@@ -190,7 +303,100 @@ func (s *tokenLogicModuleTestSuite) setBlockHeight(height int64) {
 // assertNoPendingClaims asserts that no pending claims exist.
 func (s *tokenLogicModuleTestSuite) assertNoPendingClaims(t *testing.T) {
 	sdkCtx := cosmostypes.UnwrapSDKContext(s.ctx)
-	pendingClaims, err := s.keepers.Keeper.GetExpiringClaims(sdkCtx)
+	pendingClaims, err := s.keepers.GetExpiringClaims(sdkCtx)
 	require.NoError(t, err)
 	require.Zero(t, len(pendingClaims))
+}
+
+// TODO_IN_THIS_COMMIT: godoc...
+func (s *tokenLogicModuleTestSuite) getSession() (*sessiontypes.Session, error) {
+	sessionRes, err := s.keepers.GetSession(s.ctx, &sessiontypes.QueryGetSessionRequest{
+		ServiceId:          s.service.GetId(),
+		ApplicationAddress: s.app.GetAddress(),
+		BlockHeight:        1,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return sessionRes.GetSession(), nil
+}
+
+// TODO_IN_THIS_COMMIT: godoc... AND inline; is this used anywhere else?
+func (s *tokenLogicModuleTestSuite) newClaim(session *sessiontypes.Session) *prooftypes.Claim {
+	return &prooftypes.Claim{
+		SupplierOperatorAddress: s.supplier.GetOperatorAddress(),
+		SessionHeader:           session.GetHeader(),
+		RootHash:                proof.SmstRootWithSumAndCount(1000, 1000),
+	}
+}
+
+// TODO_IN_THIS_COMMIT: move & godoc...
+func (s *tokenLogicModuleTestSuite) newProof(t *testing.T, claim *prooftypes.Claim) *prooftypes.Proof {
+	sessionHeader := claim.GetSessionHeader()
+	numRelays := uint64(5)
+	sessionTree := testtree.NewFilledSessionTree(
+		s.ctx, t,
+		numRelays, s.service.ComputeUnitsPerRelay,
+		s.supplierOperatorUid, claim.GetSupplierOperatorAddress(),
+		sessionHeader, sessionHeader, sessionHeader,
+		s.keyRing,
+		s.ringClient,
+	)
+
+	merkleRootBz, err := sessionTree.Flush()
+	require.NoError(t, err)
+
+	// Override the claim root hash with a valid one which corresponds to the unmangled proof.
+	claim.RootHash = merkleRootBz
+
+	merkleProofPath := protocol.GetPathForProof(
+		s.merkleProofPathSeed,
+		sessionTree.GetSessionHeader().GetSessionId(),
+	)
+
+	// Construct a proof message with a session tree containing
+	// a valid relay but of insufficient difficulty.
+	return testtree.NewProof(t,
+		claim.GetSupplierOperatorAddress(),
+		sessionHeader,
+		sessionTree,
+		merkleProofPath,
+	)
+}
+
+// settleClaims sets the block height to the settlement height for the current
+// session and triggers the settlement of all pending claims.
+func (s *tokenLogicModuleTestSuite) settleClaims(t *testing.T) (settledResults, expiredResults tlm.PendingSettlementResults) {
+	settledPendingResults, expiredPendingResults, err := s.trySettleClaims()
+	require.NoError(t, err)
+
+	require.NotZero(t, len(settledPendingResults))
+	// TODO_IMPROVE: enhance the test scenario to include expiring claims to increase coverage.
+	require.Zero(t, len(expiredPendingResults))
+
+	return settledPendingResults, expiredPendingResults
+}
+
+// TODO_IN_THIS_COMMIT: godoc...
+func (s *tokenLogicModuleTestSuite) trySettleClaims() (settledResults, expiredResults tlm.PendingSettlementResults, err error) {
+	// Increment the block height to the settlement height.
+	settlementHeight := sharedtypes.GetSettlementSessionEndHeight(s.getSharedParams(), 1)
+	s.setBlockHeight(settlementHeight)
+
+	return s.keepers.SettlePendingClaims(cosmostypes.UnwrapSDKContext(s.ctx))
+}
+
+// TODO_IN_THIS_COMMIT: godoc...
+func (s *tokenLogicModuleTestSuite) getBlockHeight() int64 {
+	return cosmostypes.UnwrapSDKContext(s.ctx).BlockHeight()
+}
+
+// setBlockHeight sets the block height of the suite's context to height.
+func (s *tokenLogicModuleTestSuite) setBlockHeight(height int64) {
+	s.ctx = cosmostypes.UnwrapSDKContext(s.ctx).
+		WithBlockHeight(height).
+		WithHeaderHash(s.merkleProofPathSeed).
+		WithProposer(s.proposerConsAddr)
+	s.keepers.StoreBlockHash(s.ctx)
 }

--- a/tests/integration/tokenomics/token_logic_modules/unhaltable_test.go
+++ b/tests/integration/tokenomics/token_logic_modules/unhaltable_test.go
@@ -2,67 +2,383 @@ package token_logic_modules
 
 import (
 	"testing"
+
+	errorsmod "cosmossdk.io/errors"
+	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/pokt-network/smt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/poktroll/app/volatile"
+	"github.com/pokt-network/poktroll/pkg/crypto/protocol"
+	"github.com/pokt-network/poktroll/testutil/keeper"
+	"github.com/pokt-network/poktroll/testutil/testkeyring"
+	"github.com/pokt-network/poktroll/testutil/testtree"
+	apptypes "github.com/pokt-network/poktroll/x/application/types"
+	prooftypes "github.com/pokt-network/poktroll/x/proof/types"
+	servicekeeper "github.com/pokt-network/poktroll/x/service/keeper"
+	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+	suppliertypes "github.com/pokt-network/poktroll/x/supplier/types"
+	tlm "github.com/pokt-network/poktroll/x/tokenomics/token_logic_module"
+	tokenomicstypes "github.com/pokt-network/poktroll/x/tokenomics/types"
 )
 
-// TODO_TEST(@bryanchriswhite): Settlement proceeds in the face of errors
+// TODO_IN_THIS_COMMIT: add test coverage for ring client errors?
 
-// TestSettlePendingClaims_HaltingError asserts that the chain halts when claim
-// settlement results in an unexpected error.
-func (s *tokenLogicModuleTestSuite) TestSettlePendingClaims_HaltingError() {
+// TODO_TEST(@bryanchriswhite): Settlement proceeds in the face of errors
+// - Does not block settling of other claims in the same session
+// - Does not block setting subsequent sessions
+
+func (s *tlmProcessorTestSuite) TestSettlePendingClaims_HaltingError() {
+	moduleBalanceuPOKTAmount := int64(1000000000)
+	moduleBalanceCoins := cosmostypes.NewCoins(cosmostypes.NewInt64Coin(volatile.DenomuPOKT, moduleBalanceuPOKTAmount))
+	moduleAccountBalanceCfgs := []keeper.ModuleBalanceConfig{
+		{ModuleName: suppliertypes.ModuleName, Coins: moduleBalanceCoins},
+		{ModuleName: apptypes.ModuleName, Coins: moduleBalanceCoins},
+	}
+
+	// TODO_IN_THIS_COMMIT: comment... expected to be set after claim creation...
+	settlementCoin := new(cosmostypes.Coin)
+
 	tests := []struct {
 		desc             string
 		asyncStateChange func(*testing.T)
 		getExpectedErr   func() error
 	}{
-		{desc: "the application is unbonded prematurely"},
-		{desc: "the supplier is unbonded prematurely"},
-		{desc: "the service is removed prematurely"},
-		{desc: "compute units per relay is updated mid-session"},
-		{desc: "supplier service config is invalid (missing RevShares)"},
-		{desc: "supplier service config is invalid (invalid RevShare address)"},
-		{desc: "application module has insufficient funds"},
-		{desc: "tokenomics module has insufficient funds"},
-		{desc: "supplier module has insufficient funds"},
+		{
+			desc: "the application is unbonded prematurely",
+			asyncStateChange: func(t *testing.T) {
+				err := s.keepers.UnbondApplication(s.ctx, s.app)
+				require.NoError(t, err)
+			},
+			getExpectedErr: func() error {
+				return apptypes.ErrAppNotFound.Wrapf(
+					"trying to settle a claim for an application that does not exist (which should never happen) with address: %q",
+					s.app.GetAddress(),
+				)
+			},
+		},
+		{
+			desc: "the supplier is unbonded prematurely",
+			asyncStateChange: func(t *testing.T) {
+				err := s.keepers.UnbondSupplier(s.ctx, s.supplier)
+				require.NoError(t, err)
+			},
+			getExpectedErr: func() error {
+				return sessiontypes.ErrSessionSuppliersNotFound.Wrapf(
+					"could not find suppliers for service %s at height %d",
+					s.service.GetId(), 1,
+				)
+			},
+		},
+		{
+			desc: "the service is removed prematurely",
+			asyncStateChange: func(t *testing.T) {
+				s.keepers.RemoveService(s.ctx, s.service.GetId())
+			},
+			getExpectedErr: func() error {
+				return prooftypes.ErrProofServiceNotFound.Wrapf(
+					"service with ID %q not found",
+					s.service.GetId(),
+				)
+			},
+		},
+		{
+			desc: "compute units per relay is updated mid-session",
+			asyncStateChange: func(t *testing.T) {
+				s.service.ComputeUnitsPerRelay = 999
+				s.keepers.SetService(s.ctx, *s.service)
+			},
+			getExpectedErr: func() error {
+				return tokenomicstypes.ErrTokenomicsRootHashInvalid.Wrapf(
+					"mismatch: claim compute units (%d) != number of relays (%d) * service compute units per relay (%d)",
+					// TODO_IN_THIS_COMMIT: extract 5 (numRelays) from #newClaim()...
+					// TODO_IN_THIS_COMMIT: compute 5 (compute units) from numRelays * original service CUPR...
+					5, 5, s.service.ComputeUnitsPerRelay,
+				)
+			},
+		},
+		{
+			desc: "supplier service config is invalid (missing RevShares)",
+			asyncStateChange: func(t *testing.T) {
+				for idx, serviceConfig := range s.supplier.Services {
+					serviceConfig.RevShare = nil
+					s.supplier.Services[idx] = serviceConfig
+				}
+				s.keepers.SetSupplier(s.ctx, *s.supplier)
+			},
+			getExpectedErr: func() error {
+				return tokenomicstypes.ErrTokenomicsTLMError.Wrapf(
+					"TLM %q: %v",
+					tlm.TLMRelayBurnEqualsMint,
+					tokenomicstypes.ErrTokenomicsModuleMint.Wrapf(
+						"queuing operation: distributing rewards to supplier with operator address %s shareholders: %v",
+						s.supplier.GetOperatorAddress(),
+						tokenomicstypes.ErrTokenomicsSupplierRevShareFailed.Wrapf(
+							"service %q not found for supplier %v",
+							s.service.GetId(),
+							s.supplier,
+						),
+					),
+				)
+			},
+		},
+		{
+			desc: "supplier service config is invalid (invalid RevShare address)",
+			asyncStateChange: func(t *testing.T) {
+				for _, serviceConfig := range s.supplier.Services {
+					revShare := serviceConfig.RevShare[0]
+					revShare.Address = "invalid-bech32-address"
+					serviceConfig.RevShare[0] = revShare
+				}
+				s.keepers.SetSupplier(s.ctx, *s.supplier)
+			},
+			getExpectedErr: func() error {
+				return tokenomicstypes.ErrTokenomicsTLMError.Wrapf(
+					"TLM %q: %v",
+					tlm.TLMRelayBurnEqualsMint,
+					tokenomicstypes.ErrTokenomicsModuleMint.Wrapf(
+						"queuing operation: distributing rewards to supplier with operator address %s shareholders: %v",
+						s.supplier.GetOperatorAddress(),
+						"decoding bech32 failed: invalid separator index -1",
+					),
+				)
+			},
+		},
+		{
+			desc: "application module has insufficient funds",
+			asyncStateChange: func(t *testing.T) {
+				err := s.keepers.BurnCoins(s.ctx, apptypes.ModuleName, moduleBalanceCoins)
+				require.NoError(t, err)
+			},
+			getExpectedErr: func() error {
+				err := errorsmod.Wrapf(
+					sdkerrors.ErrInsufficientFunds,
+					"spendable balance %s is smaller than %s",
+					// TODO_IN_THIS_COMMIT: fix "smaller than XXX".
+					zerouPOKT, settlementCoin,
+				)
+
+				return tokenomicstypes.ErrTokenomicsModuleBurn.Wrapf(
+					"destination module %q burning %s: %s", apptypes.ModuleName, settlementCoin, err,
+				)
+			},
+		},
+		//{
+		//	desc:        "tokenomics module has insufficient funds",
+		//	getExpectedErr: fmt.Errorf("%s", "XXX"),
+		//},
+		//{
+		//	desc:        "supplier module has insufficient funds",
+		//	getExpectedErr: fmt.Errorf("%s", "XXX"),
+		//},
+	}
+
+	// TODO_IN_THIS_COMMIT: comment...
+	daoRewardAcct, ok := testkeyring.PreGeneratedAccountAtIndex(1)
+	require.True(s.T(), ok)
+
+	opts := []keeper.TokenomicsModuleKeepersOptFn{
+		keeper.WithDaoRewardBech32(daoRewardAcct.Address.String()),
+		keeper.WithProofRequirement(prooftypes.ProofRequirementReason_THRESHOLD),
+		keeper.WithModuleBalances(moduleAccountBalanceCfgs),
 	}
 
 	for _, test := range tests {
 		s.T().Run(test.desc, func(t *testing.T) {
-			// TODO_TEST:
-			// set up keepers
-			// assert 0 claims exist
-			// get the session
-			// store the proof path seed
-			// create claim(s)
-			// create proof(s)
-			// simulate asynchronous state modifications
-			// attempt claim settlement
-			// assert the error is the expected one
+			// Reset the test for each scenario.
+			s.setupKeepers(t, opts...)
+
+			// Assert that no pre-existing claims are present.
+			numExistingClaims := len(s.keepers.GetAllClaims(s.ctx))
+			require.Equal(t, 0, numExistingClaims)
+
+			// Create a claim and proof.
+			session, err := s.getSession()
+			require.NoError(t, err)
+
+			// TODO_IN_THIS_COMMIT: extract to a method...
+			earliestSupplierProofsCommitHeight := sharedtypes.GetEarliestSupplierProofCommitHeight(
+				&sharedParams,
+				session.GetHeader().GetSessionEndBlockHeight(),
+				s.merkleProofPathSeed,
+				s.supplierAcct.Address.String(),
+			)
+			proofPathSeedBlockHashHeight := earliestSupplierProofsCommitHeight - 1
+			s.setBlockHeight(proofPathSeedBlockHashHeight)
+			// ---
+
+			claim := s.newClaim(session)
+			proof := s.newProof(t, claim)
+			s.keepers.UpsertClaim(s.ctx, *claim)
+			s.keepers.UpsertProof(s.ctx, *proof)
+
+			relayMiningDifficulty := servicekeeper.NewDefaultRelayMiningDifficulty(s.ctx,
+				s.keepers.Logger(),
+				claim.GetSessionHeader().GetServiceId(),
+				// TODO_IN_THIS_COMMIT: fix...
+				5,
+			)
+
+			sharedParams := s.keepers.SharedKeeper.GetParams(s.ctx)
+			*settlementCoin, err = claim.GetClaimeduPOKT(sharedParams, relayMiningDifficulty)
+			require.NoError(t, err)
+
+			if test.asyncStateChange != nil {
+				test.asyncStateChange(t)
+			}
+			_, _, err = s.trySettleClaims()
+
+			require.EqualError(t, err, test.getExpectedErr().Error())
 		})
 	}
 }
 
-// TestSettlePendingClaims_NonHaltingError asserts that the chain does NOT halt
-// when claim settlement results in certain anticipated and non-halting errors.
-func (s *tokenLogicModuleTestSuite) TestSettlePendingClaims_NonHaltingError() {
+// TODO_IN_THIS_COMMIT: app oveserviced test case...
+func (s *tlmProcessorTestSuite) TestSettlePendingClaims_NonHaltingError() {
 	tests := []struct {
 		desc  string
 		setup func(*testing.T)
 	}{
-		{desc: "supplier operator pubkey not on-chain"},
-		{desc: "closest merkle proof is invalid (mangled)"},
-		{desc: "closest merkle proof is invalid (non-compact)"},
-		{desc: "closest merkle proof leaf is not a relay"},
-		{desc: "the application is overserviced"},
+		{
+			desc: "supplier operator pubkey not on-chain",
+			setup: func(t *testing.T) {
+				// Replace the supplier operator with one which does not have a
+				// public key on-chain (i.e. stored in the account keeper).
+				s.supplierAcct = s.preGeneratedAccts.MustNext()
+				// NB: AddToKeyring should overwrite the existing key UID.
+				err := s.supplierAcct.AddToKeyring(s.keyRing, s.supplierOperatorUid)
+				require.NoError(t, err)
+
+				s.supplier.OwnerAddress = s.supplierAcct.Address.String()
+				s.supplier.OperatorAddress = s.supplierAcct.Address.String()
+
+				s.keepers.SupplierKeeper.RemoveSupplier(s.ctx, s.supplier.GetOperatorAddress())
+				s.keepers.SetSupplier(s.ctx, *s.supplier)
+
+				session, err := s.getSession()
+				require.NoError(t, err)
+
+				claim := s.newClaim(session)
+				proof := s.newProof(t, claim)
+
+				s.keepers.UpsertClaim(s.ctx, *claim)
+				s.keepers.UpsertProof(s.ctx, *proof)
+			},
+		},
+		{
+			desc: "closest merkle proof is invalid (mangled)",
+			setup: func(t *testing.T) {
+				session, err := s.getSession()
+				require.NoError(t, err)
+
+				claim := s.newClaim(session)
+				proof := s.newProof(t, claim)
+
+				// Mangle the proof.
+				for i := 0; i < len(proof.ClosestMerkleProof); i++ {
+					// Only mangle the odd bytes.
+					if i%2 == 0 {
+						continue
+					}
+
+					proof.ClosestMerkleProof[i] = ^proof.ClosestMerkleProof[i]
+				}
+
+				s.keepers.UpsertClaim(s.ctx, *claim)
+				s.keepers.UpsertProof(s.ctx, *proof)
+			},
+		},
+		{
+			desc: "closest merkle proof is invalid (non-compact)",
+			setup: func(t *testing.T) {
+				session, err := s.getSession()
+				require.NoError(t, err)
+
+				claim := s.newClaim(session)
+				proof := s.newProof(t, claim)
+
+				sparseCompactMerkleClosestProof := new(smt.SparseCompactMerkleClosestProof)
+				err = sparseCompactMerkleClosestProof.Unmarshal(proof.ClosestMerkleProof)
+				require.NoError(t, err)
+
+				var sparseMerkleClosestProof *smt.SparseMerkleClosestProof
+				sparseMerkleClosestProof, err = smt.DecompactClosestProof(sparseCompactMerkleClosestProof, &protocol.SmtSpec)
+				require.NoError(t, err)
+
+				nonCompactProofBz, err := sparseMerkleClosestProof.Marshal()
+				require.NoError(t, err)
+
+				proof.ClosestMerkleProof = nonCompactProofBz
+
+				s.keepers.UpsertClaim(s.ctx, *claim)
+				s.keepers.UpsertProof(s.ctx, *proof)
+			},
+		},
+		{
+			desc: "closest merkle proof leaf is not a relay",
+			setup: func(t *testing.T) {
+				session, err := s.getSession()
+				require.NoError(t, err)
+
+				claim := s.newClaim(session)
+
+				sessionHeader := claim.GetSessionHeader()
+				sessionTree := testtree.NewEmptySessionTree(t, sessionHeader, claim.GetSupplierOperatorAddress())
+				err = sessionTree.Update([]byte("not-a-hash"), []byte("not-a-relay"), 1)
+				require.NoError(t, err)
+
+				merkleRootBz, err := sessionTree.Flush()
+				require.NoError(t, err)
+
+				// Override the claim root hash with a valid one which corresponds to the unmangled proof.
+				claim.RootHash = merkleRootBz
+
+				merkleProofPath := protocol.GetPathForProof(s.merkleProofPathSeed, session.GetSessionId())
+
+				// Construct a proof for a session tree where the path value (leaf) is not a valid serialized relay.
+				proof := testtree.NewProof(t,
+					claim.GetSupplierOperatorAddress(),
+					sessionHeader,
+					sessionTree,
+					merkleProofPath,
+				)
+
+				s.keepers.UpsertClaim(s.ctx, *claim)
+				s.keepers.UpsertProof(s.ctx, *proof)
+			},
+		},
+		// TODO_IN_THIS_COMMIT: add test case ...
+		//{
+		//	desc: "the application is overserviced",
+		//},
+	}
+
+	// TODO_IN_THIS_COMMIT: comment...
+	daoRewardAcct, ok := testkeyring.PreGeneratedAccountAtIndex(1)
+	require.True(s.T(), ok)
+
+	opts := []keeper.TokenomicsModuleKeepersOptFn{
+		keeper.WithDaoRewardBech32(daoRewardAcct.Address.String()),
+		keeper.WithProofRequirement(prooftypes.ProofRequirementReason_THRESHOLD),
 	}
 
 	for _, test := range tests {
 		s.T().Run(test.desc, func(t *testing.T) {
-			// TODO_TEST:
-			// set up keepers
-			// assert 0 claims exist
-			// case-specific setup
-			// settle pending claims
-			// assert results (states and balances)
+			// Reset the test for each scenario.
+			s.setupKeepers(t, opts...)
+
+			// Assert that no pre-existing claims are present.
+			numExistingClaims := len(s.keepers.GetAllClaims(s.ctx))
+			require.Equal(t, 0, numExistingClaims)
+
+			test.setup(t)
+			settledResults, expiredResults, err := s.trySettleClaims()
+
+			require.NoError(t, err)
+			require.NotNil(t, settledResults)
+			require.NotNil(t, expiredResults)
 		})
 	}
 }

--- a/testutil/keeper/tokenomics.go
+++ b/testutil/keeper/tokenomics.go
@@ -622,8 +622,13 @@ func WithTokenLogicModules(processors []tlm.TokenLogicModule) TokenomicsModuleKe
 }
 
 // TODO_IN_THIS_COMMIT: godoc...
-func WithDaoRewardBech32(daoRewardBech32 string) TokenomicsModuleKeepersOptFn {
-	return WithTLMProcessors(tlm.NewDefaultTokenLogicModules(daoRewardBech32))
+func WithDaoRewardBech32(daoRewardAddr string) TokenomicsModuleKeepersOptFn {
+	tokenomicsParams := tokenomicstypes.DefaultParams()
+	tokenomicsParams.DaoRewardAddress = daoRewardAddr
+
+	return WithModuleParams(map[string]cosmostypes.Msg{
+		tokenomicstypes.ModuleName: &tokenomicsParams,
+	})
 }
 
 // WithModuleParams returns a KeeperOptionFn that sets the moduleParams field

--- a/testutil/sample/sample.go
+++ b/testutil/sample/sample.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 
 	"github.com/cometbft/cometbft/crypto/tmhash"
+	"github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
@@ -65,4 +66,16 @@ func AccAddressFromConsBech32(consBech32 string) string {
 	consAccAddr, _ := cosmostypes.ConsAddressFromBech32(consBech32)
 	accAddr, _ := cosmostypes.AccAddressFromHexUnsafe(hex.EncodeToString(consAccAddr.Bytes()))
 	return accAddr.String()
+}
+
+// TODO_IN_THIS_COMMIT: godoc... & move to pkg/crypto/...
+func ConsAddrFromAccBech32(accBech32 string) cosmostypes.ConsAddress {
+	accAddr, _ := cosmostypes.AccAddressFromBech32(accBech32)
+
+	addrCodec := address.NewBech32Codec(cosmostypes.GetConfig().GetBech32ConsensusAddrPrefix())
+	consBech32, _ := addrCodec.BytesToString(accAddr.Bytes())
+
+	consAddr, _ := cosmostypes.ConsAddressFromBech32(consBech32)
+
+	return consAddr
 }

--- a/x/supplier/keeper/unbond_suppliers.go
+++ b/x/supplier/keeper/unbond_suppliers.go
@@ -40,39 +40,9 @@ func (k Keeper) EndBlockerUnbondSuppliers(ctx context.Context) error {
 			continue
 		}
 
-		// Retrieve the owner address of the supplier.
-		ownerAddress, err := cosmostypes.AccAddressFromBech32(supplier.OwnerAddress)
-		if err != nil {
-			logger.Error(fmt.Sprintf("could not parse the owner address %s", supplier.OwnerAddress))
+		if err := k.UnbondSupplier(ctx, &supplier); err != nil {
 			return err
 		}
-
-		// Retrieve the address of the supplier.
-		supplierOperatorAddress, err := cosmostypes.AccAddressFromBech32(supplier.OperatorAddress)
-		if err != nil {
-			logger.Error(fmt.Sprintf("could not parse the operator address %s", supplier.OperatorAddress))
-			return err
-		}
-
-		// If the supplier stake is 0 due to slashing, then do not move 0 coins
-		// to its account.
-		// Coin#IsPositive returns false if the coin is 0.
-		if supplier.Stake.IsPositive() {
-			// Send the coins from the supplier pool back to the supplier.
-			if err = k.bankKeeper.SendCoinsFromModuleToAccount(
-				ctx, suppliertypes.ModuleName, ownerAddress, []cosmostypes.Coin{*supplier.Stake},
-			); err != nil {
-				logger.Error(fmt.Sprintf(
-					"could not send %s coins from module %s to account %s due to %s",
-					supplier.Stake.String(), suppliertypes.ModuleName, ownerAddress, err,
-				))
-				return err
-			}
-		}
-
-		// Remove the supplier from the store.
-		k.RemoveSupplier(ctx, supplierOperatorAddress.String())
-		logger.Info(fmt.Sprintf("Successfully removed the supplier: %+v", supplier))
 
 		// Emit an event which signals that the supplier has sucessfully unbonded.
 		event := &suppliertypes.EventSupplierUnbondingEnd{
@@ -83,6 +53,46 @@ func (k Keeper) EndBlockerUnbondSuppliers(ctx context.Context) error {
 			logger.Error(fmt.Sprintf("failed to emit event: %+v; %s", event, eventErr))
 		}
 	}
+
+	return nil
+}
+
+func (k Keeper) UnbondSupplier(ctx context.Context, supplier *sharedtypes.Supplier) error {
+	logger := k.Logger().With("method", "UnbondSupplier")
+
+	// Retrieve the owner address of the supplier.
+	ownerAddress, err := cosmostypes.AccAddressFromBech32(supplier.GetOwnerAddress())
+	if err != nil {
+		logger.Error(fmt.Sprintf("could not parse the owner address %s", supplier.GetOwnerAddress()))
+		return err
+	}
+
+	// Retrieve the address of the supplier.
+	supplierOperatorAddress, err := cosmostypes.AccAddressFromBech32(supplier.OperatorAddress)
+	if err != nil {
+		logger.Error(fmt.Sprintf("could not parse the operator address %s", supplier.GetOperatorAddress()))
+		return err
+	}
+
+	// If the supplier stake is 0 due to slashing, then do not move 0 coins
+	// to its account.
+	// Coin#IsPositive returns false if the coin is 0.
+	if supplier.Stake.IsPositive() {
+		// Send the coins from the supplier pool back to the supplier.
+		if err = k.bankKeeper.SendCoinsFromModuleToAccount(
+			ctx, suppliertypes.ModuleName, ownerAddress, []cosmostypes.Coin{*supplier.Stake},
+		); err != nil {
+			logger.Error(fmt.Sprintf(
+				"could not send %s coins from module %s to account %s due to %s",
+				supplier.Stake.String(), suppliertypes.ModuleName, ownerAddress, err,
+			))
+			return err
+		}
+	}
+
+	// Remove the supplier from the store.
+	k.RemoveSupplier(ctx, supplierOperatorAddress.String())
+	logger.Info(fmt.Sprintf("Successfully removed the supplier: %+v", supplier))
 
 	return nil
 }

--- a/x/tokenomics/keeper/token_logic_modules.go
+++ b/x/tokenomics/keeper/token_logic_modules.go
@@ -128,7 +128,12 @@ func (k Keeper) ProcessTokenLogicModules(
 	supplier, isSupplierFound := k.supplierKeeper.GetSupplier(ctx, supplierOperatorAddr.String())
 	if !isSupplierFound {
 		logger.Warn(fmt.Sprintf("supplier for claim with address %q not found", supplierOperatorAddr))
-		return tokenomicstypes.ErrTokenomicsSupplierNotFound
+		return tokenomicstypes.ErrTokenomicsSupplierNotFound.Wrapf(
+			"could not find supplier with operator address %q for service %q at height %d",
+			pendingResult.Claim.GetSupplierOperatorAddress(),
+			sessionHeader.ServiceId,
+			cosmostypes.UnwrapSDKContext(ctx).BlockHeight(),
+		)
 	}
 
 	service, isServiceFound := k.serviceKeeper.GetService(ctx, sessionHeader.ServiceId)

--- a/x/tokenomics/token_logic_module/global_mint.go
+++ b/x/tokenomics/token_logic_module/global_mint.go
@@ -115,7 +115,7 @@ func (tlm tlmGlobalMint) Process(
 		uint64(supplierCoinsToShareAmt),
 	); err != nil {
 		return tokenomicstypes.ErrTokenomicsTLMInternal.Wrapf(
-			"queueing operation: distributing rewards to supplier with operator address %s shareholders: %v",
+			"queueing operation: distributing rewards to supplier with operator address %q shareholders: %s",
 			tlmCtx.Supplier.OperatorAddress,
 			err,
 		)

--- a/x/tokenomics/token_logic_module/relay_burn_equals_mint.go
+++ b/x/tokenomics/token_logic_module/relay_burn_equals_mint.go
@@ -67,7 +67,7 @@ func (tlm tlmRelayBurnEqualsMint) Process(
 		tlmCtx.SettlementCoin.Amount.Uint64(),
 	); err != nil {
 		return tokenomicstypes.ErrTokenomicsTLMInternal.Wrapf(
-			"queueing operation: distributing rewards to supplier with operator address %s shareholders: %v",
+			"queueing operation: distributing rewards to supplier with operator address %q shareholders: %s",
 			tlmCtx.Supplier.OperatorAddress,
 			err,
 		)

--- a/x/tokenomics/types/expected_keepers.go
+++ b/x/tokenomics/types/expected_keepers.go
@@ -85,6 +85,8 @@ type SupplierKeeper interface {
 	GetSupplier(ctx context.Context, supplierOperatorAddr string) (supplier sharedtypes.Supplier, found bool)
 	GetAllSuppliers(ctx context.Context) (suppliers []sharedtypes.Supplier)
 	SetSupplier(ctx context.Context, supplier sharedtypes.Supplier)
+	RemoveSupplier(ctx context.Context, supplierOperatorAddress string)
+	UnbondSupplier(ctx context.Context, app *sharedtypes.Supplier) error
 }
 
 type ServiceKeeper interface {
@@ -93,4 +95,5 @@ type ServiceKeeper interface {
 	UpdateRelayMiningDifficulty(ctx context.Context, relaysPerServiceMap map[string]uint64) (map[string]servicetypes.RelayMiningDifficulty, error)
 	// Only used for testing & simulation
 	SetService(ctx context.Context, service sharedtypes.Service)
+	RemoveService(ctx context.Context, serviceId string)
 }

--- a/x/tokenomics/types/settlement_result.go
+++ b/x/tokenomics/types/settlement_result.go
@@ -57,22 +57,27 @@ func (r *SettlementResult) AppendModToAcctTransfer(transfer ModToAcctTransfer) {
 
 // Validate returns an error if the MintBurnOperation has either an unspecified TLM or TLMReason.
 func (m *MintBurnOp) Validate() error {
-	return validateOpReason(m.OpReason, m)
+	if m.OpReason == SettlementOpReason_UNSPECIFIED {
+		return ErrTokenomicsSettlementModuleBurn.Wrapf("settlement operation reason is unspecified: %+v", m.OpReason)
+	}
+	return nil
 }
 
 // Validate returns an error if the ModToAcctTransfer has either an unspecified TLM or TLMReason.
 func (m *ModToAcctTransfer) Validate() error {
-	return validateOpReason(m.OpReason, m)
+	if m.OpReason == SettlementOpReason_UNSPECIFIED {
+		return ErrTokenomicsSettlementTransfer.Wrapf("settlement operation reason is unspecified: %+v", m.OpReason)
+	}
+	return nil
 }
 
 // Validate returns an error if the ModToModTransfer has either an unspecified TLM or TLMReason.
 func (m *ModToModTransfer) Validate() error {
-	return validateOpReason(m.OpReason, m)
-}
-
-func validateOpReason(opReason SettlementOpReason, op any) error {
-	if opReason == SettlementOpReason_UNSPECIFIED {
-		return ErrTokenomicsSettlementModuleBurn.Wrapf("origin reason is unspecified: %+v", op)
+	if m.OpReason == SettlementOpReason_UNSPECIFIED {
+		return ErrTokenomicsSettlementTransfer.Wrapf(
+			"settlement operation reason is unspecified: %+v",
+			m.OpReason,
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds integration tests which categorize and exercise claim/proof settlement errors into "SHOULD halt" and "SHOULD NOT halt".

## Issue

- #881

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [x] Other (specify): Tests

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [x] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
