### PR TITLE
[Off-chain] feat: in-memory query cache(s)

### DIFF
--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -360,3 +360,11 @@ type BankQueryClient interface {
 	// GetBalance queries the chain for the uPOKT balance of the account provided
 	GetBalance(ctx context.Context, address string) (*cosmostypes.Coin, error)
 }
+
+// QueryCache handles a single type of cached data
+type QueryCache[T any] interface {
+	Get(key string) (T, error)
+	Set(key string, value T) error
+	Delete(key string)
+	Clear()
+}

--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -368,3 +368,12 @@ type QueryCache[T any] interface {
 	Delete(key string)
 	Clear()
 }
+
+// HistoricalQueryCache extends QueryCache to support historical values at different heights
+type HistoricalQueryCache[T any] interface {
+	QueryCache[T]
+	// GetAtHeight retrieves the nearest value <= the specified height
+	GetAtHeight(key string, height int64) (T, error)
+	// SetAtHeight adds or updates a value at a specific height
+	SetAtHeight(key string, value T, height int64) error
+}

--- a/pkg/client/query/cache/config.go
+++ b/pkg/client/query/cache/config.go
@@ -1,0 +1,76 @@
+package cache
+
+import (
+	"time"
+)
+
+// EvictionPolicy determines how items are removed when cache is full.
+type EvictionPolicy int64
+
+const (
+	FirstInFirstOut = EvictionPolicy(iota)
+	LeastRecentlyUsed
+	LeastFrequentlyUsed
+)
+
+// CacheConfig is the configuration options for a cache.
+type CacheConfig struct {
+	// MaxKeys is the maximum number of items the cache can hold.
+	MaxKeys int64
+	// EvictionPolicy is how items should be removed when the cache is full.
+	EvictionPolicy EvictionPolicy
+	// TTL is how long items should remain in the cache
+	TTL time.Duration
+
+	// historical is whether the cache will cache a single value for each key
+	// (false) or whether it will cache a history of values for each key (true).
+	historical bool
+	// pruneOlderThan is the number of past blocks for which to keep historical
+	// values. If 0, no historical pruning is performed.
+	pruneOlderThan int64
+}
+
+// CacheOption defines a function that configures a CacheConfig
+type CacheOption func(*CacheConfig)
+
+// HistoricalCacheConfig extends the basic CacheConfig with historical settings.
+type HistoricalCacheConfig struct {
+	CacheConfig
+
+	// MaxHeightsPerKey is the maximum number of different heights to store per key
+	MaxHeightsPerKey int
+	// PruneOlderThan specifies how many blocks back to maintain in history
+	// If 0, no historical pruning is performed
+	PruneOlderThan int64
+}
+
+// WithHistoricalMode enables historical caching with the given pruneOlderThan
+// configuration, if 0 no historical pruning is performed.
+func WithHistoricalMode(pruneOlderThan int64) CacheOption {
+	return func(cfg *CacheConfig) {
+		cfg.historical = true
+		cfg.pruneOlderThan = pruneOlderThan
+	}
+}
+
+// WithMaxKeys sets the maximum number of distinct key/value pairs the cache will
+// hold before evicting according to the configured eviction policy.
+func WithMaxKeys(size int64) CacheOption {
+	return func(cfg *CacheConfig) {
+		cfg.MaxKeys = size
+	}
+}
+
+// WithEvictionPolicy sets the eviction policy
+func WithEvictionPolicy(policy EvictionPolicy) CacheOption {
+	return func(cfg *CacheConfig) {
+		cfg.EvictionPolicy = policy
+	}
+}
+
+// WithTTL sets the time-to-live for cache entries
+func WithTTL(ttl time.Duration) CacheOption {
+	return func(cfg *CacheConfig) {
+		cfg.TTL = ttl
+	}
+}

--- a/pkg/client/query/cache/errors.go
+++ b/pkg/client/query/cache/errors.go
@@ -1,0 +1,10 @@
+package cache
+
+import "cosmossdk.io/errors"
+
+const codesace = "client/query/cache"
+
+var (
+	ErrCacheMiss                = errors.Register(codesace, 1, "cache miss")
+	ErrHistoricalModeNotEnabled = errors.Register(codesace, 2, "historical mode not enabled")
+)

