### PR TITLE
chore: add localnet_config option to disable hot-reloading

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -26,6 +26,7 @@ def merge_dicts(base, updates):
 #            environment is not broken for future engineers.
 localnet_config_path = "localnet_config.yaml"
 localnet_config_defaults = {
+    "hot-reloading": True,
     "validator": {
         "cleanupBeforeEachStart": True,
         "logs": {
@@ -182,29 +183,30 @@ secret_create_generic(
 # Import configuration files into Kubernetes ConfigMap
 configmap_create("poktrolld-configs", from_file=listdir("localnet/poktrolld/config/"), watch=True)
 
-# Hot reload protobuf changes
-local_resource(
-    "hot-reload: generate protobufs",
-    "make proto_regen",
-    deps=["proto"],
-    labels=["hot-reloading"],
-)
-# Hot reload the poktrolld binary used by the k8s cluster
-local_resource(
-    "hot-reload: poktrolld",
-    "GOOS=linux ignite chain build --skip-proto --output=./bin --debug -v",
-    deps=hot_reload_dirs,
-    labels=["hot-reloading"],
-    resource_deps=["hot-reload: generate protobufs"],
-)
-# Hot reload the local poktrolld binary used by the CLI
-local_resource(
-    "hot-reload: poktrolld - local cli",
-    "ignite chain build --skip-proto --debug -v -o $(go env GOPATH)/bin",
-    deps=hot_reload_dirs,
-    labels=["hot-reloading"],
-    resource_deps=["hot-reload: generate protobufs"],
-)
+if localnet_config["hot-reloading"]:
+    # Hot reload protobuf changes
+    local_resource(
+        "hot-reload: generate protobufs",
+        "make proto_regen",
+        deps=["proto"],
+        labels=["hot-reloading"],
+    )
+    # Hot reload the poktrolld binary used by the k8s cluster
+    local_resource(
+        "hot-reload: poktrolld",
+        "GOOS=linux ignite chain build --skip-proto --output=./bin --debug -v",
+        deps=hot_reload_dirs,
+        labels=["hot-reloading"],
+        resource_deps=["hot-reload: generate protobufs"],
+    )
+    # Hot reload the local poktrolld binary used by the CLI
+    local_resource(
+        "hot-reload: poktrolld - local cli",
+        "ignite chain build --skip-proto --debug -v -o $(go env GOPATH)/bin",
+        deps=hot_reload_dirs,
+        labels=["hot-reloading"],
+        resource_deps=["hot-reload: generate protobufs"],
+    )
 
 # Build an image with a poktrolld binary
 docker_build_with_restart(


### PR DESCRIPTION
## Summary

Add a top-level `hot-reloading` boolean field to `localnet_config.yaml` in order to support easier disabling hot-reload.

## Issue

There are times where hot-reloading is not desireable. In these instances, in the absence of such a config option, it takes 6 button clicks in the UI to accomplish the same result.

- #N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
