### PR TITLE
[Docs] adding params - fix gRPC status error code

### DIFF
--- a/docusaurus/docs/develop/developer_guide/adding_params.md
+++ b/docusaurus/docs/develop/developer_guide/adding_params.md
@@ -243,7 +243,7 @@ Prepare `x/examplemod/keeper/msg_server_update_param.go` to handle parameter upd
 +
 +   if k.GetAuthority() != msg.Authority {
 +     return nil, status.Error(
-+       codes.InvalidArgument,
++       codes.PermissionDenied,
 +       examplemodtypes.ErrExamplemodInvalidSigner.Wrapf(
 +         "invalid authority; expected %s, got %s",
 +         k.GetAuthority(), msg.Authority,


### PR DESCRIPTION
## Summary

```diff
func (k msgServer) UpdateParam(ctx context.Context, msg *examplemodtypes.MsgUpdateParam) (*examplemodtypes.MsgUpdateParamResponse, error) {
	// ...
	if k.GetAuthority() != msg.Authority {
		return nil, status.Error(
-			codes.InvalidArgument,
+			codes.PermissionDenied,
			examplemodtypes.ErrExamplemodInvalidSigner.Wrapf(
				"invalid authority; expected %s, got %s",
				k.GetAuthority(), msg.Authority,
			).Error(),
		)
	}
	// ...
}
```

## Issue

- N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
