### PR TITLE
[Off-chain] fix: duplicate log fields

### DIFF
--- a/x/tokenomics/keeper/settle_pending_claims.go
+++ b/x/tokenomics/keeper/settle_pending_claims.go
@@ -330,36 +330,36 @@ func (k Keeper) ExecutePendingSettledResults(ctx cosmostypes.Context, settledRes
 	logger.Info(fmt.Sprintf("begin executing %d pending settlement results", len(settledResults)))
 
 	for _, settledResult := range settledResults {
-		logger = logger.With("session_id", settledResult.GetSessionId())
-		logger.Info("begin executing pending settlement result")
+		sessionLogger := logger.With("session_id", settledResult.GetSessionId())
+		sessionLogger.Info("begin executing pending settlement result")
 
-		logger.Info(fmt.Sprintf("begin executing %d pending mints", len(settledResult.GetMints())))
-		if err := k.executePendingModuleMints(ctx, logger, settledResult.GetMints()); err != nil {
+		sessionLogger.Info(fmt.Sprintf("begin executing %d pending mints", len(settledResult.GetMints())))
+		if err := k.executePendingModuleMints(ctx, sessionLogger, settledResult.GetMints()); err != nil {
 			return err
 		}
-		logger.Info("done executing pending mints")
+		sessionLogger.Info("done executing pending mints")
 
-		logger.Info(fmt.Sprintf("begin executing %d pending module to module transfers", len(settledResult.GetModToModTransfers())))
-		if err := k.executePendingModToModTransfers(ctx, logger, settledResult.GetModToModTransfers()); err != nil {
+		sessionLogger.Info(fmt.Sprintf("begin executing %d pending module to module transfers", len(settledResult.GetModToModTransfers())))
+		if err := k.executePendingModToModTransfers(ctx, sessionLogger, settledResult.GetModToModTransfers()); err != nil {
 			return err
 		}
-		logger.Info("done executing pending module account to module account transfers")
+		sessionLogger.Info("done executing pending module account to module account transfers")
 
-		logger.Info(fmt.Sprintf("begin executing %d pending module to account transfers", len(settledResult.GetModToAcctTransfers())))
-		if err := k.executePendingModToAcctTransfers(ctx, logger, settledResult.GetModToAcctTransfers()); err != nil {
+		sessionLogger.Info(fmt.Sprintf("begin executing %d pending module to account transfers", len(settledResult.GetModToAcctTransfers())))
+		if err := k.executePendingModToAcctTransfers(ctx, sessionLogger, settledResult.GetModToAcctTransfers()); err != nil {
 			return err
 		}
-		logger.Info("done executing pending module to account transfers")
+		sessionLogger.Info("done executing pending module to account transfers")
 
-		logger.Info(fmt.Sprintf("begin executing %d pending burns", len(settledResult.GetBurns())))
-		if err := k.executePendingModuleBurns(ctx, logger, settledResult.GetBurns()); err != nil {
+		sessionLogger.Info(fmt.Sprintf("begin executing %d pending burns", len(settledResult.GetBurns())))
+		if err := k.executePendingModuleBurns(ctx, sessionLogger, settledResult.GetBurns()); err != nil {
 			return err
 		}
-		logger.Info("done executing pending burns")
+		sessionLogger.Info("done executing pending burns")
 
-		logger.Info("done executing pending settlement result")
+		sessionLogger.Info("done executing pending settlement result")
 
-		logger.Info(fmt.Sprintf(
+		sessionLogger.Info(fmt.Sprintf(
 			"done applying settled results for session %q",
 			settledResult.Claim.GetSessionHeader().GetSessionId(),
 		))


### PR DESCRIPTION
## Summary

Construct a new logger instance for each session during settlement to avoid field duplication.

## Issue

- https://discord.com/channels/824324475256438814/1316109400917934201/1330007345882988665

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [ ] **Documentation**: `make docusaurus_start`; only needed if you make doc changes
- [ ] **Unit Tests**: `make go_develop_and_test`
- [ ] **LocalNet E2E Tests**: `make test_e2e`
- [ ] **DevNet E2E Tests**: Add the `devnet-test-e2e` label to the PR.

## Sanity Checklist

- [ ] I have tested my changes using the available tooling
- [ ] I have commented my code
- [ ] I have performed a self-review of my own code; both comments & source code
- [ ] I create and reference any new tickets, if applicable
- [ ] I have left TODOs throughout the codebase, if applicable