--- a/pkg/client/query/cache/memory.go
+++ b/pkg/client/query/cache/memory.go
@@ -1,0 +1,245 @@
+package cache
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pokt-network/poktroll/pkg/client"
+)
+
+var (
+	_ client.QueryCache[any]           = (*InMemoryCache[any])(nil)
+	_ client.HistoricalQueryCache[any] = (*InMemoryCache[any])(nil)
+)
+
+// InMemoryCache provides a concurrency-safe in-memory cache implementation with
+// optional historical value support.
+type InMemoryCache[T any] struct {
+	config       CacheConfig
+	latestHeight atomic.Int64
+
+	itemsMu sync.RWMutex
+	// items type depends on historical mode:
+	// | historical mode |  type                                   |
+	// | --------------- | --------------------------------------- |
+	// | false           | map[string]cacheItem[T]                 |
+	// | true            | map[string]map[int64]heightCacheItem[T] |
+	items map[string]any
+}
+
+// cacheItem wraps cached values with metadata
+type cacheItem[T any] struct {
+	value     T
+	timestamp time.Time
+}
+
+// heightCacheItem is used when the cache is in historical mode
+type heightCacheItem[T any] struct {
+	value     T
+	timestamp time.Time
+}
+
+// NewInMemoryCache creates a new cache with the given configuration
+func NewInMemoryCache[T any](opts ...CacheOption) *InMemoryCache[T] {
+	config := CacheConfig{
+		EvictionPolicy: FirstInFirstOut,
+	}
+
+	for _, opt := range opts {
+		opt(&config)
+	}
+
+	return &InMemoryCache[T]{
+		items:  make(map[string]interface{}),
+		config: config,
+	}
+}
+
+// Get retrieves an item from the cache
+func (c *InMemoryCache[T]) Get(key string) (T, error) {
+	if c.config.historical {
+		return c.GetAtHeight(key, c.latestHeight.Load())
+	}
+
+	c.itemsMu.RLock()
+	defer c.itemsMu.RUnlock()
+
+	var zero T
+
+	item, exists := c.items[key]
+	if !exists {
+		return zero, ErrCacheMiss
+	}
+
+	cItem := item.(cacheItem[T])
+	if c.config.TTL > 0 && time.Since(cItem.timestamp) > c.config.TTL {
+		// TODO_QUESTION: should we prune here?
+		return zero, ErrCacheMiss
+	}
+
+	return cItem.value, nil
+}
+
+// GetAtHeight retrieves an item from the cache at or before the specified height
+func (c *InMemoryCache[T]) GetAtHeight(key string, height int64) (T, error) {
+	var zero T
+
+	if !c.config.historical {
+		return zero, ErrHistoricalModeNotEnabled
+	}
+
+	c.itemsMu.RLock()
+	defer c.itemsMu.RUnlock()
+
+	heightMap, exists := c.items[key]
+	if !exists {
+		return zero, ErrCacheMiss
+	}
+
+	versions := heightMap.(map[int64]heightCacheItem[T])
+	var nearestHeight int64 = -1
+	for h := range versions {
+		if h <= height && h > nearestHeight {
+			nearestHeight = h
+		}
+	}
+
+	if nearestHeight == -1 {
+		return zero, ErrCacheMiss
+	}
+
+	item := versions[nearestHeight]
+	if c.config.TTL > 0 && time.Since(item.timestamp) > c.config.TTL {
+		return zero, ErrCacheMiss
+	}
+
+	return item.value, nil
+}
+
+// Set adds or updates an item in the cache
+func (c *InMemoryCache[T]) Set(key string, value T) error {
+	if c.config.historical {
+		return c.SetAtHeight(key, value, c.latestHeight.Load())
+	}
+
+	if c.config.MaxKeys > 0 && int64(len(c.items)) >= c.config.MaxKeys {
+		c.evict()
+	}
+
+	c.itemsMu.Lock()
+	defer c.itemsMu.Unlock()
+
+	c.items[key] = cacheItem[T]{
+		value:     value,
+		timestamp: time.Now(),
+	}
+
+	return nil
+}
+
+// SetAtHeight adds or updates an item in the cache at a specific height
+func (c *InMemoryCache[T]) SetAtHeight(key string, value T, height int64) error {
+	if !c.config.historical {
+		return ErrHistoricalModeNotEnabled
+	}
+
+	// Update latest height if this is newer
+	latestHeight := c.latestHeight.Load()
+	if height > latestHeight {
+		// NB: Only update if c.latestHeight hasn't changed since we loaded it above.
+		c.latestHeight.CompareAndSwap(latestHeight, height)
+	}
+
+	c.itemsMu.Lock()
+	defer c.itemsMu.Unlock()
+
+	var history map[int64]heightCacheItem[T]
+	if existing, exists := c.items[key]; exists {
+		history = existing.(map[int64]heightCacheItem[T])
+	} else {
+		history = make(map[int64]heightCacheItem[T])
+		c.items[key] = history
+	}
+
+	// Prune old heights if configured
+	if c.config.pruneOlderThan > 0 {
+		for h := range history {
+			if height-h > c.config.pruneOlderThan {
+				delete(history, h)
+			}
+		}
+	}
+
+	history[height] = heightCacheItem[T]{
+		value:     value,
+		timestamp: time.Now(),
+	}
+
+	return nil
+}
+
+// Delete removes an item from the cache.
+func (c *InMemoryCache[T]) Delete(key string) {
+	c.itemsMu.Lock()
+	defer c.itemsMu.Unlock()
+
+	delete(c.items, key)
+}
+
+// Clear removes all items from the cache
+func (c *InMemoryCache[T]) Clear() {
+	c.itemsMu.Lock()
+	defer c.itemsMu.Unlock()
+
+	c.items = make(map[string]interface{})
+	c.latestHeight.Store(0)
+}
+
+// evict removes one item according to the configured eviction policy
+func (c *InMemoryCache[T]) evict() {
+	switch c.config.EvictionPolicy {
+	case FirstInFirstOut:
+		var oldestKey string
+		var oldestTime time.Time
+		first := true
+
+		for key, item := range c.items {
+			var itemTime time.Time
+			if c.config.historical {
+				versions := item.(map[int64]heightCacheItem[T])
+				for _, v := range versions {
+					if itemTime.IsZero() || v.timestamp.Before(itemTime) {
+						itemTime = v.timestamp
+					}
+				}
+			} else {
+				itemTime = item.(cacheItem[T]).timestamp
+			}
+
+			if first || itemTime.Before(oldestTime) {
+				oldestKey = key
+				oldestTime = itemTime
+				first = false
+			}
+		}
+		delete(c.items, oldestKey)
+
+	case LeastRecentlyUsed:
+		// TODO: Implement LRU eviction
+		// This will require tracking access times
+		panic("LRU eviction not implemented")
+
+	case LeastFrequentlyUsed:
+		// TODO: Implement LFU eviction
+		// This will require tracking access times
+		panic("LFU eviction not implemented")
+
+	default:
+		// Default to FIFO if policy not recognized
+		for key := range c.items {
+			delete(c.items, key)
+			return
+		}
+	}
+}

