### PR TITLE
[Docs] Fix Docker Walkthrough gateway container name and add supplier staking note

### DIFF
--- a/docusaurus/docs/operate/quickstart/docker_compose_walkthrough.md
+++ b/docusaurus/docs/operate/quickstart/docker_compose_walkthrough.md
@@ -618,13 +618,13 @@ explains what the Gateway Server operation config is and how it can be used.
 appgate/config/gateway_config.yaml
 
 ```bash
-docker-compose up -d gateway-example
+docker-compose up -d gateway
 ```
 
 Check logs and confirm the node works as expected:
 
 ```bash
-docker-compose logs -f --tail 100 gateway-example
+docker-compose logs -f --tail 100 gateway
 ```
 
 ### Delegate your Application to the Gateway <!-- omit in toc -->

--- a/docusaurus/docs/operate/quickstart/docker_compose_walkthrough.md
+++ b/docusaurus/docs/operate/quickstart/docker_compose_walkthrough.md
@@ -315,6 +315,8 @@ You can check that your address is funded correctly by running:
 poktrolld query bank balances $SUPPLIER_ADDR
 ```
 
+**Note: You must wait until `full-node` has synced up to [current block #](https://shannon.testnet.pokt.network/poktroll/block) before this command and the stake command below (`poktrolld tx supplier stake-supplier...`) will work successfully. Watch your node's block height [here.](https://dev.poktroll.com/operate/quickstart/docker_compose_walkthrough#watch-the-height-)**
+
 If you're waiting to see if your transaction has been included in a block, you can run:
 
 ```bash

--- a/docusaurus/docs/operate/quickstart/docker_compose_walkthrough.md
+++ b/docusaurus/docs/operate/quickstart/docker_compose_walkthrough.md
@@ -315,7 +315,7 @@ You can check that your address is funded correctly by running:
 poktrolld query bank balances $SUPPLIER_ADDR
 ```
 
-**Note: You must wait until `full-node` has synced up to [current block #](https://shannon.testnet.pokt.network/poktroll/block) before this command and the stake command below (`poktrolld tx supplier stake-supplier...`) will work successfully. Watch your node's block height [here.](https://dev.poktroll.com/operate/quickstart/docker_compose_walkthrough#watch-the-height-)**
+_Note: You must wait until `full-node` has synced up to the [current block #](https://shannon.testnet.pokt.network/poktroll/block) before this command and the stake command below (`poktrolld tx supplier stake-supplier...`) will work successfully. Watch your node's block height [here.](https://dev.poktroll.com/operate/quickstart/docker_compose_walkthrough#watch-the-height-)_
 
 If you're waiting to see if your transaction has been included in a block, you can run:
 


### PR DESCRIPTION
<!-- READ & DELETE:
    1. Add a descriptive title `[<Tag>] <DESCRIPTION>`
    2. Update _Assignee(s)_
    3. Add _Label(s)_
    4. Set _Project(s)_
    5. Specify _Epic_ and _Iteration_ under _Project_
    6. Set _Milestone_
-->

## Summary

- Changed incorrect `gateway-example` Docker container name to `gateway` under the **Configure and run your Gateway Server** section of Docker Compose Walkthrough.
- Added a note clarifying one must wait till the `full-node` has caught up with the current block number before staking their supplier.

I have not run `make docusaurus_start` as changes are fairly simple and I'm assuming they run on PR submission. Will do so if requested :)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Testing

<!-- READ & DELETE:
- Documentation changes: only keep this if you're making documentation changes
- Unit Testing: Remove this if you didn't make code changes
- E2E Testing: Remove this if you didn't make code changes
    - See the quickstart guide for instructions: https://dev.poktroll.com/developer_guide/quickstart
- DevNet E2E Testing: Remove this if you didn't make code changes
    - THIS IS VERY EXPENSIVE: only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)
-->

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
