### PR TITLE
[Bug, Tooling] fix: app/gateway/supplier stake/unstake make targets

### DIFF
--- a/localnet/poktrolld/config/application1_stake_config.yaml
+++ b/localnet/poktrolld/config/application1_stake_config.yaml
@@ -1,5 +1,3 @@
-stake_amount: 1000069upokt
+stake_amount: 100000068upokt
 service_ids:
   - anvil
-  - svc1
-  - svc2

--- a/localnet/poktrolld/config/application2_stake_config.yaml
+++ b/localnet/poktrolld/config/application2_stake_config.yaml
@@ -1,5 +1,3 @@
-stake_amount: 1000070upokt
+stake_amount: 100000069upokt
 service_ids:
-  - anvil
-  - svc2
-  - svc3
+  - rest

--- a/localnet/poktrolld/config/application3_stake_config.yaml
+++ b/localnet/poktrolld/config/application3_stake_config.yaml
@@ -1,5 +1,3 @@
-stake_amount: 1000071upokt
+stake_amount: 100000070upokt
 service_ids:
   - anvil
-  - svc3
-  - svc4

--- a/localnet/poktrolld/config/gateway1_stake_config.yaml
+++ b/localnet/poktrolld/config/gateway1_stake_config.yaml
@@ -1,1 +1,1 @@
-stake_amount: 1000069upokt
+stake_amount: 100000068upokt

--- a/localnet/poktrolld/config/gateway2_stake_config.yaml
+++ b/localnet/poktrolld/config/gateway2_stake_config.yaml
@@ -1,1 +1,1 @@
-stake_amount: 10070upokt
+stake_amount: 100000069upokt

--- a/localnet/poktrolld/config/gateway3_stake_config.yaml
+++ b/localnet/poktrolld/config/gateway3_stake_config.yaml
@@ -1,1 +1,1 @@
-stake_amount: 10071upokt
+stake_amount: 100000070upokt

--- a/makefiles/suppliers.mk
+++ b/makefiles/suppliers.mk
@@ -24,7 +24,7 @@ supplier3_stake: ## Stake supplier3
 
 .PHONY: supplier_unstake
 supplier_unstake: ## Unstake an supplier (must specify the SUPPLIER env var)
-	poktrolld --home=$(POKTROLLD_HOME) tx supplier unstake-supplier $(SUPPLIER) --keyring-backend test --from $(SUPPLIER) --node $(POCKET_NODE)
+	poktrolld --home=$(POKTROLLD_HOME) tx supplier unstake-supplier $(SUPPLIER) -y --keyring-backend test --from $(SUPPLIER) --node $(POCKET_NODE)
 
 .PHONY: supplier1_unstake
 supplier1_unstake: ## Unstake supplier1


### PR DESCRIPTION
## Summary

1. The supplier unstaking make targets are missing `-y` which bypass the tx confirmation prompt
2. The application stake configs used by the application staking make targets are out of date and invalid; they may only contain one service and require a stake amount above the minimun.
3. The gateway stake configs used by the gateway staking make targets are out of date and invalid; they require a stake amount above the minimun.

## Issue

- #N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
