### PR TITLE
[Tokenomics] Reduce MinProofSubmissionFee

### DIFF
--- a/x/proof/types/params.go
+++ b/x/proof/types/params.go
@@ -36,7 +36,7 @@ var (
 	ParamProofSubmissionFee = "proof_submission_fee"
 	// TODO_MAINNET: Determine a sensible default value for the proof submission fee.
 	// MinProofSubmissionFee is the default and minimum fee for submitting a proof.
-	MinProofSubmissionFee = cosmostypes.NewCoin(volatile.DenomuPOKT, math.NewInt(1000000))
+	MinProofSubmissionFee = cosmostypes.NewCoin(volatile.DenomuPOKT, math.NewInt(100))
 )
 
 // ParamKeyTable the param key table for launch module


### PR DESCRIPTION
## Summary

Reducing `MinProofSubmissionFee`.

Changes:
- Reducing `1000000` to `100`

## Issue

- Description: Beta TestNet tests indicated that we require too large of a submission fee. Tried to lower the fee, but this value prevented the param change.
- Issue: https://www.notion.so/buildwithgrove/Load-Testing-Findings-15aa36edfff68020a324d1b0d490dec4?pvs=4

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
