### PR TITLE
[Service] Return the default RelayMinerDifficuly for services that have none.

### DIFF
--- a/pkg/client/query/servicequerier.go
+++ b/pkg/client/query/servicequerier.go
@@ -5,11 +5,8 @@ import (
 
 	"cosmossdk.io/depinject"
 	"github.com/cosmos/gogoproto/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/pokt-network/poktroll/pkg/client"
-	"github.com/pokt-network/poktroll/pkg/crypto/protocol"
 	servicetypes "github.com/pokt-network/poktroll/x/service/types"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
@@ -75,16 +72,6 @@ func (servq *serviceQuerier) GetServiceRelayDifficulty(
 	}
 
 	res, err := servq.serviceQuerier.RelayMiningDifficulty(ctx, req)
-	if status.Code(err) == codes.NotFound {
-		newServiceDifficulty := servicetypes.RelayMiningDifficulty{
-			ServiceId:    serviceId,
-			BlockHeight:  0,
-			NumRelaysEma: 0,
-			TargetHash:   protocol.BaseRelayDifficultyHashBz,
-		}
-
-		return newServiceDifficulty, nil
-	}
 	if err != nil {
 		return servicetypes.RelayMiningDifficulty{}, err
 	}

--- a/x/proof/keeper/msg_server_submit_proof.go
+++ b/x/proof/keeper/msg_server_submit_proof.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/pokt-network/poktroll/telemetry"
 	"github.com/pokt-network/poktroll/x/proof/types"
-	servicekeeper "github.com/pokt-network/poktroll/x/service/keeper"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
@@ -219,10 +218,7 @@ func (k Keeper) ProofRequirementForClaim(ctx context.Context, claim *types.Claim
 	sharedParams := k.sharedKeeper.GetParams(ctx)
 
 	serviceId := claim.GetSessionHeader().GetServiceId()
-	relayMiningDifficulty, found := k.serviceKeeper.GetRelayMiningDifficulty(ctx, serviceId)
-	if !found {
-		relayMiningDifficulty = servicekeeper.NewDefaultRelayMiningDifficulty(ctx, logger, serviceId, servicekeeper.TargetNumRelays)
-	}
+	relayMiningDifficulty, _ := k.serviceKeeper.GetRelayMiningDifficulty(ctx, serviceId)
 
 	// Retrieve the number of tokens claimed to compare against the threshold.
 	// Different services have varying compute_unit -> token multipliers, so the

--- a/x/proof/keeper/proof_validation.go
+++ b/x/proof/keeper/proof_validation.go
@@ -38,7 +38,6 @@ import (
 	"github.com/pokt-network/poktroll/pkg/crypto/protocol"
 	"github.com/pokt-network/poktroll/telemetry"
 	"github.com/pokt-network/poktroll/x/proof/types"
-	servicekeeper "github.com/pokt-network/poktroll/x/service/keeper"
 	servicetypes "github.com/pokt-network/poktroll/x/service/types"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 )
@@ -169,11 +168,7 @@ func (k Keeper) EnsureValidProof(
 	logger.Debug("successfully verified relay response signature")
 
 	// Get the service's relay mining difficulty.
-	serviceRelayDifficulty, found := k.serviceKeeper.GetRelayMiningDifficulty(ctx, sessionHeader.GetServiceId())
-	if !found {
-		// If the relay mining difficulty is not found, use the default relay mining difficulty.
-		serviceRelayDifficulty = servicekeeper.NewDefaultRelayMiningDifficulty(ctx, k.Logger(), sessionHeader.GetServiceId(), servicekeeper.TargetNumRelays)
-	}
+	serviceRelayDifficulty, _ := k.serviceKeeper.GetRelayMiningDifficulty(ctx, sessionHeader.GetServiceId())
 
 	// Verify the relay difficulty is above the minimum required to earn rewards.
 	if err = validateRelayDifficulty(

--- a/x/service/keeper/query_relay_mining_difficulty.go
+++ b/x/service/keeper/query_relay_mining_difficulty.go
@@ -44,13 +44,15 @@ func (k Keeper) RelayMiningDifficulty(ctx context.Context, req *types.QueryGetRe
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
-	difficulty, found := k.GetRelayMiningDifficulty(
-		ctx,
-		req.ServiceId,
-	)
-	if !found {
-		return nil, status.Error(codes.NotFound, "not found")
+	_, serviceFound := k.GetService(ctx, req.ServiceId)
+	if !serviceFound {
+		return nil, status.Error(
+			codes.NotFound,
+			types.ErrServiceNotFound.Wrapf("serviceID: %s", req.ServiceId).Error(),
+		)
 	}
+
+	difficulty, _ := k.GetRelayMiningDifficulty(ctx, req.ServiceId)
 
 	return &types.QueryGetRelayMiningDifficultyResponse{RelayMiningDifficulty: difficulty}, nil
 }

--- a/x/service/keeper/relay_mining_difficulty.go
+++ b/x/service/keeper/relay_mining_difficulty.go
@@ -29,11 +29,9 @@ func (k Keeper) GetRelayMiningDifficulty(
 	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.RelayMiningDifficultyKeyPrefix))
 
-	difficultyBz := store.Get(types.RelayMiningDifficultyKey(
-		serviceId,
-	))
+	difficultyBz := store.Get(types.RelayMiningDifficultyKey(serviceId))
 	if difficultyBz == nil {
-		difficulty.ServiceId = serviceId
+		difficulty = NewDefaultRelayMiningDifficulty(ctx, k.logger, serviceId, TargetNumRelays)
 		return difficulty, false
 	}
 

--- a/x/service/keeper/relay_mining_difficulty.go
+++ b/x/service/keeper/relay_mining_difficulty.go
@@ -31,6 +31,10 @@ func (k Keeper) GetRelayMiningDifficulty(
 
 	difficultyBz := store.Get(types.RelayMiningDifficultyKey(serviceId))
 	if difficultyBz == nil {
+		k.Logger().Warn(fmt.Sprintf(
+			"relayMiningDifficulty not found for service: %s, defaulting to base difficulty with protocol TargetNumRelays (%d)",
+			serviceId, TargetNumRelays,
+		))
 		difficulty = NewDefaultRelayMiningDifficulty(ctx, k.logger, serviceId, TargetNumRelays)
 		return difficulty, false
 	}

--- a/x/service/keeper/relay_mining_difficulty_test.go
+++ b/x/service/keeper/relay_mining_difficulty_test.go
@@ -30,9 +30,7 @@ func TestRelayMiningDifficultyGet(t *testing.T) {
 	keeper, ctx := keepertest.ServiceKeeper(t)
 	difficulties := createNRelayMiningDifficulty(keeper, ctx, 10)
 	for _, difficulty := range difficulties {
-		rst, found := keeper.GetRelayMiningDifficulty(ctx,
-			difficulty.ServiceId,
-		)
+		rst, found := keeper.GetRelayMiningDifficulty(ctx, difficulty.ServiceId)
 		require.True(t, found)
 		require.Equal(t,
 			nullify.Fill(&difficulty),
@@ -40,6 +38,7 @@ func TestRelayMiningDifficultyGet(t *testing.T) {
 		)
 	}
 }
+
 func TestRelayMiningDifficultyRemove(t *testing.T) {
 	keeper, ctx := keepertest.ServiceKeeper(t)
 	difficulties := createNRelayMiningDifficulty(keeper, ctx, 10)
@@ -47,9 +46,7 @@ func TestRelayMiningDifficultyRemove(t *testing.T) {
 		keeper.RemoveRelayMiningDifficulty(ctx,
 			difficulty.ServiceId,
 		)
-		_, found := keeper.GetRelayMiningDifficulty(ctx,
-			difficulty.ServiceId,
-		)
+		_, found := keeper.GetRelayMiningDifficulty(ctx, difficulty.ServiceId)
 		require.False(t, found)
 	}
 }

--- a/x/service/types/errors.go
+++ b/x/service/types/errors.go
@@ -19,4 +19,5 @@ var (
 	ErrServiceInvalidOwnerAddress          = sdkerrors.Register(ModuleName, 1113, "invalid owner address")
 	ErrServiceParamInvalid                 = sdkerrors.Register(ModuleName, 1115, "the provided param is invalid")
 	ErrServiceMissingRelayMiningDifficulty = sdkerrors.Register(ModuleName, 1116, "missing relay mining difficulty")
+	ErrServiceNotFound                     = sdkerrors.Register(ModuleName, 1117, "service not found")
 )


### PR DESCRIPTION
## Summary

Make `servicekeeper.GetRelayMinerDifficulty` always return a valid difficulty by defaulting to the base difficulty for new `Services`.

## Issue

Querying for a `RelayMiningDifficulty` corresponding to a new `Service` does not return a valid one.

This results in redundant code that aims to recreate the base `RelayMiningDifficulty`.

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
