### PR TITLE
[Code Health] fix: tokenomics module gRPC return errors

### DIFF
--- a/x/tokenomics/keeper/msg_server_update_param.go
+++ b/x/tokenomics/keeper/msg_server_update_param.go
@@ -22,11 +22,17 @@ func (k msgServer) UpdateParam(
 	)
 
 	if err := msg.ValidateBasic(); err != nil {
-		return nil, err
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if k.GetAuthority() != msg.Authority {
-		return nil, tokenomicstypes.ErrTokenomicsInvalidSigner.Wrapf("invalid authority; expected %s, got %s", k.GetAuthority(), msg.Authority)
+		return nil, status.Error(
+			codes.PermissionDenied,
+			tokenomicstypes.ErrTokenomicsInvalidSigner.Wrapf(
+				"invalid authority; expected %s, got %s",
+				k.GetAuthority(), msg.Authority,
+			).Error(),
+		)
 	}
 
 	params := k.GetParams(ctx)

--- a/x/tokenomics/keeper/msg_update_params.go
+++ b/x/tokenomics/keeper/msg_update_params.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/pokt-network/poktroll/x/tokenomics/types"
 )
 
@@ -11,21 +14,25 @@ func (k msgServer) UpdateParams(ctx context.Context, msg *types.MsgUpdateParams)
 	logger := k.Logger()
 
 	if err := msg.ValidateBasic(); err != nil {
-		return nil, err
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	if msg.Authority != k.GetAuthority() {
-		return nil, types.ErrTokenomicsInvalidSigner.Wrapf(
-			"invalid authority; expected %s, got %s",
-			k.GetAuthority(),
-			msg.Authority,
+		return nil, status.Error(
+			codes.PermissionDenied,
+			types.ErrTokenomicsInvalidSigner.Wrapf(
+				"invalid authority; expected %s, got %s",
+				k.GetAuthority(),
+				msg.Authority,
+			).Error(),
 		)
 	}
 
 	logger.Info(fmt.Sprintf("About to update params from [%v] to [%v]", k.GetParams(ctx), msg.Params))
 
 	if err := k.SetParams(ctx, msg.Params); err != nil {
-		return nil, err
+		err = status.Error(codes.Internal, err.Error())
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	logger.Info("Done updating params")

--- a/x/tokenomics/keeper/msg_update_params.go
+++ b/x/tokenomics/keeper/msg_update_params.go
@@ -31,7 +31,8 @@ func (k msgServer) UpdateParams(ctx context.Context, msg *types.MsgUpdateParams)
 	logger.Info(fmt.Sprintf("About to update params from [%v] to [%v]", k.GetParams(ctx), msg.Params))
 
 	if err := k.SetParams(ctx, msg.Params); err != nil {
-		err = status.Error(codes.Internal, err.Error())
+		err = fmt.Errorf("unable to set params: %w", err)
+		logger.Error(err.Error())
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 


### PR DESCRIPTION
## Summary

Ensure all supplier message and query handlers return gRPC status errors.

## Issue

- #860

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [x] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [x] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
