### PR TITLE
[Code Health] fix: session module gRPC status return errors

### DIFF
--- a/x/proof/keeper/session.go
+++ b/x/proof/keeper/session.go
@@ -2,8 +2,10 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+	"google.golang.org/grpc/status"
 
 	"github.com/pokt-network/poktroll/x/proof/types"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
@@ -30,6 +32,8 @@ func (k Keeper) queryAndValidateSessionHeader(
 	// session header is to be validated.
 	sessionRes, err := k.sessionKeeper.GetSession(ctx, sessionReq)
 	if err != nil {
+		// NB: Strip internal error status from error. An appropriate status will be associated by the caller.
+		err = fmt.Errorf("%s", status.Convert(err).Message())
 		return nil, err
 	}
 	onChainSession := sessionRes.GetSession()

--- a/x/session/keeper/msg_update_params.go
+++ b/x/session/keeper/msg_update_params.go
@@ -2,21 +2,34 @@ package keeper
 
 import (
 	"context"
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pokt-network/poktroll/x/session/types"
 )
 
 func (k msgServer) UpdateParams(ctx context.Context, req *types.MsgUpdateParams) (*types.MsgUpdateParamsResponse, error) {
+	logger := k.Logger().With("method", "UpdateParams")
+
 	if err := req.ValidateBasic(); err != nil {
-		return nil, err
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if k.GetAuthority() != req.Authority {
-		return nil, types.ErrSessionInvalidSigner.Wrapf("invalid authority; expected %s, got %s", k.GetAuthority(), req.Authority)
+		return nil, status.Error(
+			codes.PermissionDenied,
+			types.ErrSessionInvalidSigner.Wrapf(
+				"invalid authority; expected %s, got %s", k.GetAuthority(), req.Authority,
+			).Error(),
+		)
 	}
 
 	if err := k.SetParams(ctx, req.Params); err != nil {
-		return nil, err
+		err = fmt.Errorf("unable to set params: %w", err)
+		logger.Error(err.Error())
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	return &types.MsgUpdateParamsResponse{}, nil

--- a/x/session/keeper/query_get_session.go
+++ b/x/session/keeper/query_get_session.go
@@ -43,7 +43,6 @@ func (k Keeper) GetSession(ctx context.Context, req *types.QueryGetSessionReques
 	sessionHydrator := NewSessionHydrator(req.ApplicationAddress, req.ServiceId, blockHeight)
 	session, err := k.HydrateSession(ctx, sessionHydrator)
 	if err != nil {
-		err = types.ErrSessionHydration.Wrapf("QueryGetSessionRequest: %+v: %s", req, err)
 		logger.Error(err.Error())
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/x/session/keeper/query_get_session.go
+++ b/x/session/keeper/query_get_session.go
@@ -14,8 +14,6 @@ import (
 // GetSession should be deterministic and always return the same session for
 // the same block height.
 func (k Keeper) GetSession(ctx context.Context, req *types.QueryGetSessionRequest) (*types.QueryGetSessionResponse, error) {
-	logger := k.Logger().With("method", "GetSession")
-
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
@@ -38,14 +36,12 @@ func (k Keeper) GetSession(ctx context.Context, req *types.QueryGetSessionReques
 		blockHeight = req.BlockHeight
 	}
 
-	logger.Debug(fmt.Sprintf("Getting session for height: %d", blockHeight))
+	k.Logger().Debug(fmt.Sprintf("Getting session for height: %d", blockHeight))
 
 	sessionHydrator := NewSessionHydrator(req.ApplicationAddress, req.ServiceId, blockHeight)
 	session, err := k.HydrateSession(ctx, sessionHydrator)
 	if err != nil {
-		err = types.ErrSessionHydration.Wrapf("QueryGetSessionRequest: %+v: %s", req, err)
-		logger.Error(err.Error())
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 
 	res := &types.QueryGetSessionResponse{


### PR DESCRIPTION
## Summary

Ensure all session message and query handlers return gRPC status errors.

## Issue

- #860 

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [x] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [x] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
