### PR TITLE
[Clients] embed `ParamsQuerier` into `ProofQueryClient`

### DIFF
--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -336,6 +336,8 @@ type BlockQueryClient interface {
 // protobuf message. Since the generated go types don't include interface types, this
 // is necessary to prevent dependency cycles.
 type ProofParams interface {
+	cosmostypes.Msg
+
 	GetProofRequestProbability() float64
 	GetProofRequirementThreshold() *cosmostypes.Coin
 	GetProofMissingPenalty() *cosmostypes.Coin
@@ -345,8 +347,7 @@ type ProofParams interface {
 // ProofQueryClient defines an interface that enables the querying of the
 // on-chain proof module params.
 type ProofQueryClient interface {
-	// GetParams queries the chain for the current shared module parameters.
-	GetParams(ctx context.Context) (ProofParams, error)
+	ParamsQuerier[ProofParams]
 }
 
 // ServiceQueryClient defines an interface that enables the querying of the

--- a/x/proof/types/expected_keepers.go
+++ b/x/proof/types/expected_keepers.go
@@ -49,7 +49,7 @@ type ApplicationKeeper interface {
 	GetApplication(ctx context.Context, address string) (app apptypes.Application, found bool)
 	GetAllApplications(ctx context.Context) []apptypes.Application
 	SetApplication(context.Context, apptypes.Application)
-	GetParams(context.Context) apptypes.Params
+	GetParams(ctx context.Context) apptypes.Params
 }
 
 // SharedKeeper defines the expected interface needed to retrieve shared information.

--- a/x/proof/types/query_client.go
+++ b/x/proof/types/query_client.go
@@ -1,0 +1,33 @@
+package types
+
+import (
+	"context"
+
+	gogogrpc "github.com/cosmos/gogoproto/grpc"
+
+	"github.com/pokt-network/poktroll/pkg/client"
+)
+
+// TODO_IN_THIS_COMMIT: godoc...
+type ProofQueryClient interface {
+	QueryClient
+
+	GetParams(context.Context) (client.ProofParams, error)
+}
+
+// TODO_IN_THIS_COMMIT: godoc...
+func NewProofQueryClient(conn gogogrpc.ClientConn) ProofQueryClient {
+	return NewQueryClient(conn).(ProofQueryClient)
+}
+
+// TODO_IN_THIS_COMMIT: investigate generalization...
+// TODO_IN_THIS_COMMIT: godoc...
+func (c *queryClient) GetParams(ctx context.Context) (client.ProofParams, error) {
+	res, err := c.Params(ctx, &QueryParamsRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	params := res.GetParams()
+	return &params, nil
+}


### PR DESCRIPTION
## Summary

Embed the `ParamsQuerier` interface into `ProofQueryClient` and update the implementation.

## Issue

- #543

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
