### PR TITLE
[RelayMiner] Allow big transactions simulation

### DIFF
--- a/.github/workflows-helpers/run-e2e-test-job-template.yaml
+++ b/.github/workflows-helpers/run-e2e-test-job-template.yaml
@@ -50,13 +50,13 @@ spec:
             - name: POKTROLLD_HOME
               value: /root/.poktroll
             - name: PATH_URL
-              value: http://${NAMESPACE}-path:3000/v1
+              value: http://${NAMESPACE}-path:3069/v1
               # PATH relies on subdomains to get the requested service but our DevNet infra is not
               # built to expose arbitrary subdomains and supporting it would be a significant effort.
               # As a workaround, PATH_HOST_OVERRIDE is used as the host:port to connect to PATH while
               # the subdomain is passed as a Host header in the request.
             - name: PATH_HOST_OVERRIDE
-              value: ${NAMESPACE}-path:3000
+              value: ${NAMESPACE}-path:3069
           volumeMounts:
             - mountPath: /root/.poktroll/keyring-test/
               name: writable-keys-volume

--- a/config.yml
+++ b/config.yml
@@ -104,6 +104,11 @@ validators:
       instrumentation:
         prometheus: true
       log_level: "info"
+      # Increase the rpc and mempool max bytes to support larger proof transactions.
+      rpc:
+        max_body_bytes: "100000000"
+      mempool:
+        max_tx_bytes: "100000000"
     client:
       chain-id: poktroll
 

--- a/config.yml
+++ b/config.yml
@@ -104,10 +104,19 @@ validators:
       instrumentation:
         prometheus: true
       log_level: "info"
-      # Increase the rpc and mempool max bytes to support larger proof transactions.
+      # Increase the rpc and mempool max bytes to support large transactions.
+      # DEV_NOTE: These values were selected arbitrarily, but chosen to be large,
+      # as a result of load testing and seeing large proof messages during the
+      # Claim & Proof lifecycle.
       rpc:
+        # Controls how large any single RPC request accepted by the CometBFT
+        # server (offchain) can be.
         max_body_bytes: "100000000"
       mempool:
+        # Control how big any single transaction accepted by the CometBFT server
+        # (offchain) can be.
+        # Since multiple messages are bundled into a single transaction,
+        # max_tx_bytes needs to be increased alongside max_txs_bytes as well.
         max_tx_bytes: "100000000"
     client:
       chain-id: poktroll

--- a/pkg/client/tx/context.go
+++ b/pkg/client/tx/context.go
@@ -9,11 +9,21 @@ import (
 	cosmostx "github.com/cosmos/cosmos-sdk/client/tx"
 	cosmoskeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx"
 	authclient "github.com/cosmos/cosmos-sdk/x/auth/client"
+	grpc "google.golang.org/grpc"
 
 	"github.com/pokt-network/poktroll/pkg/client"
 	txtypes "github.com/pokt-network/poktroll/pkg/client/tx/types"
 )
+
+// maxGRPCMsgSize is the maximum message size the gRPC client can send and receive.
+// The current value has been arbitrarily set to a large value after observing
+// proof messages bundled within transactions exceeding the default 4MB limit.
+// TODO_TECHDEBT: Adjust the max message size to a more sensible value.
+// DEV_NOTE: This value should adjusted in concert with the CometBFT's rpc max_body_bytes,
+// mempool max_tx_bytes and max_txs_bytes.
+const maxGRPCMsgSize = 100 * 1024 * 1024 // 100MB
 
 var _ client.TxContext = (*cosmosTxContext)(nil)
 
@@ -134,10 +144,24 @@ func (txCtx cosmosTxContext) GetSimulatedTxGas(
 		WithFromName(signingKeyName).
 		WithSequence(seq)
 
-	_, gas, err := cosmostx.CalculateGas(txCtx.GetClientCtx(), txf, msgs...)
+	txBytes, err := txf.BuildSimTx(msgs...)
 	if err != nil {
 		return 0, err
 	}
 
-	return gas, nil
+	txSvcClient := tx.NewServiceClient(clientCtx)
+
+	simRequest := &tx.SimulateRequest{TxBytes: txBytes}
+	// Set the maximum message size for the gRPC client to allow large transactions
+	// (e.g. transactions with multiple proof messages) to be simulated.
+	gRPCOpts := []grpc.CallOption{
+		grpc.MaxCallSendMsgSize(maxGRPCMsgSize),
+		grpc.MaxCallRecvMsgSize(maxGRPCMsgSize),
+	}
+	simRes, err := txSvcClient.Simulate(context.Background(), simRequest, gRPCOpts...)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(txf.GasAdjustment() * float64(simRes.GasInfo.GasUsed)), nil
 }

--- a/pkg/client/tx/context.go
+++ b/pkg/client/tx/context.go
@@ -18,11 +18,12 @@ import (
 )
 
 // maxGRPCMsgSize is the maximum message size the gRPC client can send and receive.
-// The current value has been arbitrarily set to a large value after observing
-// proof messages bundled within transactions exceeding the default 4MB limit.
-// TODO_TECHDEBT: Adjust the max message size to a more sensible value.
-// DEV_NOTE: This value should adjusted in concert with the CometBFT's rpc max_body_bytes,
-// mempool max_tx_bytes and max_txs_bytes.
+// The current value has been set arbitrarily to a large value after empirically
+// observing multiple Proof messages bundled within a single transaction exceeding
+// the default 4MB limit.
+// TODO_MAINNET: Adjust the max message size to a more sensible value.
+// DEV_NOTE: This value should adjusted in concert with the CometBFT's rpc
+// max_body_bytes, mempool max_tx_bytes and max_txs_bytes.
 const maxGRPCMsgSize = 100 * 1024 * 1024 // 100MB
 
 var _ client.TxContext = (*cosmosTxContext)(nil)


### PR DESCRIPTION
## Summary

This pull request includes changes to support larger proof transactions by increasing the maximum allowed sizes for RPC and mempool, and by adjusting the gRPC client configuration.

## Issue

`RelayMiner`s simulate and broadcast transaction with multiple proofs that tend to be too large than the default gRPC client's `MaxCall{Send,Recv}MsgSize`.

![image](https://github.com/user-attachments/assets/e9d57be0-07c8-498e-9494-50b18a1fbf49)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing


- [x] **Unit Tests**: `make go_develop_and_test`
- [x] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [x] I have tested my changes using the available tooling
- [x] I have commented my code
- [x] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [x] I have left TODOs throughout the codebase, if applicable
