### PR TITLE
fix: E2E tests - RPC URL path

### DIFF
--- a/e2e/tests/node.go
+++ b/e2e/tests/node.go
@@ -213,6 +213,14 @@ func (p *pocketdBin) runCurlCmd(rpcBaseURL, service, method, path, appAddr, data
 	}
 	rpcUrl.Path = rpcUrl.Path + path
 
+	// Ensure that the path also ends with a "/" if it only contains the version.
+	// This is required because the server responds with a 301 redirect for "/v1"
+	// and curl binaries on some platforms MAY NOT support re-sending POST data
+	// while following a redirect (`-L` flag).
+	if strings.HasSuffix(rpcUrl.Path, "/v1") {
+		rpcUrl.Path = rpcUrl.Path + "/"
+	}
+
 	base := []string{
 		"-v",                                   // verbose output
 		"-sS",                                  // silent with error


### PR DESCRIPTION
## Summary

Update the E2E step definition which queries the gateway. The path was `/v1`, and is now `/v1/` to avoid a redirect response. 

## Issue

E2E tests involving relays fail on `main`.

Previously, `POST`ing to the `/v1` path returned a response directly; it now seems to redirect to `/v1/` which curl can't reliably handle on all platforms.

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
