### PR TITLE
[Workflows] Update GitHub actions from v3 to v4

### DIFF
--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -18,5 +18,5 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      # TODO_TECHDEBT: switch to `dessant/label-actions@v4` when https://github.com/dessant/label-actions/pull/29 is merged.
+      # TODO_TECHDEBT: switch to `dessant/label-actions@v3` when https://github.com/dessant/label-actions/pull/29 is merged.
       - uses: okdas/label-actions@patch-1

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -18,5 +18,5 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      # TODO_TECHDEBT: switch to `dessant/label-actions@v3` when https://github.com/dessant/label-actions/pull/29 is merged.
+      # TODO_TECHDEBT: switch to `dessant/label-actions@v4` when https://github.com/dessant/label-actions/pull/29 is merged.
       - uses: okdas/label-actions@patch-1

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: (github.ref == 'refs/heads/main') || (contains(github.event.pull_request.labels.*.name, 'push-image')) || (contains(github.event.pull_request.labels.*.name, 'devnet-test-e2e'))
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker Metadata action
         if: (github.ref == 'refs/heads/main') || (contains(github.event.pull_request.labels.*.name, 'push-image')) || (contains(github.event.pull_request.labels.*.name, 'devnet-test-e2e'))
@@ -59,7 +59,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: (github.ref == 'refs/heads/main') || (contains(github.event.pull_request.labels.*.name, 'push-image')) || (contains(github.event.pull_request.labels.*.name, 'devnet-test-e2e'))
-        uses: docker/login-action@v4
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -13,7 +13,7 @@ jobs:
   build-push-container:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: "0" # Per https://github.com/ignite/cli/issues/1674#issuecomment-1144619147
 
@@ -40,7 +40,7 @@ jobs:
 
       - name: Set up Docker Buildx
         if: (github.ref == 'refs/heads/main') || (contains(github.event.pull_request.labels.*.name, 'push-image')) || (contains(github.event.pull_request.labels.*.name, 'devnet-test-e2e'))
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker Metadata action
         if: (github.ref == 'refs/heads/main') || (contains(github.event.pull_request.labels.*.name, 'push-image')) || (contains(github.event.pull_request.labels.*.name, 'devnet-test-e2e'))
@@ -59,7 +59,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: (github.ref == 'refs/heads/main') || (contains(github.event.pull_request.labels.*.name, 'push-image')) || (contains(github.event.pull_request.labels.*.name, 'devnet-test-e2e'))
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -13,7 +13,7 @@ jobs:
   release-artifacts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: "0" # Per https://github.com/ignite/cli/issues/1674#issuecomment-1144619147
 
@@ -44,7 +44,7 @@ jobs:
           make cosmovisor_cross_compile
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker Metadata action
         id: meta
@@ -62,7 +62,7 @@ jobs:
             type=sha,format=long,suffix=-prod
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -44,7 +44,7 @@ jobs:
           make cosmovisor_cross_compile
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker Metadata action
         id: meta

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -82,7 +82,7 @@ jobs:
 
       # TODO_TECHDEBT(@okdas): use for releases (also change the "on" part at the top so it only tgirrered for tags/releases)
       - name: Add release and publish binaries
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             release/*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
   go-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: "0" # Per https://github.com/ignite/cli/issues/1674#issuecomment-1144619147
 

--- a/.github/workflows/upload-pages-artifact.yml
+++ b/.github/workflows/upload-pages-artifact.yml
@@ -83,7 +83,7 @@ jobs:
           yarn build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
         with:
           enablement: true
 
@@ -94,4 +94,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/upload-pages-artifact.yml
+++ b/.github/workflows/upload-pages-artifact.yml
@@ -16,7 +16,7 @@ jobs:
   update-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: "0" # Per https://github.com/ignite/cli/issues/1674#issuecomment-1144619147
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -63,7 +63,7 @@ jobs:
       pages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/upload-pages-artifact.yml
+++ b/.github/workflows/upload-pages-artifact.yml
@@ -88,7 +88,7 @@ jobs:
           enablement: true
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docusaurus/build
 


### PR DESCRIPTION
## Summary

Upgrade github ations from `v3` to `v4`.

## Issue

### Origin Document

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
<img width="1006" alt="Screenshot 2025-01-23 at 2 32 22 PM" src="https://github.com/user-attachments/assets/bcf75024-c2bb-4c2c-b38f-90d2d864af2a" />

### Example in action

<img width="1678" alt="Screenshot 2025-01-23 at 2 32 40 PM" src="https://github.com/user-attachments/assets/a0fddefd-71df-49f0-aa53-1ecb827e85af" />

https://github.com/buildwithgrove/path/actions/runs/12935368023/job/36078630477