### PR TITLE
[Docs] Fix PATH config file location

### DIFF
--- a/docusaurus/docs/operate/quickstart/gateway_cheatsheet.md
+++ b/docusaurus/docs/operate/quickstart/gateway_cheatsheet.md
@@ -219,7 +219,7 @@ Refer to [PATH Gateway modes](https://path.grove.city/) for more configuration o
 
 :::
 
-Run the following command to generate a default Shannon config `cmd/.config.yaml`:
+Run the following command to generate a default Shannon config `config/.config.yaml`:
 
 _NOTE: You'll be prompted to confirm the `gateway` account private key export._
 
@@ -228,27 +228,27 @@ _NOTE: You'll be prompted to confirm the `gateway` account private key export._
 make copy_shannon_config
 
 # Replace the endpoints as needed
-sed -i "s|rpc_url: ".*"|rpc_url: $NODE|" cmd/.config.yaml
-sed -i "s|host_port: ".*"|host_port: shannon-testnet-grove-grpc.beta.poktroll.com:443|" cmd/.config.yaml
+sed -i "s|rpc_url: ".*"|rpc_url: $NODE|" config/.config.yaml
+sed -i "s|host_port: ".*"|host_port: shannon-testnet-grove-grpc.beta.poktroll.com:443|" config/.config.yaml
 
 # Update the gateway and application addresses
-sed -i "s|gateway_address: .*|gateway_address: $GATEWAY_ADDR|" cmd/.config.yaml
-sed -i "s|gateway_private_key_hex: .*|gateway_private_key_hex: $(poktrolld keys export gateway --unsafe --unarmored-hex)|" cmd/.config.yaml
-sed -i '/owned_apps_private_keys_hex:/!b;n;c\      - '"$(poktrolld keys export application --unsafe --unarmored-hex)" cmd/.config.yaml
+sed -i "s|gateway_address: .*|gateway_address: $GATEWAY_ADDR|" config/.config.yaml
+sed -i "s|gateway_private_key_hex: .*|gateway_private_key_hex: $(poktrolld keys export gateway --unsafe --unarmored-hex)|" config/.config.yaml
+sed -i '/owned_apps_private_keys_hex:/!b;n;c\      - '"$(poktrolld keys export application --unsafe --unarmored-hex)" config/.config.yaml
 
 # If you're using the test keyring-backend:
-# sed -i "s|gateway_private_key_hex: .*|gateway_private_key_hex: $(poktrolld keys export gateway --unsafe --unarmored-hex --keyring-backend test)|" cmd/.config.yaml
-# sed -i '/owned_apps_private_keys_hex:/!b;n;c\      - '"$(poktrolld keys export application --unsafe --unarmored-hex --keyring-backend test)" cmd/.config.yaml
+# sed -i "s|gateway_private_key_hex: .*|gateway_private_key_hex: $(poktrolld keys export gateway --unsafe --unarmored-hex --keyring-backend test)|" config/.config.yaml
+# sed -i '/owned_apps_private_keys_hex:/!b;n;c\      - '"$(poktrolld keys export application --unsafe --unarmored-hex --keyring-backend test)" config/.config.yaml
 ```
 
-When you're done, run `cat cmd/.config.yaml` to view the updated config file.
+When you're done, run `cat config/.config.yaml` to view the updated config file.
 
 ### Run the `PATH` Gateway
 
 #### Build and run the `PATH` Gateway from source
 
 ```bash
-cd cmd/ && go build -o path . && ./path
+go build -o ./path ./cmd
 ```
 
 You should see the following output:


### PR DESCRIPTION
## Summary

This PR includes updates to the `docusaurus/docs/operate/quickstart/gateway_cheatsheet.md` file to correct the configuration file path and improve the instructions for setting up the Shannon configuration.

Documentation updates:

* Changed the path for generating a default Shannon config from `cmd/.config.yaml` to `config/.config.yaml`.
* Updated `sed` commands to reflect the new configuration file path `config/.config.yaml` instead of `cmd/.config.yaml`.
* Adjusted the build and run instructions for the `PATH` Gateway to use a more direct build command.

## Issue

PATH changed its config file location from `cmd/` to `config/` directory which needs to be reflected in the `gateway_cheatsheet` documentation.

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Testing

- [x] **Documentation**: `make docusaurus_start`; only needed if you make doc changes

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [ ] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
