### PR TITLE
[Docs] Update documentation on installing the `poktrolld` CLI

### DIFF
--- a/docusaurus/docs/operate/user_guide/install.md
+++ b/docusaurus/docs/operate/user_guide/install.md
@@ -3,17 +3,66 @@ title: CLI Installation
 sidebar_position: 0
 ---
 
-- [Release binaries](#release-binaries)
-- [Installing from source](#installing-from-source)
-  - [Prerequisites](#prerequisites)
-- [Homebrew and pkgx](#homebrew-and-pkgx)
+- [MacOS \& Linux Users](#macos--linux-users)
+  - [Using Homebrew](#using-homebrew)
+  - [From Source](#from-source)
+  - [Using release binaries](#using-release-binaries)
 - [Windows Users](#windows-users)
 
-## Release binaries
+## MacOS & Linux Users
+
+### Using Homebrew
+
+:::tip
+See the [homebrew-poktroll](https://github.com/pokt-network/homebrew-poktroll/)
+repository for details on how to install homebrew or other details to install
+or debug the CLI.
+:::
+
+Ensure you have [Homebrew](https://brew.sh/) installed.
+
+Then run the following commands:
+
+```bash
+brew tap pokt-network/poktroll
+brew install poktrolld
+```
+
+And verify it worked by running:
+
+```bash
+poktrolld version
+poktrolld --help
+```
+
+### From Source
+
+Ensure you have the following installed:
+
+- [Go](https://go.dev/doc/install) (version 1.18 or later)
+- [Ignite CLI](https://docs.ignite.com/welcome/install)
+
+Then run the following commands:
+
+```bash
+git clone https://github.com/pokt-network/poktroll.git
+cd poktroll
+make go_develop
+make ignite_poktrolld_build
+```
+
+And verify it worked by running:
+
+```bash
+poktrolld version
+poktrolld --help
+```
+
+### Using release binaries
 
 Pre-built binaries are available on our [releases page](https://github.com/pokt-network/poktroll/releases).
 
-The following snippet downloads/upgrades the binary to the latest released version (Linux and macOS only):
+The following snippet downloads/upgrades the binary to the latest released version:
 
 ```bash
 # Download the correct binary based on the OS and architecture
@@ -28,37 +77,6 @@ sudo chmod +x /usr/local/bin/poktrolld
 # Check version
 poktrolld version
 ```
-
-## Installing from source
-
-### Prerequisites
-
-Ensure you have the following installed:
-
-- [Go](https://go.dev/doc/install) (version 1.18 or later)
-- [Ignite CLI](https://docs.ignite.com/welcome/install)
-
-```bash
-git clone https://github.com/pokt-network/poktroll.git
-cd poktroll
-make go_develop
-make ignite_poktrolld_build
-```
-
-Verify it worked by running:
-
-```bash
-poktrolld --help
-```
-
-## Homebrew and pkgx
-
-:::tip
-We have an [open GitHub issue](https://github.com/pokt-network/poktroll/issues/535)
-to introduce `poktrolld` to [brew](https://brew.sh/) and [pkgx](https://github.com/pkgxdev/pkgx).
-
-Please reach out to us in the ticket if you want to pick this ticket!
-:::
 
 ## Windows Users
 


### PR DESCRIPTION
Updating the following page for details on how to install the `poktrolld` CLI using homebrew: https://dev.poktroll.com/operate/user_guide/install

![Screenshot 2024-11-21 at 12 58 19 PM](https://github.com/user-attachments/assets/cee0c036-cc6e-486f-8c8e-4db5fa25c4b5)
