### PR TITLE
[Tooling] Add protocheck `responses` subcmd to check for empty responses

### DIFF
--- a/tools/scripts/protocheck/cmd/check_responses.go
+++ b/tools/scripts/protocheck/cmd/check_responses.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"context"
+	"fmt"
+	goast "go/ast"
 	"path/filepath"
+	"strings"
 
-	"github.com/jhump/protoreflect/desc/protoparse/ast"
+	protoparseast "github.com/jhump/protoreflect/desc/protoparse/ast"
 	"github.com/spf13/cobra"
+	"golang.org/x/tools/go/packages"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
 	"github.com/pokt-network/poktroll/tools/scripts/protocheck/protoast"
@@ -32,41 +36,59 @@ func runCheckResponses(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
 
 	// Check protobuf message types ending in "Response" for at least one field.
-	if err := checkProtoResponseTypes(ctx); err != nil {
+	responseMsgStats, err := findProtoResponseTypes(ctx)
+	if err != nil {
+		// TODO_IN_THIS_COMMIT: exit with non-zero code if error.
 		return err
 	}
 
+	validResponseMsgStats, invalidResponseMsgStats := groupProtoResponseTypes(responseMsgStats)
+
 	// Check message handler return responses for at least one field assignment.
-	// TODO_IN_THIS_COMMIT: ...
+	if err = checkValidResponseGoUsages(ctx, validResponseMsgStats); err != nil {
+		// TODO_IN_THIS_COMMIT: exit with non-zero code if error.
+		return err
+	}
+
+	printInvalidResponseMsgs(ctx, invalidResponseMsgStats)
+	// TODO_IN_THIS_COMMIT: print valid response invalid usages.
 
 	return nil
 }
 
 // TODO_IN_THIS_COMMIT: move & godoc...
-func checkProtoResponseTypes(ctx context.Context) error {
-	//logger := polylog.Ctx(ctx).With("func", "checkProtoResponseTypes")
+func findProtoResponseTypes(ctx context.Context) (responseMsgStats map[string]*protoast.ProtoMsgStat, err error) {
+	responseMsgNodes := make(map[string]*protoast.ProtoMsgStat)
 
-	responseMsgNodes := make(map[string]*ast.MessageNode)
-
-	if err := filepath.Walk(
+	if err = filepath.Walk(
 		flagRootValue,
 		protoast.ForEachMatchingFileWalkFn(
 			flagFileIncludePatternValue,
 			protoast.NewFindResponseProtosInFileFn(ctx, responseMsgNodes),
 		),
 	); err != nil {
-		return err
+		return nil, err
 	}
 
-	//logger.Debug().Msgf("responseMsgNodes: %+v", responseMsgNodes)
-	for msgName, msgNode := range responseMsgNodes {
+	return responseMsgNodes, nil
+}
+
+// TODO_IN_THIS_COMMIT: move & godoc...
+func groupProtoResponseTypes(responseMsgStats map[string]*protoast.ProtoMsgStat) (
+	validResponseMsgStats,
+	invalidResponseMsgStats map[string]*protoast.ProtoMsgStat,
+) {
+	validResponseMsgStats = make(map[string]*protoast.ProtoMsgStat)
+	invalidResponseMsgStats = make(map[string]*protoast.ProtoMsgStat)
+
+	for msgName, msgStat := range responseMsgStats {
 		var hasField bool
-		ast.Walk(msgNode, func(n ast.Node) (bool, ast.VisitFunc) {
+		protoparseast.Walk(msgStat.Node, func(n protoparseast.Node) (bool, protoparseast.VisitFunc) {
 			if hasField {
 				return false, nil
 			}
 
-			if _, ok := n.(*ast.FieldNode); ok {
+			if _, ok := n.(*protoparseast.FieldNode); ok {
 				hasField = true
 				return false, nil
 			}
@@ -75,27 +97,158 @@ func checkProtoResponseTypes(ctx context.Context) error {
 		})
 
 		if hasField {
-			delete(responseMsgNodes, msgName)
+			validResponseMsgStats[msgName] = msgStat
+		} else {
+			invalidResponseMsgStats[msgName] = msgStat
 		}
 	}
 
-	printCheckResponsesResults(ctx, responseMsgNodes)
-
-	return nil
+	return validResponseMsgStats, invalidResponseMsgStats
 }
 
-func printCheckResponsesResults(ctx context.Context, responseMsgNodes map[string]*ast.MessageNode) {
+// TODO_IN_THIS_COMMIT: move & godoc...
+func printInvalidResponseMsgs(ctx context.Context, responseMsgNodes map[string]*protoast.ProtoMsgStat) {
 	logger := polylog.Ctx(ctx)
 
 	if len(responseMsgNodes) == 0 {
-		logger.Info().Msg("🎉 No offending response messages found! 🎉")
+		logger.Info().Msg("🎉 No offending proto messages found! 🎉")
 		return
 	}
 
-	logger.Info().Msgf("🚨 Found %d offending response messages in %q 🚨",
+	logger.Info().Msgf("🚨 Found %d offending proto messages in %q 🚨",
 		len(responseMsgNodes), flagRootValue,
 	)
-	for msgName, msgNode := range responseMsgNodes {
-		logger.Info().Str("msg_name", msgName).Msg(msgNode.Start().String())
+	for msgName, msgStat := range responseMsgNodes {
+		logger.Info().Str("msg_name", msgName).Msg(msgStat.Node.Start().String())
 	}
+}
+
+// TODO_IN_THIS_COMMIT: move & godoc...
+func checkValidResponseGoUsages(ctx context.Context, responseMsgNodes map[string]*protoast.ProtoMsgStat) error {
+	logger := polylog.Ctx(ctx) //.With("func", "checkValidResponseGoUsages")
+
+	cfg := &packages.Config{
+		Mode:  packages.LoadSyntax,
+		Tests: false,
+	}
+
+	logger.Debug().Msgf("checking %d used resopnse types", len(responseMsgNodes))
+
+	modulePkgs, err := packages.Load(cfg, poktrollMoudlePkgsPattern)
+	if err != nil {
+		return err
+	}
+
+	for msgName, msgStat := range responseMsgNodes {
+		// DEV_NOTE: Assumes that the go pkg path follows the patterh:
+		// `github.com/pokt-network/poktroll/x/<module>/types`
+		goModulePkgPath := filepath.Dir(msgStat.GoPkgPath)
+
+		//logger = logger.With("go_module_pkg_path", goModulePkgPath)
+		//logger.Debug().Send()
+
+		// Look through corresponding keeper package for a selector expression where
+		// the type pkg path of X is equal to the msgStat.GoPkgPath AND the Sel name
+		// matches the msgStat.MsgName.
+		for _, pkg := range modulePkgs {
+			if !strings.HasPrefix(pkg.PkgPath, goModulePkgPath) {
+				continue
+			}
+
+			// TODO_IN_THIS_COMMIT: refactor & reuse NewInspectLastReturnArgFn.
+			// TODO_IN_THIS_COMMIT: refactor & reuse NewInspectLastReturnArgFn.
+			// TODO_IN_THIS_COMMIT: refactor & reuse NewInspectLastReturnArgFn.
+			// TODO_IN_THIS_COMMIT: refactor & reuse NewInspectLastReturnArgFn.
+			// TODO_IN_THIS_COMMIT: refactor & reuse NewInspectLastReturnArgFn.
+
+			// TODO_IN_THIS_COMMIT: extract... BEGIN
+			// TODO_IN_THIS_COMMIT: use inspectFnNodeBody to log position of usages within fnNodeBody.
+			inspectFnNodeBody := func(n goast.Node) bool {
+				if n == nil {
+					return false
+				}
+
+				if sel, ok := n.(*goast.SelectorExpr); ok {
+					if xIdent, ok := sel.X.(*goast.Ident); ok {
+						if sel.Sel.Name == msgName { //&&
+							//xIdent.Name == msgStat.GoPkgPath {
+							//logger.Debug().Msgf("found usage of %s.%s", xIdent.Name, sel.Sel.Name)
+							xIdentPosition := pkg.Fset.Position(xIdent.Pos()).String()
+							logger.Debug().
+								Str("position", fmt.Sprintf(" %s ", xIdentPosition)).
+								Msgf("found usage of %s", msgName)
+							return false
+						}
+						//} else {
+						//	logger.Warn().
+						//		Str("node_type", fmt.Sprintf("%T", n)).
+						//		Str("position", fmt.Sprintf(" %s ", pkg.Fset.Position(n.Pos()).String())).
+						//		Msgf("skipping non ident selector X")
+					}
+					//} else {
+					//	logger.Warn().
+					//		Str("node_type", fmt.Sprintf("%T", n)).
+					//		Str("position", fmt.Sprintf(" %s ", pkg.Fset.Position(n.Pos()).String())).
+					//		Msgf("skipping non selector expression")
+				}
+
+				return true
+			}
+			inspectFirstReturnArgFn := func(fnNode *goast.FuncDecl) bool {
+				fnNodePosition := pkg.Fset.Position(fnNode.Pos())
+
+				if pathMatchesProtobufGenGo(fnNodePosition.Filename) {
+					return false
+				}
+
+				fnPos := pkg.Fset.Position(fnNode.Pos())
+				fnFilename := filepath.Base(fnPos.Filename)
+				if !isNodeReceiverMethod("msgServer", fnNode) &&
+					!strings.HasPrefix(fnFilename, "query_") {
+					return false
+				}
+
+				//logger.Debug().Msgf("inspecting %s", fnNodePosition)
+
+				// Ensure the first return argument matches the msgName.
+				firstResultType := fnNode.Type.Results.List[0].Type
+				// TODO_IN_THIS_COMMIT: investigate consolidating this with TraceExpressionStack.
+				if firstResultTypePtr, ok := firstResultType.(*goast.StarExpr); ok {
+					if firstResultTypeSel, ok := firstResultTypePtr.X.(*goast.SelectorExpr); ok {
+						if firstResultTypeSel.Sel.Name == msgName {
+							//logger.Debug().
+							//	Str("position", fmt.Sprintf(" %s ", fnNodePosition)).
+							//	Msgf("found usage of %s", msgName)
+
+							goast.Inspect(fnNode.Body, inspectFnNodeBody)
+
+							return false
+						}
+					}
+				} else {
+					// TODO_IN_THIS_COMMIT: handle cases where we need to trace the first result type.
+					//logger.Warn().
+					//	Str("node_type", fmt.Sprintf("%T", firstResultType)).
+					//	Msg("skipping")
+
+					//goast2.TraceExpressionStack(ctx, firstResultType, modulePkgs, pkg, fnNode,
+					//	func(ctx context.Context, str string) {
+					//
+					//	},
+					//)
+				}
+
+				return false
+			}
+			// --- END
+
+			inspectReturnStmtFn := newInspectReturnStmtFn(ctx, pkg, inspectFirstReturnArgFn)
+
+			for _, fileNode := range pkg.Syntax {
+				goast.Inspect(fileNode, inspectReturnStmtFn)
+			}
+		}
+	}
+
+	return err
 }

--- a/tools/scripts/protocheck/cmd/check_responses.go
+++ b/tools/scripts/protocheck/cmd/check_responses.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/jhump/protoreflect/desc/protoparse/ast"
+	"github.com/spf13/cobra"
+
+	"github.com/pokt-network/poktroll/pkg/polylog"
+	"github.com/pokt-network/poktroll/tools/scripts/protocheck/protoast"
+)
+
+var (
+	checkResponsesCmd = &cobra.Command{
+		Use:    "responses [flags]",
+		Short:  "Checks that all message responses contain results.",
+		PreRun: setupPrettyLogger,
+		RunE:   runCheckResponses,
+	}
+)
+
+func init() {
+	//checkResponsesCmd.Flags().StringVarP(&flagModuleValue, flagModule, flagModuleShorthand, flagModuleValue, flagModuleUsage)
+	checkResponsesCmd.Flags().StringVarP(&flagRootValue, flagRootName, flagRootShorthand, flagRootValue, flagRootUsage)
+	checkResponsesCmd.Flags().StringVarP(&flagFileIncludePatternValue, flagFileIncludePatternName, flagFileIncludePatternShorthand, flagFileIncludePatternValue, flagFileIncludePatternUsage)
+	checkResponsesCmd.Flags().StringVarP(&flagLogLevelValue, flagLogLevel, flagLogLevelShorthand, flagLogLevelValue, flagLogLevelUsage)
+	rootCmd.AddCommand(checkResponsesCmd)
+}
+
+func runCheckResponses(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	// Check protobuf message types ending in "Response" for at least one field.
+	if err := checkProtoResponseTypes(ctx); err != nil {
+		return err
+	}
+
+	// Check message handler return responses for at least one field assignment.
+	// TODO_IN_THIS_COMMIT: ...
+
+	return nil
+}
+
+// TODO_IN_THIS_COMMIT: move & godoc...
+func checkProtoResponseTypes(ctx context.Context) error {
+	//logger := polylog.Ctx(ctx).With("func", "checkProtoResponseTypes")
+
+	responseMsgNodes := make(map[string]*ast.MessageNode)
+
+	if err := filepath.Walk(
+		flagRootValue,
+		protoast.ForEachMatchingFileWalkFn(
+			flagFileIncludePatternValue,
+			protoast.NewFindResponseProtosInFileFn(ctx, responseMsgNodes),
+		),
+	); err != nil {
+		return err
+	}
+
+	//logger.Debug().Msgf("responseMsgNodes: %+v", responseMsgNodes)
+	for msgName, msgNode := range responseMsgNodes {
+		var hasField bool
+		ast.Walk(msgNode, func(n ast.Node) (bool, ast.VisitFunc) {
+			if hasField {
+				return false, nil
+			}
+
+			if _, ok := n.(*ast.FieldNode); ok {
+				hasField = true
+				return false, nil
+			}
+
+			return true, nil
+		})
+
+		if hasField {
+			delete(responseMsgNodes, msgName)
+		}
+	}
+
+	printCheckResponsesResults(ctx, responseMsgNodes)
+
+	return nil
+}
+
+func printCheckResponsesResults(ctx context.Context, responseMsgNodes map[string]*ast.MessageNode) {
+	logger := polylog.Ctx(ctx)
+
+	if len(responseMsgNodes) == 0 {
+		logger.Info().Msg("🎉 No offending response messages found! 🎉")
+		return
+	}
+
+	logger.Info().Msgf("🚨 Found %d offending response messages in %q 🚨",
+		len(responseMsgNodes), flagRootValue,
+	)
+	for msgName, msgNode := range responseMsgNodes {
+		logger.Info().Str("msg_name", msgName).Msg(msgNode.Start().String())
+	}
+}

--- a/tools/scripts/protocheck/cmd/check_unstable.go
+++ b/tools/scripts/protocheck/cmd/check_unstable.go
@@ -44,7 +44,7 @@ func runUnstable(cmd *cobra.Command, args []string) error {
 		flagRootValue,
 		protoast.ForEachMatchingFileWalkFn(
 			flagFileIncludePatternValue,
-			protoast.FindUnstableProtosInFileFn(ctx, unstableProtoFilesByPath),
+			protoast.NewFindUnstableProtosInFileFn(ctx, unstableProtoFilesByPath),
 		),
 	); pathWalkErr != nil {
 		logger.Error().Err(pathWalkErr)

--- a/tools/scripts/protocheck/goast/trace.go
+++ b/tools/scripts/protocheck/goast/trace.go
@@ -62,7 +62,7 @@ func TraceSelectorExpr(
 
 					if decl, ok := n.(*ast.FuncDecl); ok {
 						if decl.Name.Name == selectionNode.(*ast.Ident).Name &&
-							decl.Pos() < selectionNode.Pos() &&
+							decl.Pos() <= selectionNode.Pos() &&
 							selectionNode.Pos() <= decl.End() {
 							declNode = decl
 							return false
@@ -86,7 +86,7 @@ func TraceSelectorExpr(
 		return true
 	}
 
-	// TODO_IN_THIS_COMMIT: refactor; below happens when the selector is not found within any package.
+	// TODO_IN_THIS_COMMIT: refactor; below happens when the selector is not found within any module package.
 
 	// Resolve the base expression
 	switch x := expr.X.(type) {

--- a/tools/scripts/protocheck/protoast/find.go
+++ b/tools/scripts/protocheck/protoast/find.go
@@ -1,0 +1,209 @@
+package protoast
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jhump/protoreflect/desc/protoparse/ast"
+
+	"github.com/pokt-network/poktroll/pkg/polylog"
+)
+
+const StableMarshalerAllOptName = "(gogoproto.stable_marshaler_all)"
+
+const GogoImportName = "gogoproto/gogo.proto"
+
+// TODO_IN_THIS_COMMIT: godoc...
+func NewFindResponseProtosInFileFn(
+	ctx context.Context,
+	responseMsgNodes map[string]*ast.MessageNode,
+) func(path string) {
+	logger := polylog.Ctx(ctx).With("func", "NewFindResponseProtosInFileFn")
+
+	return func(protoFilePath string) {
+		// Parse the .proto file into file nodes.
+		// NB: MUST use #ParseToAST instead of #ParseFiles to get source positions.
+		protoAST, parseErr := DefaultParser.ParseToAST(protoFilePath)
+		if parseErr != nil {
+			logger.Error().Err(parseErr).Msgf("Unable to parse proto file: %q", protoFilePath)
+		}
+
+		// Iterate through the file nodes and build a protoFileStat for each file.
+		// NB: There should only be one file node per file.
+		for _, fileNode := range protoAST {
+			ast.Walk(fileNode, func(n ast.Node) (bool, ast.VisitFunc) {
+				if msg, ok := n.(*ast.MessageNode); ok {
+					if strings.HasSuffix(msg.Name.Val, "Response") {
+						logger.Debug().Msgf("found response message: %s", msg.Name.Val)
+
+						responseMsgNodes[msg.Name.Val] = msg
+					}
+
+					return false, nil
+				}
+
+				return true, nil
+			})
+		}
+	}
+}
+
+// NewFindUnstableProtosInFileFn returns a function which is expected to be called for
+// each proto file found. The function walks that file's AST and excludes it from
+// the list of unstable files if it contains the stable_marshaler_all option.
+func NewFindUnstableProtosInFileFn(
+	ctx context.Context,
+	unstableProtoFilesByPath map[string]*ProtoFileStat,
+) func(path string) {
+	logger := polylog.Ctx(ctx)
+
+	return func(protoFilePath string) {
+		// Parse the .proto file into file nodes.
+		// NB: MUST use #ParseToAST instead of #ParseFiles to get source positions.
+		protoAST, parseErr := DefaultParser.ParseToAST(protoFilePath)
+		if parseErr != nil {
+			logger.Error().Err(parseErr).Msgf("Unable to parse proto file: %q", protoFilePath)
+		}
+
+		// Iterate through the file nodes and build a protoFileStat for each file.
+		// NB: There should only be one file node per file.
+		for _, fileNode := range protoAST {
+			protoStat := newProtoFileStat(fileNode)
+
+			// Add all proto files to unstableProtoFilePaths by default. If a file
+			// has a stable_marshaler_all option, that file protoFilePath will be
+			// removed from the map when the option is traversed (found).
+			unstableProtoFilesByPath[protoFilePath] = protoStat
+
+			ast.Walk(
+				fileNode,
+				excludeFileIfStableVisitFn(
+					ctx,
+					protoFilePath,
+					unstableProtoFilesByPath,
+				),
+			)
+		}
+	}
+}
+
+// excludeStableMarshalersVisitFn returns an ast.VisitFunc which removes proto files
+// from unstableProtoFilesByPath if they contain the stable_marshaler_all option, and
+// it is set to true.
+func excludeFileIfStableVisitFn(
+	ctx context.Context,
+	protoFilePath string,
+	unstableProtoFilesByPath map[string]*ProtoFileStat,
+) ast.VisitFunc {
+	logger := polylog.Ctx(ctx)
+
+	return func(n ast.Node) (bool, ast.VisitFunc) {
+		optNode, optNodeOk := n.(*ast.OptionNode)
+		if !optNodeOk {
+			return true, nil
+		}
+
+		optSrc := optNode.Start()
+
+		optName, optNameOk := getOptNodeName(optNode)
+		if !optNameOk {
+			logger.Warn().Msgf(
+				"unable to extract option name from option node at %s:%d:%d",
+				protoFilePath, optSrc.Line, optSrc.Col,
+			)
+			return true, nil
+		}
+
+		if optName != StableMarshalerAllOptName {
+			// Not the option we're looking for, continue traversing...
+			return true, nil
+		}
+
+		optValueNode := optNode.GetValue().Value()
+		optValue, ok := optValueNode.(ast.Identifier)
+		if !ok {
+			logger.Error().Msgf(
+				"unable to cast option value to ast.Identifier for option %q, got: %T at %s:%d:%d",
+				optName, optValueNode, protoFilePath, optSrc.Line, optSrc.Col,
+			)
+			return true, nil
+		}
+
+		if optValue != "true" {
+			// Not the value we're looking for, continue traversing...
+			logger.Warn().Msgf(
+				"discovered an unstable_marshaler_all option with unexpected value %q at %s:%d:%d",
+				optValue, protoFilePath, optSrc.Line, optSrc.Col,
+			)
+			return true, nil
+		}
+
+		// Remove stable proto file from unstableProtoFilesByPath.
+		delete(unstableProtoFilesByPath, protoFilePath)
+
+		// Stop traversing the AST after finding the stable_marshaler_all option.
+		// We only expect one stable_marshaler_all option per file.
+		return false, nil
+	}
+}
+
+// getOptNodeName returns the name of the option node as a string and a boolean
+// indicating whether the name was successfully extracted.
+func getOptNodeName(optNode *ast.OptionNode) (optName string, ok bool) {
+	optNameNode, optNameNodeOk := optNode.GetName().(*ast.OptionNameNode)
+	if !optNameNodeOk {
+		return "", false
+	}
+
+	if len(optNameNode.Parts) < 1 {
+		return "", false
+	}
+
+	for i, optNamePart := range optNameNode.Parts {
+		// Only insert delimiters if there is more than one part.
+		if i > 0 {
+			optName += "."
+		}
+		optName += optNamePart.Value()
+	}
+
+	return optName, true
+}
+
+// TODO_IN_THIS_COMMIT: godoc...
+func newProtoFileStat(fileNode *ast.FileNode) *ProtoFileStat {
+	var (
+		pkgNode         *ast.PackageNode
+		lastOptionNode  *ast.OptionNode
+		lastImportNode  *ast.ImportNode
+		foundGogoImport bool
+	)
+
+	for _, n := range fileNode.Children() {
+		switch node := n.(type) {
+		case *ast.PackageNode:
+			pkgNode = node
+		case *ast.ImportNode:
+			lastImportNode = node
+
+			if node.Name.AsString() == GogoImportName {
+				foundGogoImport = true
+			}
+		case *ast.OptionNode:
+			lastOptionNode = node
+		}
+	}
+
+	protoStat := &ProtoFileStat{
+		PkgSource:     pkgNode.Start(),
+		HasGogoImport: foundGogoImport,
+	}
+	if lastOptionNode != nil {
+		protoStat.LastOptSource = lastOptionNode.Start()
+	}
+	if lastImportNode != nil {
+		protoStat.LastImportSource = lastImportNode.Start()
+	}
+
+	return protoStat
+}

--- a/tools/scripts/protocheck/protoast/modify.go
+++ b/tools/scripts/protocheck/protoast/modify.go
@@ -1,0 +1,119 @@
+package protoast
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const expectedStableMarshalerAllOptionValue = "true"
+
+var (
+	stableMarshalerAllOptionSource = fmt.Sprintf(`option %s = %s;`, StableMarshalerAllOptName, expectedStableMarshalerAllOptionValue)
+	gogoImportSource               = fmt.Sprintf(`import "%s";`, GogoImportName)
+)
+
+// TODO_IN_THIS_COMMIT: godoc...
+func InsertStableMarshalerAllOption(protoFilePath string, protoFile *ProtoFileStat) (err error) {
+	var (
+		importInsertLine,
+		importInsertCol,
+		optionInsertLine,
+		optionInsertCol,
+		numInsertedLines int
+
+		optionLine = stableMarshalerAllOptionSource
+		importLine = gogoImportSource
+	)
+
+	if protoFile.LastOptSource == nil {
+		optionInsertLine = protoFile.PkgSource.Line + 1
+		optionInsertCol = protoFile.PkgSource.Col
+		optionLine += "\n"
+		numInsertedLines += 2
+	} else {
+		optionInsertLine = protoFile.LastOptSource.Line
+		optionInsertCol = protoFile.LastOptSource.Col
+		numInsertedLines++
+	}
+
+	if err = insertLine(
+		protoFilePath,
+		optionInsertLine,
+		optionInsertCol,
+		optionLine,
+	); err != nil {
+		return err
+	}
+
+	if protoFile.HasGogoImport {
+		return nil
+	}
+
+	if protoFile.LastImportSource == nil {
+		importInsertLine = optionInsertLine + 1 + numInsertedLines
+		importInsertCol = optionInsertCol
+		importLine += "\n"
+	} else {
+		importInsertLine = protoFile.LastImportSource.Line + numInsertedLines
+		importInsertCol = protoFile.LastImportSource.Col
+	}
+
+	return insertLine(
+		protoFilePath,
+		importInsertLine,
+		importInsertCol,
+		importLine,
+	)
+}
+
+// TODO_IN_THIS_COMMIT: godoc...
+func insertLine(filePath string, lineNumber int, columnNumber int, textToInsert string) error {
+	// Open the file for reading
+	file, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Read the file into a slice of strings (each string is a line)
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err = scanner.Err(); err != nil {
+		return err
+	}
+
+	// Check if the line number is within the range of lines in the file
+	if lineNumber < 1 || lineNumber > len(lines) {
+		return fmt.Errorf("line number %d is out of range", lineNumber)
+	}
+
+	// Create the new line with the specified amount of leading whitespace
+	whitespace := strings.Repeat(" ", columnNumber-1)
+	newLine := whitespace + textToInsert
+
+	// Insert the new line after the specified line
+	lineIndex := lineNumber - 1
+	lines = append(lines[:lineIndex+1], append([]string{newLine}, lines[lineIndex+1:]...)...)
+
+	// Open the file for writing
+	file, err = os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Write the modified lines back to the file
+	writer := bufio.NewWriter(file)
+	for _, line := range lines {
+		_, err := writer.WriteString(line + "\n")
+		if err != nil {
+			return err
+		}
+	}
+	return writer.Flush()
+}

--- a/tools/scripts/protocheck/protoast/types.go
+++ b/tools/scripts/protocheck/protoast/types.go
@@ -1,0 +1,19 @@
+package protoast
+
+import (
+	"github.com/jhump/protoreflect/desc/protoparse"
+	"github.com/jhump/protoreflect/desc/protoparse/ast"
+)
+
+// TODO_IN_THIS_COMMIT: godoc...
+type ProtoFileStat struct {
+	PkgSource        *ast.SourcePos
+	LastOptSource    *ast.SourcePos
+	LastImportSource *ast.SourcePos
+	HasGogoImport    bool
+}
+
+// TODO_IN_THIS_COMMIT: godoc...
+var DefaultParser = protoparse.Parser{
+	IncludeSourceCodeInfo: true,
+}

--- a/tools/scripts/protocheck/protoast/types.go
+++ b/tools/scripts/protocheck/protoast/types.go
@@ -14,6 +14,12 @@ type ProtoFileStat struct {
 }
 
 // TODO_IN_THIS_COMMIT: godoc...
+type ProtoMsgStat struct {
+	Node      *ast.MessageNode
+	GoPkgPath string
+}
+
+// TODO_IN_THIS_COMMIT: godoc...
 var DefaultParser = protoparse.Parser{
 	IncludeSourceCodeInfo: true,
 }

--- a/tools/scripts/protocheck/protoast/walk.go
+++ b/tools/scripts/protocheck/protoast/walk.go
@@ -1,0 +1,35 @@
+package protoast
+
+import (
+	"io/fs"
+	"path/filepath"
+)
+
+// ForEachMatchingFileWalkFn returns a filepath.WalkFunc which does the following:
+// 1. Iterates over files matching fileNamePattern against each file name.
+// 2. For matching files, it calls fileMatchedFn with the respective path.
+func ForEachMatchingFileWalkFn(
+	fileNamePattern string,
+	fileMatchedFn func(path string),
+) filepath.WalkFunc {
+	return func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Ignore directories
+		if info.IsDir() {
+			return nil
+		}
+
+		matched, matchErr := filepath.Match(fileNamePattern, info.Name())
+		if matchErr != nil {
+			return matchErr
+		}
+
+		if matched {
+			fileMatchedFn(path)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary

Adds a status-errors subcommand to protocheck which identifies `msgServer` methods and query handlers which don't return gRPC status error codes:

![image](https://github.com/user-attachments/assets/dd3a845b-3887-4003-8f11-2b31a6fe3c3f)

## Issue

- #663

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
