### PR TITLE
[Off-Chain, Scalability] Query client caching & history

### DIFF
--- a/pkg/client/block/client.go
+++ b/pkg/client/block/client.go
@@ -187,6 +187,12 @@ func (b *blockReplayClient) queryLatestBlock(
 	errCh := make(chan error)
 
 	go func() {
+		// TODO_IN_THIS_COMMIT: extract labels (and values?) to constants.
+		defer client.AllQueriesTotalCounter.With(
+			"method", "block",
+			"client_type", "block",
+		).Add(1)
+
 		queryBlockResult, err := b.onStartQueryClient.Block(ctx, nil)
 		if err != nil {
 			errCh <- err

--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -destination=../../testutil/mockgrpc/grpc_conn_mock.go -package=mockgrpc github.com/cosmos/gogoproto/grpc ClientConn
 //go:generate mockgen -destination=../../testutil/mockclient/events_query_client_mock.go -package=mockclient . Dialer,Connection,EventsQueryClient
 //go:generate mockgen -destination=../../testutil/mockclient/block_client_mock.go -package=mockclient . Block,BlockClient
 //go:generate mockgen -destination=../../testutil/mockclient/delegation_client_mock.go -package=mockclient . DelegationClient
@@ -359,4 +360,21 @@ type ServiceQueryClient interface {
 type BankQueryClient interface {
 	// GetBalance queries the chain for the uPOKT balance of the account provided
 	GetBalance(ctx context.Context, address string) (*cosmostypes.Coin, error)
+}
+
+// QueryCache handles a single type of cached data
+type QueryCache[T any] interface {
+	Get(key string) (T, error)
+	Set(key string, value T) error
+	Delete(key string)
+	Clear()
+}
+
+// HistoricalQueryCache extends QueryCache to support historical values at different heights
+type HistoricalQueryCache[T any] interface {
+	QueryCache[T]
+	// GetAtHeight retrieves the nearest value <= the specified height
+	GetAtHeight(key string, height int64) (T, error)
+	// SetAtHeight adds or updates a value at a specific height
+	SetAtHeight(key string, value T, height int64) error
 }

--- a/pkg/client/query/appquerier.go
+++ b/pkg/client/query/appquerier.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	"cosmossdk.io/depinject"
-	grpc "github.com/cosmos/gogoproto/grpc"
+	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+	accounttypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/gogoproto/grpc"
 
 	"github.com/pokt-network/poktroll/pkg/client"
 	apptypes "github.com/pokt-network/poktroll/x/application/types"
@@ -45,6 +47,12 @@ func (aq *appQuerier) GetApplication(
 	ctx context.Context,
 	appAddress string,
 ) (apptypes.Application, error) {
+	defer client.AllQueriesTotalCounter.With(
+		"method", "account",
+		"client_type", "account",
+		"msg_type", cosmostypes.MsgTypeURL(new(accounttypes.QueryAccountRequest)),
+	).Add(1)
+
 	req := apptypes.QueryGetApplicationRequest{Address: appAddress}
 	res, err := aq.applicationQuerier.Application(ctx, &req)
 	if err != nil {

--- a/pkg/client/query/cache/badger.go
+++ b/pkg/client/query/cache/badger.go
@@ -1,0 +1,15 @@
+package cache
+
+import (
+	"github.com/dgraph-io/badger/v2"
+)
+
+// TODO_UP_NEXT(@bryanchriswhite): Implement a persistent cache using badger.
+//
+// var _ query.QueryCache[any] = (*BadgerCache[any])(nil)
+
+// BadgerCache is a persistent cache backed by a badger database.
+type BadgerCache[T any] struct {
+	db     *badger.DB
+	config CacheConfig
+}

--- a/pkg/client/query/cache/config.go
+++ b/pkg/client/query/cache/config.go
@@ -1,0 +1,74 @@
+package cache
+
+import (
+	"time"
+)
+
+// EvictionPolicy determines how items are removed when cache is full
+type EvictionPolicy string
+
+// TODO_IN_THIS_COMMIT: refactor to an enum.
+const (
+	LeastRecentlyUsed   EvictionPolicy = "LEAST_RECENTLY_USED"
+	LeastFrequentlyUsed EvictionPolicy = "LEAST_FREQUENTLY_USED"
+	FirstInFirstOut     EvictionPolicy = "FIRST_IN_FIRST_OUT"
+)
+
+// CacheConfig is the configuration options for a cache.
+type CacheConfig struct {
+	// MaxSize is the maximum number of items the cache can hold.
+	MaxSize int64
+	// EvictionPolicy is how items should be removed when the cache is full.
+	EvictionPolicy EvictionPolicy
+	// TTL is how long items should remain in the cache
+	TTL time.Duration
+
+	// historical is whether the cache will cache a single value for each key
+	// (false) or whether it will cache a history of values for each key (true).
+	historical bool
+	// TODO_IN_THIS_COMMIT: godoc...
+	pruneOlderThan int64
+}
+
+// CacheOption defines a function that configures a CacheConfig
+type CacheOption func(*CacheConfig)
+
+// HistoricalCacheConfig extends the basic CacheConfig with historical settings.
+type HistoricalCacheConfig struct {
+	CacheConfig
+
+	// MaxHeightsPerKey is the maximum number of different heights to store per key
+	MaxHeightsPerKey int
+	// PruneOlderThan specifies how many blocks back to maintain in history
+	// If 0, no historical pruning is performed
+	PruneOlderThan int64
+}
+
+// WithHistoricalMode enables historical caching with the specified configuration
+func WithHistoricalMode(pruneOlderThan int64) CacheOption {
+	return func(cfg *CacheConfig) {
+		cfg.historical = true
+		cfg.pruneOlderThan = pruneOlderThan
+	}
+}
+
+// WithMaxSize sets the maximum size of the cache
+func WithMaxSize(size int64) CacheOption {
+	return func(cfg *CacheConfig) {
+		cfg.MaxSize = size
+	}
+}
+
+// WithEvictionPolicy sets the eviction policy
+func WithEvictionPolicy(policy EvictionPolicy) CacheOption {
+	return func(cfg *CacheConfig) {
+		cfg.EvictionPolicy = policy
+	}
+}
+
+// WithTTL sets the time-to-live for cache entries
+func WithTTL(ttl time.Duration) CacheOption {
+	return func(cfg *CacheConfig) {
+		cfg.TTL = ttl
+	}
+}

--- a/pkg/client/query/cache/errors.go
+++ b/pkg/client/query/cache/errors.go
@@ -1,0 +1,11 @@
+package cache
+
+import "cosmossdk.io/errors"
+
+const codesace = "client/query/cache"
+
+var (
+	// TODO_IN_THIS_COMMIT: godoc...
+	ErrCacheMiss                = errors.Register(codesace, 1, "cache miss")
+	ErrHistoricalModeNotEnabled = errors.Register(codesace, 2, "historical mode not enabled")
+)

--- a/pkg/client/query/cache/memory.go
+++ b/pkg/client/query/cache/memory.go
@@ -1,0 +1,279 @@
+package cache
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pokt-network/poktroll/pkg/client"
+)
+
+var (
+	_ client.QueryCache[any]           = (*InMemoryCache[any])(nil)
+	_ client.HistoricalQueryCache[any] = (*InMemoryCache[any])(nil)
+)
+
+// InMemoryCache provides a concurrency-safe in-memory cache implementation with
+// optional historical value support.
+type InMemoryCache[T any] struct {
+	config       CacheConfig
+	latestHeight atomic.Int64
+
+	itemsMu sync.RWMutex
+	// items type depends on historical mode:
+	// | historical mode |  type                                   |
+	// | --------------- | --------------------------------------- |
+	// | false           | map[string]cacheItem[T]                 |
+	// | true            | map[string]map[int64]heightCacheItem[T] |
+	items map[string]any
+}
+
+// cacheItem wraps cached values with metadata
+type cacheItem[T any] struct {
+	value     T
+	timestamp time.Time
+}
+
+// heightCacheItem is used when the cache is in historical mode
+type heightCacheItem[T any] struct {
+	value     T
+	timestamp time.Time
+}
+
+// NewInMemoryCache creates a new cache with the given configuration
+func NewInMemoryCache[T any](opts ...CacheOption) *InMemoryCache[T] {
+	config := CacheConfig{
+		EvictionPolicy: FirstInFirstOut,
+	}
+
+	for _, opt := range opts {
+		opt(&config)
+	}
+
+	return &InMemoryCache[T]{
+		items:  make(map[string]interface{}),
+		config: config,
+	}
+}
+
+// Get retrieves an item from the cache
+func (c *InMemoryCache[T]) Get(key string) (T, error) {
+	if c.config.historical {
+		return c.GetAtHeight(key, c.latestHeight.Load())
+	}
+
+	c.itemsMu.RLock()
+	defer c.itemsMu.RUnlock()
+
+	var zero T
+
+	item, exists := c.items[key]
+	if !exists {
+		return zero, ErrCacheMiss
+	}
+
+	cItem := item.(cacheItem[T])
+	if c.config.TTL > 0 && time.Since(cItem.timestamp) > c.config.TTL {
+		// TODO_QUESTION: should we prune here?
+		return zero, ErrCacheMiss
+	}
+
+	return cItem.value, nil
+}
+
+// GetAtHeight retrieves an item from the cache at or before the specified height
+func (c *InMemoryCache[T]) GetAtHeight(key string, height int64) (T, error) {
+	var zero T
+
+	if !c.config.historical {
+		return zero, ErrHistoricalModeNotEnabled
+	}
+
+	c.itemsMu.RLock()
+	defer c.itemsMu.RUnlock()
+
+	heightMap, exists := c.items[key]
+	if !exists {
+		return zero, ErrCacheMiss
+	}
+
+	versions := heightMap.(map[int64]heightCacheItem[T])
+	var nearestHeight int64 = -1
+	for h := range versions {
+		if h <= height && h > nearestHeight {
+			nearestHeight = h
+		}
+	}
+
+	if nearestHeight == -1 {
+		return zero, ErrCacheMiss
+	}
+
+	item := versions[nearestHeight]
+	if c.config.TTL > 0 && time.Since(item.timestamp) > c.config.TTL {
+		return zero, ErrCacheMiss
+	}
+
+	return item.value, nil
+}
+
+// Set adds or updates an item in the cache
+func (c *InMemoryCache[T]) Set(key string, value T) error {
+	if c.config.historical {
+		return c.SetAtHeight(key, value, c.latestHeight.Load())
+	}
+
+	if c.config.MaxSize > 0 && int64(len(c.items)) >= c.config.MaxSize {
+		c.evict()
+	}
+
+	c.itemsMu.Lock()
+	defer c.itemsMu.Unlock()
+
+	c.items[key] = cacheItem[T]{
+		value:     value,
+		timestamp: time.Now(),
+	}
+
+	return nil
+}
+
+// SetAtHeight adds or updates an item in the cache at a specific height
+func (c *InMemoryCache[T]) SetAtHeight(key string, value T, height int64) error {
+	if !c.config.historical {
+		return ErrHistoricalModeNotEnabled
+	}
+
+	// Update latest height if this is newer
+	latestHeight := c.latestHeight.Load()
+	if height > latestHeight {
+		// NB: Only update if c.latestHeight hasn't changed since we loaded it above.
+		c.latestHeight.CompareAndSwap(latestHeight, height)
+	}
+
+	c.itemsMu.Lock()
+	defer c.itemsMu.Unlock()
+
+	var history map[int64]heightCacheItem[T]
+	if existing, exists := c.items[key]; exists {
+		history = existing.(map[int64]heightCacheItem[T])
+	} else {
+		history = make(map[int64]heightCacheItem[T])
+		c.items[key] = history
+	}
+
+	// Prune old heights if configured
+	if c.config.pruneOlderThan > 0 {
+		for h := range history {
+			if height-h > c.config.pruneOlderThan {
+				delete(history, h)
+			}
+		}
+	}
+
+	history[height] = heightCacheItem[T]{
+		value:     value,
+		timestamp: time.Now(),
+	}
+
+	return nil
+}
+
+// Delete removes an item from the cache.
+func (c *InMemoryCache[T]) Delete(key string) {
+	c.itemsMu.Lock()
+	defer c.itemsMu.Unlock()
+
+	delete(c.items, key)
+}
+
+// Clear removes all items from the cache
+func (c *InMemoryCache[T]) Clear() {
+	c.itemsMu.Lock()
+	defer c.itemsMu.Unlock()
+
+	c.items = make(map[string]interface{})
+	c.latestHeight.Store(0)
+}
+
+// evict removes one item according to the configured eviction policy
+func (c *InMemoryCache[T]) evict() {
+	switch c.config.EvictionPolicy {
+	case FirstInFirstOut:
+		var oldestKey string
+		var oldestTime time.Time
+		first := true
+
+		for key, item := range c.items {
+			var itemTime time.Time
+			if c.config.historical {
+				versions := item.(map[int64]heightCacheItem[T])
+				for _, v := range versions {
+					if itemTime.IsZero() || v.timestamp.Before(itemTime) {
+						itemTime = v.timestamp
+					}
+				}
+			} else {
+				itemTime = item.(cacheItem[T]).timestamp
+			}
+
+			if first || itemTime.Before(oldestTime) {
+				oldestKey = key
+				oldestTime = itemTime
+				first = false
+			}
+		}
+		delete(c.items, oldestKey)
+
+	case LeastRecentlyUsed:
+		// TODO: Implement LRU eviction
+		// This will require tracking access times
+		panic("LRU eviction not implemented")
+
+	case LeastFrequentlyUsed:
+		// TODO: Implement LFU eviction
+		// This will require tracking access times
+		panic("LFU eviction not implemented")
+
+	default:
+		// Default to FIFO if policy not recognized
+		for key := range c.items {
+			delete(c.items, key)
+			return
+		}
+	}
+}
+
+// evictHeight removes one height entry according to the configured eviction policy
+func (c *InMemoryCache[T]) evictHeight(versions map[int64]heightCacheItem[T]) {
+	switch c.config.EvictionPolicy {
+	case FirstInFirstOut:
+		var oldestHeight int64
+		var oldestTime time.Time
+		first := true
+
+		for height, item := range versions {
+			if first || item.timestamp.Before(oldestTime) {
+				oldestHeight = height
+				oldestTime = item.timestamp
+				first = false
+			}
+		}
+		delete(versions, oldestHeight)
+
+	case LeastRecentlyUsed:
+		// TODO: Implement LRU eviction for heights
+		// This will require tracking access times per height
+		panic("LRU eviction not implemented")
+
+	default:
+		// Default to removing oldest height
+		var oldestHeight int64 = -1
+		for height := range versions {
+			if oldestHeight == -1 || height < oldestHeight {
+				oldestHeight = height
+			}
+		}
+		delete(versions, oldestHeight)
+	}
+}

--- a/pkg/client/query/cache/memory_test.go
+++ b/pkg/client/query/cache/memory_test.go
@@ -1,0 +1,343 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestInMemoryCache_NonHistorical tests the basic cache functionality without historical mode
+func TestInMemoryCache_NonHistorical(t *testing.T) {
+	t.Run("basic operations", func(t *testing.T) {
+		cache := NewInMemoryCache[string]()
+
+		// Test Set and Get
+		err := cache.Set("key1", "value1")
+		require.NoError(t, err)
+		val, err := cache.Get("key1")
+		require.NoError(t, err)
+		require.Equal(t, "value1", val)
+
+		// Test missing key
+		_, err = cache.Get("nonexistent")
+		require.ErrorIs(t, err, ErrCacheMiss)
+
+		// Test Delete
+		cache.Delete("key1")
+		_, err = cache.Get("key1")
+		require.ErrorIs(t, err, ErrCacheMiss)
+
+		// Test Clear
+		err = cache.Set("key2", "value2")
+		require.NoError(t, err)
+		cache.Clear()
+		_, err = cache.Get("key2")
+		require.ErrorIs(t, err, ErrCacheMiss)
+	})
+
+	t.Run("TTL expiration", func(t *testing.T) {
+		cache := NewInMemoryCache[string](
+			WithTTL(100 * time.Millisecond),
+		)
+
+		err := cache.Set("key", "value")
+		require.NoError(t, err)
+
+		// Value should be available immediately
+		val, err := cache.Get("key")
+		require.NoError(t, err)
+		require.Equal(t, "value", val)
+
+		// Wait for TTL to expire
+		time.Sleep(150 * time.Millisecond)
+
+		// Value should now be expired
+		_, err = cache.Get("key")
+		require.ErrorIs(t, err, ErrCacheMiss)
+	})
+
+	t.Run("max size eviction", func(t *testing.T) {
+		cache := NewInMemoryCache[string](
+			WithMaxSize(2),
+			WithEvictionPolicy(FirstInFirstOut),
+		)
+
+		// Add items up to max size
+		err := cache.Set("key1", "value1")
+		require.NoError(t, err)
+		err = cache.Set("key2", "value2")
+		require.NoError(t, err)
+
+		// Add one more item, should trigger eviction
+		err = cache.Set("key3", "value3")
+		require.NoError(t, err)
+
+		// First item should be evicted
+		_, err = cache.Get("key1")
+		require.ErrorIs(t, err, ErrCacheMiss)
+
+		// Other items should still be present
+		val, err := cache.Get("key2")
+		require.NoError(t, err)
+		require.Equal(t, "value2", val)
+
+		val, err = cache.Get("key3")
+		require.NoError(t, err)
+		require.Equal(t, "value3", val)
+	})
+}
+
+// TestInMemoryCache_Historical tests the historical mode functionality
+func TestInMemoryCache_Historical(t *testing.T) {
+	t.Run("basic historical operations", func(t *testing.T) {
+		cache := NewInMemoryCache[string](
+			WithHistoricalMode(100),
+		)
+
+		// Test SetAtHeight and GetAtHeight
+		err := cache.SetAtHeight("key", "value1", 10)
+		require.NoError(t, err)
+		err = cache.SetAtHeight("key", "value2", 20)
+		require.NoError(t, err)
+
+		// Test getting exact heights
+		val, err := cache.GetAtHeight("key", 10)
+		require.NoError(t, err)
+		require.Equal(t, "value1", val)
+
+		val, err = cache.GetAtHeight("key", 20)
+		require.NoError(t, err)
+		require.Equal(t, "value2", val)
+
+		// Test getting intermediate height (should return nearest lower height)
+		val, err = cache.GetAtHeight("key", 15)
+		require.NoError(t, err)
+		require.Equal(t, "value1", val)
+
+		// Test getting height before first entry
+		_, err = cache.GetAtHeight("key", 5)
+		require.ErrorIs(t, err, ErrCacheMiss)
+
+		// Test getting height after last entry
+		val, err = cache.GetAtHeight("key", 25)
+		require.NoError(t, err)
+		require.Equal(t, "value2", val)
+	})
+
+	t.Run("historical TTL expiration", func(t *testing.T) {
+		cache := NewInMemoryCache[string](
+			WithHistoricalMode(100),
+			WithTTL(100*time.Millisecond),
+		)
+
+		err := cache.SetAtHeight("key", "value1", 10)
+		require.NoError(t, err)
+
+		// Value should be available immediately
+		val, err := cache.GetAtHeight("key", 10)
+		require.NoError(t, err)
+		require.Equal(t, "value1", val)
+
+		// Wait for TTL to expire
+		time.Sleep(150 * time.Millisecond)
+
+		// Value should now be expired
+		_, err = cache.GetAtHeight("key", 10)
+		require.ErrorIs(t, err, ErrCacheMiss)
+	})
+
+	t.Run("pruning old heights", func(t *testing.T) {
+		cache := NewInMemoryCache[string](
+			WithHistoricalMode(10), // Prune entries older than 10 blocks
+		)
+
+		// Add entries at different heights
+		err := cache.SetAtHeight("key", "value1", 10)
+		require.NoError(t, err)
+		err = cache.SetAtHeight("key", "value2", 20)
+		require.NoError(t, err)
+		err = cache.SetAtHeight("key", "value3", 30)
+		require.NoError(t, err)
+
+		// Add a new entry that should trigger pruning
+		err = cache.SetAtHeight("key", "value4", 40)
+		require.NoError(t, err)
+
+		// Entries more than 10 blocks old should be pruned
+		_, err = cache.GetAtHeight("key", 10)
+		require.ErrorIs(t, err, ErrCacheMiss)
+		_, err = cache.GetAtHeight("key", 20)
+		require.ErrorIs(t, err, ErrCacheMiss)
+
+		// Recent entries should still be available
+		val, err := cache.GetAtHeight("key", 30)
+		require.NoError(t, err)
+		require.Equal(t, "value3", val)
+
+		val, err = cache.GetAtHeight("key", 40)
+		require.NoError(t, err)
+		require.Equal(t, "value4", val)
+	})
+
+	t.Run("non-historical operations on historical cache", func(t *testing.T) {
+		cache := NewInMemoryCache[string](
+			WithHistoricalMode(100),
+		)
+
+		// Set some historical values
+		err := cache.SetAtHeight("key", "value1", 10)
+		require.NoError(t, err)
+		err = cache.SetAtHeight("key", "value2", 20)
+		require.NoError(t, err)
+
+		// Regular Set should work with latest height
+		err = cache.Set("key", "value3")
+		require.NoError(t, err)
+
+		// Regular Get should return the latest value
+		val, err := cache.Get("key")
+		require.NoError(t, err)
+		require.Equal(t, "value3", val)
+
+		// Delete should remove all historical values
+		cache.Delete("key")
+		_, err = cache.GetAtHeight("key", 10)
+		require.ErrorIs(t, err, ErrCacheMiss)
+		_, err = cache.GetAtHeight("key", 20)
+		require.ErrorIs(t, err, ErrCacheMiss)
+		_, err = cache.Get("key")
+		require.ErrorIs(t, err, ErrCacheMiss)
+	})
+}
+
+// TestInMemoryCache_ErrorCases tests various error conditions
+func TestInMemoryCache_ErrorCases(t *testing.T) {
+	t.Run("historical operations on non-historical cache", func(t *testing.T) {
+		cache := NewInMemoryCache[string]()
+
+		// Attempting historical operations should return error
+		err := cache.SetAtHeight("key", "value", 10)
+		require.ErrorIs(t, err, ErrHistoricalModeNotEnabled)
+
+		_, err = cache.GetAtHeight("key", 10)
+		require.ErrorIs(t, err, ErrHistoricalModeNotEnabled)
+	})
+
+	t.Run("zero values", func(t *testing.T) {
+		cache := NewInMemoryCache[string]()
+
+		// Test with empty key
+		err := cache.Set("", "value")
+		require.NoError(t, err)
+		val, err := cache.Get("")
+		require.NoError(t, err)
+		require.Equal(t, "value", val)
+
+		// Test with empty value
+		err = cache.Set("key", "")
+		require.NoError(t, err)
+		val, err = cache.Get("key")
+		require.NoError(t, err)
+		require.Equal(t, "", val)
+	})
+}
+
+// TestInMemoryCache_ConcurrentAccess tests thread safety of the cache
+func TestInMemoryCache_ConcurrentAccess(t *testing.T) {
+	t.Run("concurrent access non-historical", func(t *testing.T) {
+		cache := NewInMemoryCache[int]()
+		const numGoroutines = 10
+		const numOperations = 100
+
+		// Create a context with timeout
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(routineID int) {
+				defer wg.Done()
+				for j := 0; j < numOperations; j++ {
+					// Check for timeout
+					select {
+					case <-ctx.Done():
+						t.Errorf("test timed out: %v", ctx.Err())
+						return
+					default:
+						key := "key"
+						err := cache.Set(key, j)
+						require.NoError(t, err)
+						_, _ = cache.Get(key)
+					}
+				}
+			}(i)
+		}
+
+		// Wait with timeout
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-ctx.Done():
+			t.Errorf("test timed out waiting for goroutines to complete: %v", ctx.Err())
+		case <-done:
+			// Test completed successfully
+		}
+	})
+
+	t.Run("concurrent access historical", func(t *testing.T) {
+		cache := NewInMemoryCache[int](
+			WithHistoricalMode(100),
+		)
+		const numGoroutines = 10
+		const numOpsPerGoRoutine = 100
+
+		// Create a context with timeout
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(routineID int) {
+				defer wg.Done()
+				for j := 0; j < numOpsPerGoRoutine; j++ {
+					// Check for timeout
+					select {
+					case <-ctx.Done():
+						t.Errorf("test timed out: %v", ctx.Err())
+						return
+					default:
+						key := "key"
+						err := cache.SetAtHeight(key, j, int64(j))
+						require.NoError(t, err)
+						_, _ = cache.GetAtHeight(key, int64(j))
+					}
+				}
+			}(i)
+		}
+
+		// Wait with timeout
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-ctx.Done():
+			t.Errorf("test timed out waiting for goroutines to complete: %v", ctx.Err())
+		case <-done:
+			// Test completed successfully
+		}
+	})
+}

--- a/pkg/client/query/sessionquerier.go
+++ b/pkg/client/query/sessionquerier.go
@@ -2,11 +2,16 @@ package query
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 
 	"cosmossdk.io/depinject"
 	"github.com/cosmos/gogoproto/grpc"
 
 	"github.com/pokt-network/poktroll/pkg/client"
+	"github.com/pokt-network/poktroll/pkg/client/query/cache"
+	"github.com/pokt-network/poktroll/pkg/polylog"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 )
 
