### PR TITLE
[Bug, Testing] fix: app transfer module-integration test

### DIFF
--- a/tests/integration/application/application_transfer_test.go
+++ b/tests/integration/application/application_transfer_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package application
 
 import (
@@ -20,7 +18,7 @@ import (
 
 var (
 	appFundAmount = int64(100000000)
-	stakeAmount   = int64(100)
+	stakeAmount   = int64(10000000)
 
 	service1Id = "svc1"
 	service2Id = "svc2"
@@ -66,8 +64,8 @@ func (s *appTransferTestSuite) SetupTest() {
 
 	// Stake app1 and app2.
 	s.setupStakeApps(map[string][]string{
-		s.app1: {service1Id, service3Id},
-		s.app2: {service1Id, service2Id},
+		s.app1: {service1Id},
+		s.app2: {service2Id},
 	})
 
 	// Delegate app 1 to gateway 1 and 3 and app 2 to gateways 1 and 2.
@@ -299,7 +297,6 @@ func (s *appTransferTestSuite) TestMultipleSourceToSameNonexistentDestinationMer
 	expectedApp3ServiceIds := []string{
 		service1Id,
 		service2Id,
-		service3Id,
 	}
 	for _, serviceId := range expectedApp3ServiceIds {
 		require.Contains(s.T(),
@@ -477,11 +474,15 @@ func (s *appTransferTestSuite) shouldObserveTransferEndEvent(
 			return false
 		}
 
-		eventSrcAddr, hasSrcAddr := events.GetAttributeValue(event, "source_address")
+		_, hasSrcAddr := events.GetAttributeValue(event, "source_address")
 		require.True(s.T(), hasSrcAddr)
 
-		return eventSrcAddr == expectedDstApp.GetAddress()
+		eventDstAddr, hasDstAddr := events.GetAttributeValue(event, "destination_address")
+		require.True(s.T(), hasDstAddr)
+
+		return eventDstAddr == expectedDstApp.GetAddress()
 	})
+
 	require.NotNil(s.T(), targetTransferEndEvent)
 
 	evtSrcAddr, hasSrcAddrAttr := events.GetAttributeValue(targetTransferEndEvent, "source_address")

--- a/tests/integration/application/application_transfer_test.go
+++ b/tests/integration/application/application_transfer_test.go
@@ -22,7 +22,6 @@ var (
 
 	service1Id = "svc1"
 	service2Id = "svc2"
-	service3Id = "svc3"
 )
 
 type appTransferTestSuite struct {
@@ -229,8 +228,8 @@ func (s *appTransferTestSuite) TestMultipleSourceToSameNonexistentDestinationMer
 		require.EqualValues(s.T(), expectedPendingTransfer, pendingTransfer)
 
 		// Query and assert application pending transfer field updated in the store.
-		foundSrcApp, err := s.GetAppQueryClient().GetApplication(s.SdkCtx(), expectedSrcBech32)
-		require.NoError(s.T(), err)
+		foundSrcApp, srcAppErr := s.GetAppQueryClient().GetApplication(s.SdkCtx(), expectedSrcBech32)
+		require.NoError(s.T(), srcAppErr)
 		require.EqualValues(s.T(), expectedPendingTransfer, foundSrcApp.GetPendingTransfer())
 
 		// Assert that the "message" type event (tx result event) is observed which

--- a/testutil/integration/suites/application.go
+++ b/testutil/integration/suites/application.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package suites
 
 import (

--- a/testutil/integration/suites/gateway.go
+++ b/testutil/integration/suites/gateway.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package suites
 
 import (


### PR DESCRIPTION
## Summary

Remove problematic build constraint from app transfer test and dependencies.

## Issue

A `//go:build integration` constraint was unintentionally left in a few files related to app transfer module-integration tests, causing them to be skipped in CI. As a result, they've fallen out of date.

- #N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
