### PR TITLE
[Docs] Followup on making homebrew troubleshooting easier to identify

### DIFF
--- a/cmd/poktrolld/cmd/root.go
+++ b/cmd/poktrolld/cmd/root.go
@@ -62,8 +62,12 @@ func NewRootCmd() *cobra.Command {
 	}
 
 	rootCmd := &cobra.Command{
-		Use:           app.Name + "d",
-		Short:         "Start poktroll node",
+		Use:   app.Name + "d",
+		Short: "Interface with Pocket Network",
+		Long: `poktrolld is a binary that can be used to query, send transaction or start Pocket Network actors.
+
+		For additional documentation, see https://dev.poktroll.com/tools/user_guide/poktrolld_cli
+		`,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) (err error) {
 			// set the default command outputs

--- a/docusaurus/docs/tools/user_guide/poktrolld_cli.md
+++ b/docusaurus/docs/tools/user_guide/poktrolld_cli.md
@@ -16,7 +16,7 @@ brew install poktrolld
 
 - [MacOS \& Linux Users](#macos--linux-users)
   - [Using Homebrew](#using-homebrew)
-    - [Troubleshooting Homebrew](#troubleshooting-homebrew)
+  - [Troubleshooting Homebrew](#troubleshooting-homebrew)
   - [From Source](#from-source)
     - [Installing dependencies](#installing-dependencies)
     - [Installing poktrolld](#installing-poktrolld)
@@ -49,7 +49,13 @@ repository for details on how to install homebrew or other details to install
 or debug the CLI.
 :::
 
-#### Troubleshooting Homebrew
+### Troubleshooting Homebrew
+
+:::info Having issues with Homebrew?
+
+Read this section if you're having problems downloading or upgrading your `poktrolld` binary using Homebrew.
+
+:::
 
 The source code for the Homebrew formula is available in the [homebrew-poktroll](https://github.com/pokt-network/homebrew-poktroll) repository.
 


### PR DESCRIPTION
## Summary

- Update `poktrolld` CLI description and documentation structure

### Primary Changes:
- Update CLI description to clarify `poktrolld` as a comprehensive interface for Pocket Network interactions
- Add detailed `Long` description with link to documentation at `dev.poktroll.com`

### Secondary changes:
- Fix indentation in documentation table of contents
- Enhance Homebrew troubleshooting section with improved formatting and descriptive info box

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)
