### PR TITLE
Update links to Soothe's Explorer and GraphQL Playground

### DIFF
--- a/docusaurus/docs/tools/tools/shannon_alpha.md
+++ b/docusaurus/docs/tools/tools/shannon_alpha.md
@@ -5,5 +5,5 @@ sidebar_position: 1
 
 - 🪙 [Token Faucet](https://faucet.alpha.testnet.pokt.network/)
 - 🗺️ [Explorer](https://shannon.alpha.testnet.pokt.network)
-- 🗺️ [POKTScan's Explorer](https://shannon-alpha.poktscan.com/)
-- 👨‍💻 [POKTScan's GraphQL Playground](https://shannon-alpha-api.poktscan.com/)
+- 🗺️ [Soothe's Explorer](https://shannon-alpha.trustsoothe.io/)
+- 👨‍💻 [Soothe's GraphQL Playground](https://shannon-alpha-api.trustsoothe.io/)

--- a/docusaurus/docs/tools/tools/shannon_beta.md
+++ b/docusaurus/docs/tools/tools/shannon_beta.md
@@ -5,5 +5,5 @@ sidebar_position: 1
 
 - 🪙 [Token Faucet](https://faucet.beta.testnet.pokt.network/)
 - 🗺️ [Explorer](https://shannon.beta.testnet.pokt.network)
-- 🗺️ [POKTScan's Explorer](https://shannon-beta.poktscan.com/)
-- 👨‍💻 [POKTScan's GraphQL Playground](https://shannon-beta-api.poktscan.com/)
+- 🗺️ [Soothe's Explorer](https://shannon-beta.trustsoothe.io/)
+- 👨‍💻 [Soothe's GraphQL Playground](https://shannon-beta-api.trustsoothe.io/)


### PR DESCRIPTION
## Summary

Replaced outdated POKTScan links with Soothe's updated counterparts for both Shannon Alpha and Beta documentation. This ensures users are directed to the correct tools and information.

Changes:
- Update Beta Explorer page
- Update Alpha Explorer page 

## Issue

- Description: Alpha and Beta explorer page was out of date.

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [x] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