--- a/pkg/client/query/cache/memory_test.go
+++ b/pkg/client/query/cache/memory_test.go
@@ -1,0 +1,343 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestInMemoryCache_NonHistorical tests the basic cache functionality without historical mode
+func TestInMemoryCache_NonHistorical(t *testing.T) {
+	t.Run("basic operations", func(t *testing.T) {
+		cache := NewInMemoryCache[string]()
+
+		// Test Set and Get
+		err := cache.Set("key1", "value1")
+		require.NoError(t, err)
+		val, err := cache.Get("key1")
+		require.NoError(t, err)
+		require.Equal(t, "value1", val)
+
+		// Test missing key
+		_, err = cache.Get("nonexistent")
+		require.ErrorIs(t, err, ErrCacheMiss)
+
+		// Test Delete
+		cache.Delete("key1")
+		_, err = cache.Get("key1")
+		require.ErrorIs(t, err, ErrCacheMiss)
+
+		// Test Clear
+		err = cache.Set("key2", "value2")
+		require.NoError(t, err)
+		cache.Clear()
+		_, err = cache.Get("key2")
+		require.ErrorIs(t, err, ErrCacheMiss)
+	})
+
+	t.Run("TTL expiration", func(t *testing.T) {
+		cache := NewInMemoryCache[string](
+			WithTTL(100 * time.Millisecond),
+		)
+
+		err := cache.Set("key", "value")
+		require.NoError(t, err)
+
+		// Value should be available immediately
+		val, err := cache.Get("key")
+		require.NoError(t, err)
+		require.Equal(t, "value", val)
+
+		// Wait for TTL to expire
+		time.Sleep(150 * time.Millisecond)
+
+		// Value should now be expired
+		_, err = cache.Get("key")
+		require.ErrorIs(t, err, ErrCacheMiss)
+	})
+
+	t.Run("max size eviction", func(t *testing.T) {
+		cache := NewInMemoryCache[string](
+			WithMaxKeys(2),
+			WithEvictionPolicy(FirstInFirstOut),
+		)
+
+		// Add items up to max size
+		err := cache.Set("key1", "value1")
+		require.NoError(t, err)
+		err = cache.Set("key2", "value2")
+		require.NoError(t, err)
+
+		// Add one more item, should trigger eviction
+		err = cache.Set("key3", "value3")
+		require.NoError(t, err)
+
+		// First item should be evicted
+		_, err = cache.Get("key1")
+		require.ErrorIs(t, err, ErrCacheMiss)
+
+		// Other items should still be present
+		val, err := cache.Get("key2")
+		require.NoError(t, err)
+		require.Equal(t, "value2", val)
+
+		val, err = cache.Get("key3")
+		require.NoError(t, err)
+		require.Equal(t, "value3", val)
+	})
+}
+
+// TestInMemoryCache_Historical tests the historical mode functionality
+func TestInMemoryCache_Historical(t *testing.T) {
+	t.Run("basic historical operations", func(t *testing.T) {
+		cache := NewInMemoryCache[string](
+			WithHistoricalMode(100),
+		)
+
+		// Test SetAtHeight and GetAtHeight
+		err := cache.SetAtHeight("key", "value1", 10)
+		require.NoError(t, err)
+		err = cache.SetAtHeight("key", "value2", 20)
+		require.NoError(t, err)
+
+		// Test getting exact heights
+		val, err := cache.GetAtHeight("key", 10)
+		require.NoError(t, err)
+		require.Equal(t, "value1", val)
+
+		val, err = cache.GetAtHeight("key", 20)
+		require.NoError(t, err)
+		require.Equal(t, "value2", val)
+
+		// Test getting intermediate height (should return nearest lower height)
+		val, err = cache.GetAtHeight("key", 15)
+		require.NoError(t, err)
+		require.Equal(t, "value1", val)
+
+		// Test getting height before first entry
+		_, err = cache.GetAtHeight("key", 5)
+		require.ErrorIs(t, err, ErrCacheMiss)
+
+		// Test getting height after last entry
+		val, err = cache.GetAtHeight("key", 25)
+		require.NoError(t, err)
+		require.Equal(t, "value2", val)
+	})
+
+	t.Run("historical TTL expiration", func(t *testing.T) {
+		cache := NewInMemoryCache[string](
+			WithHistoricalMode(100),
+			WithTTL(100*time.Millisecond),
+		)
+
+		err := cache.SetAtHeight("key", "value1", 10)
+		require.NoError(t, err)
+
+		// Value should be available immediately
+		val, err := cache.GetAtHeight("key", 10)
+		require.NoError(t, err)
+		require.Equal(t, "value1", val)
+
+		// Wait for TTL to expire
+		time.Sleep(150 * time.Millisecond)
+
+		// Value should now be expired
+		_, err = cache.GetAtHeight("key", 10)
+		require.ErrorIs(t, err, ErrCacheMiss)
+	})
+
+	t.Run("pruning old heights", func(t *testing.T) {
+		cache := NewInMemoryCache[string](
+			WithHistoricalMode(10), // Prune entries older than 10 blocks
+		)
+
+		// Add entries at different heights
+		err := cache.SetAtHeight("key", "value1", 10)
+		require.NoError(t, err)
+		err = cache.SetAtHeight("key", "value2", 20)
+		require.NoError(t, err)
+		err = cache.SetAtHeight("key", "value3", 30)
+		require.NoError(t, err)
+
+		// Add a new entry that should trigger pruning
+		err = cache.SetAtHeight("key", "value4", 40)
+		require.NoError(t, err)
+
+		// Entries more than 10 blocks old should be pruned
+		_, err = cache.GetAtHeight("key", 10)
+		require.ErrorIs(t, err, ErrCacheMiss)
+		_, err = cache.GetAtHeight("key", 20)
+		require.ErrorIs(t, err, ErrCacheMiss)
+
+		// Recent entries should still be available
+		val, err := cache.GetAtHeight("key", 30)
+		require.NoError(t, err)
+		require.Equal(t, "value3", val)
+
+		val, err = cache.GetAtHeight("key", 40)
+		require.NoError(t, err)
+		require.Equal(t, "value4", val)
+	})
+
+	t.Run("non-historical operations on historical cache", func(t *testing.T) {
+		cache := NewInMemoryCache[string](
+			WithHistoricalMode(100),
+		)
+
+		// Set some historical values
+		err := cache.SetAtHeight("key", "value1", 10)
+		require.NoError(t, err)
+		err = cache.SetAtHeight("key", "value2", 20)
+		require.NoError(t, err)
+
+		// Regular Set should work with latest height
+		err = cache.Set("key", "value3")
+		require.NoError(t, err)
+
+		// Regular Get should return the latest value
+		val, err := cache.Get("key")
+		require.NoError(t, err)
+		require.Equal(t, "value3", val)
+
+		// Delete should remove all historical values
+		cache.Delete("key")
+		_, err = cache.GetAtHeight("key", 10)
+		require.ErrorIs(t, err, ErrCacheMiss)
+		_, err = cache.GetAtHeight("key", 20)
+		require.ErrorIs(t, err, ErrCacheMiss)
+		_, err = cache.Get("key")
+		require.ErrorIs(t, err, ErrCacheMiss)
+	})
+}
+
+// TestInMemoryCache_ErrorCases tests various error conditions
+func TestInMemoryCache_ErrorCases(t *testing.T) {
+	t.Run("historical operations on non-historical cache", func(t *testing.T) {
+		cache := NewInMemoryCache[string]()
+
+		// Attempting historical operations should return error
+		err := cache.SetAtHeight("key", "value", 10)
+		require.ErrorIs(t, err, ErrHistoricalModeNotEnabled)
+
+		_, err = cache.GetAtHeight("key", 10)
+		require.ErrorIs(t, err, ErrHistoricalModeNotEnabled)
+	})
+
+	t.Run("zero values", func(t *testing.T) {
+		cache := NewInMemoryCache[string]()
+
+		// Test with empty key
+		err := cache.Set("", "value")
+		require.NoError(t, err)
+		val, err := cache.Get("")
+		require.NoError(t, err)
+		require.Equal(t, "value", val)
+
+		// Test with empty value
+		err = cache.Set("key", "")
+		require.NoError(t, err)
+		val, err = cache.Get("key")
+		require.NoError(t, err)
+		require.Equal(t, "", val)
+	})
+}
+
+// TestInMemoryCache_ConcurrentAccess tests thread safety of the cache
+func TestInMemoryCache_ConcurrentAccess(t *testing.T) {
+	t.Run("concurrent access non-historical", func(t *testing.T) {
+		cache := NewInMemoryCache[int]()
+		const numGoroutines = 10
+		const numOperations = 100
+
+		// Create a context with timeout
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(routineID int) {
+				defer wg.Done()
+				for j := 0; j < numOperations; j++ {
+					// Check for timeout
+					select {
+					case <-ctx.Done():
+						t.Errorf("test timed out: %v", ctx.Err())
+						return
+					default:
+						key := "key"
+						err := cache.Set(key, j)
+						require.NoError(t, err)
+						_, _ = cache.Get(key)
+					}
+				}
+			}(i)
+		}
+
+		// Wait with timeout
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-ctx.Done():
+			t.Errorf("test timed out waiting for goroutines to complete: %v", ctx.Err())
+		case <-done:
+			// Test completed successfully
+		}
+	})
+
+	t.Run("concurrent access historical", func(t *testing.T) {
+		cache := NewInMemoryCache[int](
+			WithHistoricalMode(100),
+		)
+		const numGoroutines = 10
+		const numOpsPerGoRoutine = 100
+
+		// Create a context with timeout
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(routineID int) {
+				defer wg.Done()
+				for j := 0; j < numOpsPerGoRoutine; j++ {
+					// Check for timeout
+					select {
+					case <-ctx.Done():
+						t.Errorf("test timed out: %v", ctx.Err())
+						return
+					default:
+						key := "key"
+						err := cache.SetAtHeight(key, j, int64(j))
+						require.NoError(t, err)
+						_, _ = cache.GetAtHeight(key, int64(j))
+					}
+				}
+			}(i)
+		}
+
+		// Wait with timeout
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
+
+		select {
+		case <-ctx.Done():
+			t.Errorf("test timed out waiting for goroutines to complete: %v", ctx.Err())
+		case <-done:
+			// Test completed successfully
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds the `QueryCache[T any]` and `HistoricalQueryCache[T any]` interfaces, `InMemoryCache[T any]` implementation, configurations, and options functions.

## Issue

<!-- READ & DELETE:
     - Explain the reasoning for the PR in 1-2 sentences. Adding a screenshot is fair game.
     - If applicable: specify the ticket number below if there is a relevant issue; _keep the `-` so the full issue is referenced._
-->

- #543

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
