### PR TITLE
[Clients] embed `ParamsQuerier` into `ApplicationQueryClient`

### DIFF
--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -268,6 +268,8 @@ type AccountQueryClient interface {
 // ApplicationQueryClient defines an interface that enables the querying of the
 // on-chain application information
 type ApplicationQueryClient interface {
+	ParamsQuerier[*apptypes.Params]
+
 	// GetApplication queries the chain for the details of the application provided
 	GetApplication(ctx context.Context, appAddress string) (apptypes.Application, error)
 

--- a/x/application/types/expected_keepers.go
+++ b/x/application/types/expected_keepers.go
@@ -37,3 +37,7 @@ type SharedKeeper interface {
 	GetParams(ctx context.Context) sharedtypes.Params
 	GetSessionEndHeight(ctx context.Context, queryHeight int64) int64
 }
+
+type ApplicationKeeper interface {
+	GetParams(ctx context.Context) Params
+}

--- a/x/application/types/query_client.go
+++ b/x/application/types/query_client.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	"context"
+
+	gogogrpc "github.com/cosmos/gogoproto/grpc"
+)
+
+// TODO_IN_THIS_COMMIT: godoc...
+type ApplicationQueryClient interface {
+	QueryClient
+
+	GetParams(context.Context) (*Params, error)
+}
+
+// TODO_IN_THIS_COMMIT: godoc...
+func NewAppQueryClient(conn gogogrpc.ClientConn) ApplicationQueryClient {
+	return NewQueryClient(conn).(ApplicationQueryClient)
+}
+
+// TODO_IN_THIS_COMMIT: investigate generalization...
+// TODO_IN_THIS_COMMIT: godoc...
+func (c *queryClient) GetParams(ctx context.Context) (*Params, error) {
+	res, err := c.Params(ctx, &QueryParamsRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	params := res.GetParams()
+	return &params, nil
+}

--- a/x/proof/types/application_query_client.go
+++ b/x/proof/types/application_query_client.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pokt-network/poktroll/pkg/client"
 	apptypes "github.com/pokt-network/poktroll/x/application/types"
+	sharedkeeper "github.com/pokt-network/poktroll/x/shared/keeper"
 )
 
 var _ client.ApplicationQueryClient = (*AppKeeperQueryClient)(nil)
@@ -13,6 +14,8 @@ var _ client.ApplicationQueryClient = (*AppKeeperQueryClient)(nil)
 // It does not rely on the QueryClient, and therefore does not make any
 // network requests as in the off-chain implementation.
 type AppKeeperQueryClient struct {
+	client.ParamsQuerier[*apptypes.Params]
+
 	keeper ApplicationKeeper
 }
 
@@ -22,7 +25,12 @@ type AppKeeperQueryClient struct {
 // has delegated its signing power to.
 // It should be injected into the RingClient when initialized from within the a keeper.
 func NewAppKeeperQueryClient(appKeeper ApplicationKeeper) client.ApplicationQueryClient {
-	return &AppKeeperQueryClient{keeper: appKeeper}
+	keeperParamsQuerier := sharedkeeper.NewKeeperParamsQuerier[apptypes.Params](appKeeper)
+
+	return &AppKeeperQueryClient{
+		keeper:        appKeeper,
+		ParamsQuerier: keeperParamsQuerier,
+	}
 }
 
 // GetApplication returns the application corresponding to the given address.

--- a/x/proof/types/expected_keepers.go
+++ b/x/proof/types/expected_keepers.go
@@ -49,6 +49,7 @@ type ApplicationKeeper interface {
 	GetApplication(ctx context.Context, address string) (app apptypes.Application, found bool)
 	GetAllApplications(ctx context.Context) []apptypes.Application
 	SetApplication(context.Context, apptypes.Application)
+	GetParams(context.Context) apptypes.Params
 }
 
 // SharedKeeper defines the expected interface needed to retrieve shared information.

--- a/x/tokenomics/types/expected_keepers.go
+++ b/x/tokenomics/types/expected_keepers.go
@@ -46,6 +46,7 @@ type ApplicationKeeper interface {
 	GetAllApplications(ctx context.Context) []apptypes.Application
 	UnbondApplication(ctx context.Context, app *apptypes.Application) error
 	EndBlockerUnbondApplications(ctx context.Context) error
+	GetParams(ctx context.Context) apptypes.Params
 }
 
 type ProofKeeper interface {


### PR DESCRIPTION
## Summary

Embed the `ParamsQuerier` interface into `ApplicationQueryClient` and update both off- and on-chain implementations; i.e. `appQuerier` and `AppKeeperQueryClient`, respectively.

```mermaid
---
title: Legend
---

classDiagram-v2

class GenericInterface__T__any {
    <<interface>>
    GenericMethod() T
}

class Implementer {
    ExportedField FieldType
    unexportedField FieldType
}

Implementer --|> GenericInterface__T__any: implements

class Embedder__T__any {
    <<interface>>
    GenericInterface[T]
}

Embedder__T__any ..|> GenericInterface__T__any: embeds

Implementer --* FieldType: composes*
Implementer --o FieldType: aggregates*

```
> ***Aggregation** implies that the compose component instance DOES have an independent existence from its composition, **composition** DOES NOT.

```mermaid
---
title: Application Query Client Integration (off-chain)
---

classDiagram-v2

class ParamsQuerier__P__sdk_Msg {
    <<interface>>
    GetParams(ctx context.Context) (params P, err error)
    GetParamsAtHeight(ctx context.Context, height int64) (params P, err error)
}


class cachedParamsQuerier__P__sdk_Msg__Q__paramsQuerier {
    queryClient Q__paramsQuerier[P]
    paramsCache HistoricalQueryCache[P]
    ...
}
cachedParamsQuerier__P__sdk_Msg__Q__paramsQuerier --|> ParamsQuerier__P__sdk_Msg

class HistoricalQueryCache__T__any {
    <<interface>>
    QueryCache__T__any  // omitted from this diagram
    GetAtHeight(key string, heigt int64) (value T, err error)
    SetAtHeight(key string, value T, heigt int64) (err error)
}

cachedParamsQuerier__P__sdk_Msg__Q__paramsQuerier --* HistoricalQueryCache__T__any

class ApplicationQueryClient {
    <<interface>>
    ParamsQuerier__P__sdk_Msg
}
ApplicationQueryClient ..|> ParamsQuerier__P__sdk_Msg
applicationQuerier --|> ApplicationQueryClient

class applicationQuerier {
    ParamsQuerier__P__sdk_Msg
}
applicationQuerier --* cachedParamsQuerier__P__sdk_Msg__Q__paramsQuerier
```

```mermaid
---
title: Application Querier Integration (on-chain)
---

classDiagram-v2

class ParamsQuerier__P__sdk_Msg {
    <<interface>>
    GetParams(ctx context.Context) (params P, err error)
    GetParamsAtHeight(ctx context.Context, height int64) (params P, err error)
}

class keeperParamsQuerier__P__any__K__paramsKeeperIface {
    keeper K

    GetParams(ctx context.Context) (params P, err error)
    GetParamsAtHeight(ctx context.Context, height int64) (params P, err error)  // NEVER called; blocked by #931
}

keeperParamsQuerier__P__any__K__paramsKeeperIface --|> ParamsQuerier__P__sdk_Msg

%% class paramsKeeperIface__P__any {
%%     GetParams(context.Context) P
%% }
%% keeperParamsQuerier__P__any__K__paramsKeeperIface --> paramsKeeperIface__P__any

class applicationkeeper.Keeper {
    GetParams(ctx context.Context) (params P, err error)
    %% GetParamsAtHeight(ctx context.Context, height int64) (params P, err error)
}

keeperParamsQuerier__P__any__K__paramsKeeperIface --o applicationkeeper.Keeper

class ApplicationQuerier {
    <<interface>>
    ParamsQuerier__P__sdk_Msg
}
ApplicationQuerier ..|> ParamsQuerier__P__sdk_Msg
applicationKeeperQueryClient --|> ApplicationQuerier

class applicationKeeperQueryClient {
    ParamsQuerier__P__sdk_Msg

    applicationKeeper applicationKeeper
    sessionKeeper SessionKeeper  // omitted from this diagram
}
applicationKeeperQueryClient --* keeperParamsQuerier__P__any__K__paramsKeeperIface
applicationKeeperQueryClient --o applicationkeeper.Keeper
```

## Issue

- #543

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