@@ -18,6 +23,8 @@ var _ client.SessionQueryClient = (*sessionQuerier)(nil)
 type sessionQuerier struct {
 	clientConn     grpc.ClientConn
 	sessionQuerier sessiontypes.QueryClient
+	sessionCache   client.QueryCache[*sessiontypes.Session]
+	paramsCache    client.QueryCache[*sessiontypes.Params]
 }
 
 // NewSessionQuerier returns a new instance of a client.SessionQueryClient by
@@ -26,49 +33,119 @@ type sessionQuerier struct {
 // Required dependencies:
 // - clientCtx (grpc.ClientConn)
 func NewSessionQuerier(deps depinject.Config) (client.SessionQueryClient, error) {
-	sessq := &sessionQuerier{}
+	sq := &sessionQuerier{}
+
+	// Initialize session cache with historical mode since sessions can vary by height
+	sq.sessionCache = cache.NewInMemoryCache[*sessiontypes.Session](
+		// TODO_IN_THIS_COMMIT: extract to a constant.
+		cache.WithMaxSize(100),
+		cache.WithEvictionPolicy(cache.LeastRecentlyUsed),
+		// TODO_IN_THIS_COMMIT: extract to a constant.
+		cache.WithTTL(time.Hour*3),
+	)
+
+	// Initialize params cache with minimal configuration since we only need latest
+	sq.paramsCache = cache.NewInMemoryCache[*sessiontypes.Params](
+		// TODO_IN_THIS_COMMIT: extract to a constant.
+		cache.WithHistoricalMode(100),
+		// TODO_IN_THIS_COMMIT: reconcile the fact that MaxSize doesn't apply to historical mode...
+		//cache.WithMaxSize(1),
+		cache.WithEvictionPolicy(cache.FirstInFirstOut),
+		// TODO_IN_THIS_COMMIT: extract to a constant.
+		cache.WithTTL(time.Hour),
+	)
 
 	if err := depinject.Inject(
 		deps,
-		&sessq.clientConn,
+		&sq.clientConn,
 	); err != nil {
 		return nil, err
 	}
 
-	sessq.sessionQuerier = sessiontypes.NewQueryClient(sessq.clientConn)
+	// TODO_IN_THIS_COMMIT: kick off a goroutine that subscribes to params updates and populates the cache.
 
-	return sessq, nil
+	sq.sessionQuerier = sessiontypes.NewQueryClient(sq.clientConn)
+	return sq, nil
 }
 
 // GetSession returns an sessiontypes.Session struct for a given appAddress,
 // serviceId and blockHeight. It implements the SessionQueryClient#GetSession function.
-func (sessq *sessionQuerier) GetSession(
+func (sq *sessionQuerier) GetSession(
 	ctx context.Context,
 	appAddress string,
 	serviceId string,
 	blockHeight int64,
 ) (*sessiontypes.Session, error) {
+	logger := polylog.Ctx(ctx).With(
+		"querier", "session",
+		"method", "GetSession",
+	)
+
+	// Create cache key from query parameters
+	cacheKey := fmt.Sprintf("%s:%s:%d", appAddress, serviceId, blockHeight)
+
+	// Check cache first
+	cached, err := sq.sessionCache.Get(cacheKey)
+	switch {
+	case err == nil:
+		logger.Debug().Msg("cache hit")
+		return cached, nil
+	case !errors.Is(err, cache.ErrCacheMiss):
+		return nil, err
+	default:
+		logger.Debug().Msg("cache miss")
+	}
+
+	// If not cached, query the chain
 	req := &sessiontypes.QueryGetSessionRequest{
 		ApplicationAddress: appAddress,
 		ServiceId:          serviceId,
 		BlockHeight:        blockHeight,
 	}
-	res, err := sessq.sessionQuerier.GetSession(ctx, req)
+	res, err := sq.sessionQuerier.GetSession(ctx, req)
 	if err != nil {
 		return nil, ErrQueryRetrieveSession.Wrapf(
-			"address: %s; serviceId: %s; block height: %d; error: [%v]",
+			"address: %s; serviceId: %s; block height: %d; error: %s",
 			appAddress, serviceId, blockHeight, err,
 		)
 	}
+
+	// Cache the result before returning
+	if err = sq.sessionCache.Set(cacheKey, res.Session); err != nil {
+		return nil, err
+	}
+
 	return res.Session, nil
 }
 
 // GetParams queries & returns the session module on-chain parameters.
-func (sessq *sessionQuerier) GetParams(ctx context.Context) (*sessiontypes.Params, error) {
-	req := &sessiontypes.QueryParamsRequest{}
-	res, err := sessq.sessionQuerier.Params(ctx, req)
-	if err != nil {
-		return nil, ErrQuerySessionParams.Wrapf("[%v]", err)
+func (sq *sessionQuerier) GetParams(ctx context.Context) (*sessiontypes.Params, error) {
+	logger := polylog.Ctx(ctx).With(
+		"querier", "session",
+		"method", "GetSession",
+	)
+
+	// Check cache first
+	cached, err := sq.paramsCache.Get("params")
+
+	switch {
+	case err == nil:
+		logger.Debug().Msg("cache hit")
+		return cached, nil
+	case !errors.Is(err, cache.ErrCacheMiss):
+		return nil, err
 	}
+
+	logger.Debug().Msg("cache miss")
+
+	// If not in cache, query the chain
+	req := &sessiontypes.QueryParamsRequest{}
+	res, err := sq.sessionQuerier.Params(ctx, req)
+	if err != nil {
+		return nil, ErrQuerySessionParams.Wrapf("%s", err)
+	}
+
+	// Cache the result before returning
+	sq.paramsCache.Set("params", &res.Params)
 	return &res.Params, nil
 }

--- a/pkg/client/query/sharedquerier.go
+++ b/pkg/client/query/sharedquerier.go
@@ -2,45 +2,61 @@ package query
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	"cosmossdk.io/depinject"
 	"github.com/cosmos/gogoproto/grpc"
 
 	"github.com/pokt-network/poktroll/pkg/client"
+	"github.com/pokt-network/poktroll/pkg/client/query/cache"
+	"github.com/pokt-network/poktroll/pkg/polylog"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
 
 var _ client.SharedQueryClient = (*sharedQuerier)(nil)
 
 // sharedQuerier is a wrapper around the sharedtypes.QueryClient that enables the
-// querying of on-chain shared information through a single exposed method
-// which returns an sharedtypes.Session struct
+// querying of on-chain shared information
 type sharedQuerier struct {
 	clientConn    grpc.ClientConn
 	sharedQuerier sharedtypes.QueryClient
 	blockQuerier  client.BlockQueryClient
+	// Add cache for params
+	paramsCache client.QueryCache[*sharedtypes.Params]
 }
 
 // NewSharedQuerier returns a new instance of a client.SharedQueryClient by
-// injecting the dependecies provided by the depinject.Config.
+// injecting the dependencies provided by the depinject.Config.
 //
 // Required dependencies:
 // - clientCtx (grpc.ClientConn)
 // - client.BlockQueryClient
 func NewSharedQuerier(deps depinject.Config) (client.SharedQueryClient, error) {
-	querier := &sharedQuerier{}
+	sq := &sharedQuerier{}
 
 	if err := depinject.Inject(
 		deps,
-		&querier.clientConn,
-		&querier.blockQuerier,
+		&sq.clientConn,
+		&sq.blockQuerier,
 	); err != nil {
 		return nil, err
 	}
 
-	querier.sharedQuerier = sharedtypes.NewQueryClient(querier.clientConn)
+	sq.paramsCache = cache.NewInMemoryCache[*sharedtypes.Params](
+		// TODO_IN_THIS_COMMIT: extract to constants.
+		cache.WithHistoricalMode(100),
+		// TODO_IN_THIS_COMMIT: reconcile the fact that MaxSize doesn't apply to historical mode...
+		//cache.WithMaxSize(1),
+		cache.WithEvictionPolicy(cache.FirstInFirstOut),
+		// TODO_IN_THIS_COMMIT: extract to a constant.
+		cache.WithTTL(time.Hour*3),
+	)
+	sq.sharedQuerier = sharedtypes.NewQueryClient(sq.clientConn)
 
-	return querier, nil
+	// TODO: Implement a goroutine that subscribes to params updates and updates the cache
+
+	return sq, nil
 }
 
 // GetParams queries & returns the shared module on-chain parameters.
@@ -49,11 +65,35 @@ func NewSharedQuerier(deps depinject.Config) (client.SharedQueryClient, error) {
 // Once `ModuleParamsClient` is implemented, use its replay observable's `#Last()` method
 // to get the most recently (asynchronously) observed (and cached) value.
 func (sq *sharedQuerier) GetParams(ctx context.Context) (*sharedtypes.Params, error) {
+	logger := polylog.Ctx(ctx).With(
+		"querier", "session",
+		"method", "GetSession",
+	)
+
+	// Check cache first
+	cached, err := sq.paramsCache.Get("params")
+	switch {
+	case err == nil:
+		logger.Debug().Msg("cache hit")
+		return cached, nil
+	case !errors.Is(err, cache.ErrCacheMiss):
+		return nil, err
+	}
+
+	logger.Debug().Msg("cache miss")
+
+	// If not in cache, query the chain
 	req := &sharedtypes.QueryParamsRequest{}
 	res, err := sq.sharedQuerier.Params(ctx, req)
 	if err != nil {
-		return nil, ErrQuerySessionParams.Wrapf("[%v]", err)
+		return nil, ErrQuerySessionParams.Wrapf("%s", err)
 	}
+
+	// Cache the result before returning
+	if err = sq.paramsCache.Set("params", &res.Params); err != nil {
+		return nil, err
+	}
+
 	return &res.Params, nil
 }
 
@@ -118,7 +158,11 @@ func (sq *sharedQuerier) GetSessionGracePeriodEndHeight(
 // to get the most recently (asynchronously) observed (and cached) value.
 // TODO_MAINNET(@bryanchriswhite, #543): We also don't really want to use the current value of the params.
 // Instead, we should be using the value that the params had for the session which includes queryHeight.
-func (sq *sharedQuerier) GetEarliestSupplierClaimCommitHeight(ctx context.Context, queryHeight int64, supplierOperatorAddr string) (int64, error) {
+func (sq *sharedQuerier) GetEarliestSupplierClaimCommitHeight(
+	ctx context.Context,
+	queryHeight int64,
+	supplierOperatorAddr string,
+) (int64, error) {
 	sharedParams, err := sq.GetParams(ctx)
 	if err != nil {
 		return 0, err
@@ -151,7 +195,11 @@ func (sq *sharedQuerier) GetEarliestSupplierClaimCommitHeight(ctx context.Contex
 // to get the most recently (asynchronously) observed (and cached) value.
 // TODO_MAINNET(@bryanchriswhite, #543): We also don't really want to use the current value of the params.
 // Instead, we should be using the value that the params had for the session which includes queryHeight.
-func (sq *sharedQuerier) GetEarliestSupplierProofCommitHeight(ctx context.Context, queryHeight int64, supplierOperatorAddr string) (int64, error) {
+func (sq *sharedQuerier) GetEarliestSupplierProofCommitHeight(
+	ctx context.Context,
+	queryHeight int64,
+	supplierOperatorAddr string,
+) (int64, error) {
 	sharedParams, err := sq.GetParams(ctx)
 	if err != nil {
 		return 0, err

--- a/pkg/client/query/sharedquerier_test.go
+++ b/pkg/client/query/sharedquerier_test.go
@@ -1,0 +1,129 @@
+package query_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cosmossdk.io/depinject"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/pokt-network/poktroll/pkg/client"
+	"github.com/pokt-network/poktroll/pkg/client/query"
+	_ "github.com/pokt-network/poktroll/pkg/polylog/polyzero"
+	"github.com/pokt-network/poktroll/testutil/mockclient"
+	"github.com/pokt-network/poktroll/testutil/mockgrpc"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+)
+
+func setupTest(t *testing.T) (client.SharedQueryClient, *mockgrpc.MockClientConn, *mockclient.MockCometRPC) {
+	ctrl := gomock.NewController(t)
+
+	mockConn := mockgrpc.NewMockClientConn(ctrl)
+	mockBlock := mockclient.NewMockCometRPC(ctrl)
+
+	cfg := depinject.Supply(mockConn, mockBlock)
+
+	querier, err := query.NewSharedQuerier(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, querier)
+
+	return querier, mockConn, mockBlock
+}
+
+func TestSharedQuerier_ParamsHistoricalValues(t *testing.T) {
+	ctx := context.Background()
+	querier, mockConn, _ := setupTest(t)
+
+	// Helper function to create params with specific values
+	createParamsWithMultiplier := func(multiplier uint64) *sharedtypes.Params {
+		return &sharedtypes.Params{
+			NumBlocksPerSession:             100,
+			GracePeriodEndOffsetBlocks:      10,
+			ClaimWindowOpenOffsetBlocks:     20,
+			ClaimWindowCloseOffsetBlocks:    30,
+			ProofWindowOpenOffsetBlocks:     40,
+			ProofWindowCloseOffsetBlocks:    50,
+			SupplierUnbondingPeriodSessions: 5,
+			ComputeUnitsToTokensMultiplier:  multiplier,
+		}
+	}
+
+	t.Run("retrieves and caches params values", func(t *testing.T) {
+		// First query - params with multiplier 1000
+		mockConn.EXPECT().
+			Invoke(
+				gomock.Any(),
+				"/poktroll.shared.Query/Params",
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Any(),
+			).
+			DoAndReturn(func(_ context.Context, _ string, _ interface{}, reply interface{}, _ ...grpc.CallOption) error {
+				resp := reply.(*sharedtypes.QueryParamsResponse)
+				resp.Params = *createParamsWithMultiplier(1000)
+				return nil
+			}).Times(1)
+
+		// Initial query should fetch from chain
+		params1, err := querier.GetParams(ctx)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1000), params1.ComputeUnitsToTokensMultiplier)
+
+		// Second query - should use cache, no mock expectation needed
+		params2, err := querier.GetParams(ctx)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1000), params2.ComputeUnitsToTokensMultiplier)
+
+		// Third query after small delay - should still use cache
+		time.Sleep(100 * time.Millisecond)
+		params3, err := querier.GetParams(ctx)
+		require.NoError(t, err)
+		require.Equal(t, uint64(1000), params3.ComputeUnitsToTokensMultiplier)
+	})
+
+	t.Run("handles cache expiration", func(t *testing.T) {
+		// First query
+		mockConn.EXPECT().
+			Invoke(
+				gomock.Any(),
+				"/poktroll.shared.Query/Params",
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Any(),
+			).
+			DoAndReturn(func(_ context.Context, _ string, _ interface{}, reply interface{}, _ ...grpc.CallOption) error {
+				resp := reply.(*sharedtypes.QueryParamsResponse)
+				resp.Params = *createParamsWithMultiplier(2000)
+				return nil
+			}).Times(1)
+
+		params1, err := querier.GetParams(ctx)
+		require.NoError(t, err)
+		require.Equal(t, uint64(2000), params1.ComputeUnitsToTokensMultiplier)
+
+		// Wait for cache to expire
+		time.Sleep(2 * time.Hour)
+
+		// Next query should hit the chain again
+		mockConn.EXPECT().
+			Invoke(
+				gomock.Any(),
+				"/poktroll.shared.Query/Params",
+				gomock.Any(),
+				gomock.Any(),
+				gomock.Any(),
+			).
+			DoAndReturn(func(_ context.Context, _ string, _ interface{}, reply interface{}, _ ...grpc.CallOption) error {
+				resp := reply.(*sharedtypes.QueryParamsResponse)
+				resp.Params = *createParamsWithMultiplier(3000)
+				return nil
+			}).Times(1)
+
+		params2, err := querier.GetParams(ctx)
+		require.NoError(t, err)
+		require.Equal(t, uint64(3000), params2.ComputeUnitsToTokensMultiplier)
+	})
+}


### PR DESCRIPTION
## Summary

Adds caching to the query clients.

## Issue

- #543

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
