### PR TITLE
[C&P] Populate NumEstimatedComputeUnits and ClaimedUpokt of Claim and Proof events

### DIFF
--- a/x/proof/keeper/msg_server_create_claim_test.go
+++ b/x/proof/keeper/msg_server_create_claim_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pokt-network/poktroll/x/proof/keeper"
 	"github.com/pokt-network/poktroll/x/proof/types"
 	prooftypes "github.com/pokt-network/poktroll/x/proof/types"
+	servicekeeper "github.com/pokt-network/poktroll/x/service/keeper"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
@@ -173,9 +174,20 @@ func TestMsgServer_CreateClaim_Success(t *testing.T) {
 			claimCreatedEvents := testutilevents.FilterEvents[*prooftypes.EventClaimCreated](t, events)
 			require.Len(t, claimCreatedEvents, 1)
 
+			targetNumRelays := servicekeeper.TargetNumRelays
+			relayMiningDifficulty := servicekeeper.NewDefaultRelayMiningDifficulty(ctx, keepers.Logger(), service.Id, targetNumRelays)
+
+			numEstimatedComputUnits, err := claim.GetNumEstimatedComputeUnits(relayMiningDifficulty)
+			require.NoError(t, err)
+
+			claimedUPOKT, err := claim.GetClaimeduPOKT(sharedParams, relayMiningDifficulty)
+			require.NoError(t, err)
+
 			require.EqualValues(t, &claim, claimCreatedEvents[0].GetClaim())
 			require.Equal(t, uint64(test.expectedNumClaimedComputeUnits), claimCreatedEvents[0].GetNumClaimedComputeUnits())
 			require.Equal(t, uint64(expectedNumRelays), claimCreatedEvents[0].GetNumRelays())
+			require.Equal(t, numEstimatedComputUnits, claimCreatedEvents[0].GetNumClaimedComputeUnits())
+			require.Equal(t, &claimedUPOKT, claimCreatedEvents[0].GetClaimedUpokt())
 		})
 	}
 }

--- a/x/proof/keeper/msg_server_submit_proof_test.go
+++ b/x/proof/keeper/msg_server_submit_proof_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pokt-network/poktroll/testutil/testtree"
 	"github.com/pokt-network/poktroll/x/proof/keeper"
 	prooftypes "github.com/pokt-network/poktroll/x/proof/types"
+	servicekeeper "github.com/pokt-network/poktroll/x/service/keeper"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 	suppliertypes "github.com/pokt-network/poktroll/x/supplier/types"
@@ -234,11 +235,21 @@ func TestMsgServer_SubmitProof_Success(t *testing.T) {
 
 			proofSubmittedEvent := proofSubmittedEvents[0]
 
+			targetNumRelays := servicekeeper.TargetNumRelays
+			relayMiningDifficulty := servicekeeper.NewDefaultRelayMiningDifficulty(ctx, keepers.Logger(), service.Id, targetNumRelays)
+
+			numEstimatedComputUnits, err := claim.GetNumEstimatedComputeUnits(relayMiningDifficulty)
+			require.NoError(t, err)
+
+			claimedUPOKT, err := claim.GetClaimeduPOKT(sharedParams, relayMiningDifficulty)
+			require.NoError(t, err)
+
 			require.EqualValues(t, claim, proofSubmittedEvent.GetClaim())
 			require.EqualValues(t, &proofs[0], proofSubmittedEvent.GetProof())
 			require.Equal(t, uint64(numRelays), proofSubmittedEvent.GetNumRelays())
 			require.Equal(t, uint64(numClaimComputeUnits), proofSubmittedEvent.GetNumClaimedComputeUnits())
-			// TODO_BETA(@red-0ne): Add NumEstimatedComputeUnits and ClaimedAmountUpokt assertions
+			require.Equal(t, numEstimatedComputUnits, proofSubmittedEvent.GetNumEstimatedComputeUnits())
+			require.Equal(t, &claimedUPOKT, proofSubmittedEvent.GetClaimedUpokt())
 		})
 	}
 }


### PR DESCRIPTION
## Summary

This PR populates `NumEstimatedComputeUnits` and `ClaimedUpokt` to the following events:
* `EventClaimCreated`
* `EventClaimUpdated`
* `EventProofSubmitted`
* `EventProofUpdated`

## Issue

TODO_BETA

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
