### PR TITLE
[Code Health] fix: proof module gRPC status error returns

### DIFF
--- a/x/proof/keeper/msg_server_create_claim.go
+++ b/x/proof/keeper/msg_server_create_claim.go
@@ -33,7 +33,7 @@ func (k msgServer) CreateClaim(
 
 	// Basic validation of the CreateClaim message.
 	if err = msg.ValidateBasic(); err != nil {
-		return nil, err
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	logger.Info("validated the createClaim message")
 

--- a/x/proof/keeper/msg_update_params.go
+++ b/x/proof/keeper/msg_update_params.go
@@ -26,8 +26,8 @@ func (k msgServer) UpdateParams(ctx context.Context, req *types.MsgUpdateParams)
 	}
 
 	if err := k.SetParams(ctx, req.Params); err != nil {
-		fmt.Errorf("unable to set params: %w", err)
-		logger.Error(err.Error)
+		err = fmt.Errorf("unable to set params: %w", err)
+		logger.Error(err.Error())
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 

--- a/x/proof/keeper/msg_update_params.go
+++ b/x/proof/keeper/msg_update_params.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -10,6 +11,8 @@ import (
 )
 
 func (k msgServer) UpdateParams(ctx context.Context, req *types.MsgUpdateParams) (*types.MsgUpdateParamsResponse, error) {
+	logger := k.Logger().With("method", "UpdateParams")
+
 	if err := req.ValidateBasic(); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -23,7 +26,8 @@ func (k msgServer) UpdateParams(ctx context.Context, req *types.MsgUpdateParams)
 	}
 
 	if err := k.SetParams(ctx, req.Params); err != nil {
-		return nil, err
+		logger.Error(fmt.Sprintf("unable to set params: %+v", err))
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	return &types.MsgUpdateParamsResponse{}, nil

--- a/x/proof/keeper/msg_update_params.go
+++ b/x/proof/keeper/msg_update_params.go
@@ -3,15 +3,23 @@ package keeper
 import (
 	"context"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/pokt-network/poktroll/x/proof/types"
 )
 
 func (k msgServer) UpdateParams(ctx context.Context, req *types.MsgUpdateParams) (*types.MsgUpdateParamsResponse, error) {
 	if err := req.ValidateBasic(); err != nil {
-		return nil, err
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	if k.GetAuthority() != req.Authority {
-		return nil, types.ErrProofInvalidSigner.Wrapf("invalid authority; expected %s, got %s", k.GetAuthority(), req.Authority)
+		return nil, status.Error(
+			codes.PermissionDenied,
+			types.ErrProofInvalidSigner.Wrapf(
+				"invalid authority; expected %s, got %s", k.GetAuthority(), req.Authority,
+			).Error(),
+		)
 	}
 
 	if err := k.SetParams(ctx, req.Params); err != nil {

--- a/x/proof/keeper/msg_update_params.go
+++ b/x/proof/keeper/msg_update_params.go
@@ -26,7 +26,8 @@ func (k msgServer) UpdateParams(ctx context.Context, req *types.MsgUpdateParams)
 	}
 
 	if err := k.SetParams(ctx, req.Params); err != nil {
-		logger.Error(fmt.Sprintf("unable to set params: %+v", err))
+		fmt.Errorf("unable to set params: %w", err)
+		logger.Error(err.Error)
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 

--- a/x/proof/keeper/query_claim.go
+++ b/x/proof/keeper/query_claim.go
@@ -68,7 +68,8 @@ func (k Keeper) AllClaims(ctx context.Context, req *types.QueryAllClaimsRequest)
 			// The value is the encoded claim.
 			var claim types.Claim
 			if err := k.cdc.Unmarshal(value, &claim); err != nil {
-				logger.Error(fmt.Sprintf("unable to unmarshal claim with key (hex): %x: %+v", key, err))
+				err = fmt.Errorf("unable to unmarshal claim with key (hex): %x: %+v", key, err)
+				logger.Error(err.Error())
 				return status.Error(codes.Internal, err.Error())
 			}
 			claims = append(claims, claim)

--- a/x/proof/keeper/query_claim.go
+++ b/x/proof/keeper/query_claim.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 
 	"cosmossdk.io/store/prefix"
 	"github.com/cosmos/cosmos-sdk/runtime"
@@ -14,6 +15,8 @@ import (
 )
 
 func (k Keeper) AllClaims(ctx context.Context, req *types.QueryAllClaimsRequest) (*types.QueryAllClaimsResponse, error) {
+	logger := k.Logger().With("method", "AllClaims")
+
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
@@ -65,7 +68,8 @@ func (k Keeper) AllClaims(ctx context.Context, req *types.QueryAllClaimsRequest)
 			// The value is the encoded claim.
 			var claim types.Claim
 			if err := k.cdc.Unmarshal(value, &claim); err != nil {
-				return err
+				logger.Error(fmt.Sprintf("unable to unmarshal claim with key (hex): %x: %+v", key, err))
+				return status.Error(codes.Internal, err.Error())
 			}
 			claims = append(claims, claim)
 		}

--- a/x/proof/keeper/query_proof.go
+++ b/x/proof/keeper/query_proof.go
@@ -65,7 +65,8 @@ func (k Keeper) AllProofs(ctx context.Context, req *types.QueryAllProofsRequest)
 			// The value is the encoded proof.
 			var proof types.Proof
 			if err := k.cdc.Unmarshal(value, &proof); err != nil {
-				logger.Error(fmt.Sprintf("unable to unmarshal proof with key (hex): %x: %+v", key, err))
+				err = fmt.Errorf("unable to unmarshal proof with key (hex): %x: %+v", key, err)
+				logger.Error(err.Error())
 				return status.Error(codes.Internal, err.Error())
 			}
 

--- a/x/proof/keeper/query_proof.go
+++ b/x/proof/keeper/query_proof.go
@@ -14,6 +14,8 @@ import (
 )
 
 func (k Keeper) AllProofs(ctx context.Context, req *types.QueryAllProofsRequest) (*types.QueryAllProofsResponse, error) {
+	logger := k.Logger().With("method", "AllProofs")
+
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
@@ -63,7 +65,8 @@ func (k Keeper) AllProofs(ctx context.Context, req *types.QueryAllProofsRequest)
 			// The value is the encoded proof.
 			var proof types.Proof
 			if err := k.cdc.Unmarshal(value, &proof); err != nil {
-				return err
+				logger.Error(fmt.Sprintf("unable to unmarshal proof with key (hex): %x: %+v", key, err))
+				return status.Error(codes.Internal, err.Error())
 			}
 
 			proofs = append(proofs, proof)


### PR DESCRIPTION
## Summary

Ensure all proof module message and query handlers return gRPC status errors.

## Issue

- #954 

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [x] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [x] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
