### PR TITLE
[Clients] embed `ParamsQuerier` into `SessionQueryClient`

### DIFF
--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -287,6 +287,8 @@ type SupplierQueryClient interface {
 // SessionQueryClient defines an interface that enables the querying of the
 // on-chain session information
 type SessionQueryClient interface {
+	ParamsQuerier[*sessiontypes.Params]
+
 	// GetSession queries the chain for the details of the session provided
 	GetSession(
 		ctx context.Context,
@@ -294,9 +296,6 @@ type SessionQueryClient interface {
 		serviceId string,
 		blockHeight int64,
 	) (*sessiontypes.Session, error)
-
-	// GetParams queries the chain for the session module parameters.
-	GetParams(ctx context.Context) (*sessiontypes.Params, error)
 }
 
 // SharedQueryClient defines an interface that enables the querying of the

--- a/pkg/client/query/sessionquerier.go
+++ b/pkg/client/query/sessionquerier.go
@@ -2,11 +2,16 @@ package query
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 
 	"cosmossdk.io/depinject"
 	"github.com/cosmos/gogoproto/grpc"
 
 	"github.com/pokt-network/poktroll/pkg/client"
+	"github.com/pokt-network/poktroll/pkg/client/query/cache"
+	"github.com/pokt-network/poktroll/pkg/polylog"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 )
 
@@ -16,8 +21,11 @@ var _ client.SessionQueryClient = (*sessionQuerier)(nil)
 // querying of on-chain session information through a single exposed method
 // which returns an sessiontypes.Session struct
 type sessionQuerier struct {
+	client.ParamsQuerier[*sessiontypes.Params]
+
 	clientConn     grpc.ClientConn
 	sessionQuerier sessiontypes.QueryClient
+	sessionCache   client.QueryCache[*sessiontypes.Session]
 }
 
 // NewSessionQuerier returns a new instance of a client.SessionQueryClient by
@@ -25,50 +33,97 @@ type sessionQuerier struct {
 //
 // Required dependencies:
 // - clientCtx (grpc.ClientConn)
-func NewSessionQuerier(deps depinject.Config) (client.SessionQueryClient, error) {
-	sessq := &sessionQuerier{}
+func NewSessionQuerier(
+	deps depinject.Config,
+	paramsQuerierOpts ...ParamsQuerierOptionFn,
+) (client.SessionQueryClient, error) {
+	paramsQuerierCfg := DefaultParamsQuerierConfig()
+	for _, opt := range paramsQuerierOpts {
+		opt(paramsQuerierCfg)
+	}
 
-	if err := depinject.Inject(
+	paramsQuerier, err := NewCachedParamsQuerier[*sessiontypes.Params, sessiontypes.SessionQueryClient](
+		deps, sessiontypes.NewSessionQueryClient,
+		WithModuleInfo[*sessiontypes.Params](sessiontypes.ModuleName, sessiontypes.ErrSessionParamInvalid),
+		WithParamsCacheOptions(paramsQuerierCfg.CacheOpts...),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize session cache with historical mode since sessions can vary by height
+	// TODO_IN_THIS_COMMIT: consider supporting multiple cache configs per query client.
+	sessionCache := cache.NewInMemoryCache[*sessiontypes.Session](
+		// TODO_IN_THIS_COMMIT: extract to an option fn.
+		cache.WithMaxKeys(100),
+		cache.WithEvictionPolicy(cache.LeastRecentlyUsed),
+		// TODO_IN_THIS_COMMIT: extract to a constant.
+		cache.WithTTL(time.Hour*3),
+	)
+
+	querier := &sessionQuerier{
+		ParamsQuerier: paramsQuerier,
+		sessionCache:  sessionCache,
+	}
+
+	if err = depinject.Inject(
 		deps,
-		&sessq.clientConn,
+		&querier.clientConn,
 	); err != nil {
 		return nil, err
 	}
 
-	sessq.sessionQuerier = sessiontypes.NewQueryClient(sessq.clientConn)
+	querier.sessionQuerier = sessiontypes.NewQueryClient(querier.clientConn)
 
-	return sessq, nil
+	return querier, nil
 }
 
 // GetSession returns an sessiontypes.Session struct for a given appAddress,
 // serviceId and blockHeight. It implements the SessionQueryClient#GetSession function.
-func (sessq *sessionQuerier) GetSession(
+func (sq *sessionQuerier) GetSession(
 	ctx context.Context,
 	appAddress string,
 	serviceId string,
 	blockHeight int64,
 ) (*sessiontypes.Session, error) {
+	logger := polylog.Ctx(ctx).With(
+		"querier", "session",
+		"method", "GetSession",
+	)
+
+	// Create cache key from query parameters
+	cacheKey := fmt.Sprintf("%s:%s:%d", appAddress, serviceId, blockHeight)
+
+	// Check cache first
+	cached, err := sq.sessionCache.Get(cacheKey)
+	switch {
+	case err == nil:
+		logger.Debug().Msg("cache hit")
+		return cached, nil
+	case !errors.Is(err, cache.ErrCacheMiss):
+		return nil, err
+	default:
+		logger.Debug().Msg("cache miss")
+	}
+
+	// If not cached, query the chain
 	req := &sessiontypes.QueryGetSessionRequest{
 		ApplicationAddress: appAddress,
 		ServiceId:          serviceId,
 		BlockHeight:        blockHeight,
 	}
-	res, err := sessq.sessionQuerier.GetSession(ctx, req)
+	res, err := sq.sessionQuerier.GetSession(ctx, req)
 	if err != nil {
 		return nil, ErrQueryRetrieveSession.Wrapf(
-			"address: %s; serviceId: %s; block height: %d; error: [%v]",
+			"address: %s; serviceId: %s; block height: %d; error: %s",
 			appAddress, serviceId, blockHeight, err,
 		)
 	}
-	return res.Session, nil
-}
 
-// GetParams queries & returns the session module on-chain parameters.
-func (sessq *sessionQuerier) GetParams(ctx context.Context) (*sessiontypes.Params, error) {
-	req := &sessiontypes.QueryParamsRequest{}
-	res, err := sessq.sessionQuerier.Params(ctx, req)
-	if err != nil {
-		return nil, ErrQuerySessionParams.Wrapf("[%v]", err)
+	// Cache the result before returning
+	if err = sq.sessionCache.Set(cacheKey, res.Session); err != nil {
+		return nil, err
 	}
-	return &res.Params, nil
+
+	return res.Session, nil
 }

--- a/x/session/types/query_client.go
+++ b/x/session/types/query_client.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	"context"
+
+	gogogrpc "github.com/cosmos/gogoproto/grpc"
+)
+
+// TODO_IN_THIS_COMMIT: godoc...
+type SessionQueryClient interface {
+	QueryClient
+
+	GetParams(context.Context) (*Params, error)
+}
+
+// TODO_IN_THIS_COMMIT: godoc...
+func NewSessionQueryClient(conn gogogrpc.ClientConn) SessionQueryClient {
+	return NewQueryClient(conn).(SessionQueryClient)
+}
+
+// TODO_IN_THIS_COMMIT: investigate generalization...
+// TODO_IN_THIS_COMMIT: godoc...
+func (c *queryClient) GetParams(ctx context.Context) (*Params, error) {
+	res, err := c.Params(ctx, &QueryParamsRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	params := res.GetParams()
+	return &params, nil
+}


### PR DESCRIPTION
## Summary

Embed the `ParamsQuerier` interface into SessionQueryClient and update the implementation.

## Issue

- #543

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

<!-- READ & DELETE:
- Documentation changes: only keep this if you're making documentation changes
- Unit Testing: Remove this if you didn't make code changes
- E2E Testing: Remove this if you didn't make code changes
    - See the quickstart guide for instructions: https://dev.poktroll.com/developer_guide/quickstart
- DevNet E2E Testing: Remove this if you didn't make code changes
    - THIS IS VERY EXPENSIVE: only do it after all the reviews are complete.
    - Optionally run `make trigger_ci` if you want to re-trigger tests without any code changes
    - If tests fail, try re-running failed tests only using the GitHub UI as shown [here](https://github.com/pokt-network/poktroll/assets/1892194/607984e9-0615-4569-9452-4c730190c1d2)
-->

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
