### PR TITLE
[Bug] fix: E2E test `s/X-App-Address/App-Address/`

### DIFF
--- a/e2e/tests/node.go
+++ b/e2e/tests/node.go
@@ -216,7 +216,7 @@ func (p *pocketdBin) runCurlCmd(rpcBaseURL, service, method, path, appAddr, data
 		"-H", `Content-Type: application/json`, // HTTP headers
 		"-H", fmt.Sprintf("Host: %s", rpcUrl.Host), // Add virtual host header
 		"-H", fmt.Sprintf("App-Address: %s", appAddr),
-		"-H", fmt.Sprintf("target-service-id: %s", service),
+		"-H", fmt.Sprintf("Target-Service-Id: %s", service),
 		rpcUrl.String(),
 	}
 

--- a/e2e/tests/node.go
+++ b/e2e/tests/node.go
@@ -215,7 +215,7 @@ func (p *pocketdBin) runCurlCmd(rpcBaseURL, service, method, path, appAddr, data
 		"-sS",                                  // silent with error
 		"-H", `Content-Type: application/json`, // HTTP headers
 		"-H", fmt.Sprintf("Host: %s", rpcUrl.Host), // Add virtual host header
-		"-H", fmt.Sprintf("X-App-Address: %s", appAddr),
+		"-H", fmt.Sprintf("App-Address: %s", appAddr),
 		"-H", fmt.Sprintf("target-service-id: %s", service),
 		rpcUrl.String(),
 	}

--- a/load-testing/tests/relays_stress_helpers_test.go
+++ b/load-testing/tests/relays_stress_helpers_test.go
@@ -1058,7 +1058,7 @@ func (s *relaysSuite) sendRelay(iteration uint64, relayPayload string) (appAddre
 		// deprecates the X-App-Address header.
 		// This is needed by the PATH Gateway's trusted mode to identify the application
 		// that is sending the relay request.
-		req.Header.Add("X-App-Address", appAddr)
+		req.Header.Add("App-Address", appAddr)
 		req.Header.Add("target-service-id", "anvil")
 		res, err := http.DefaultClient.Do(req)
 		require.NoError(s, err)

--- a/load-testing/tests/relays_stress_helpers_test.go
+++ b/load-testing/tests/relays_stress_helpers_test.go
@@ -1054,12 +1054,10 @@ func (s *relaysSuite) sendRelay(iteration uint64, relayPayload string) (appAddre
 	sendRelayRequest := func(gatewayURL, appAddr, payload string) {
 		req, err := http.NewRequest("POST", gatewayURL, strings.NewReader(payload))
 
-		// TODO_TECHDEBT(red-0ne): Use 'app-address' instead of 'X-App-Address' once PATH Gateway
-		// deprecates the X-App-Address header.
 		// This is needed by the PATH Gateway's trusted mode to identify the application
 		// that is sending the relay request.
 		req.Header.Add("App-Address", appAddr)
-		req.Header.Add("target-service-id", "anvil")
+		req.Header.Add("Target-Service-Id", "anvil")
 		res, err := http.DefaultClient.Do(req)
 		require.NoError(s, err)
 

--- a/makefiles/relay.mk
+++ b/makefiles/relay.mk
@@ -5,8 +5,8 @@
 .PHONY: send_relay_path_JSONRPC
 send_relay_path_JSONRPC: test_e2e_env ## Send a JSONRPC relay through PATH to a local anvil (test ETH) node
 	curl -X POST -H "Content-Type: application/json" \
-		-H "X-App-Address: pokt1mrqt5f7qh8uxs27cjm9t7v9e74a9vvdnq5jva4" \
-		-H "target-service-id: anvil" \
+		-H "App-Address: pokt1mrqt5f7qh8uxs27cjm9t7v9e74a9vvdnq5jva4" \
+		-H "Target-Service-Id: anvil" \
 		--data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
 		http://localhost:3000/v1/
 
@@ -15,7 +15,7 @@ send_relay_path_JSONRPC: test_e2e_env ## Send a JSONRPC relay through PATH to a 
 .PHONY: send_relay_path_REST
 send_relay_path_REST: acc_initialize_pubkeys ## Send a REST relay through PATH to a local ollama (LLM) service
 	@echo "Not implemented yet. Check if PATH supports REST relays yet: https://github.com/buildwithgrove/path/issues/87"
-# curl -X POST -H "Content-Type: application/json" -H "X-App-Address: pokt1mrqt5f7qh8uxs27cjm9t7v9e74a9vvdnq5jva4" \
+# curl -X POST -H "Content-Type: application/json" -H "App-Address: pokt1mrqt5f7qh8uxs27cjm9t7v9e74a9vvdnq5jva4" \
 # --data '{"model": "qwen:0.5b", "stream": false, "messages": [{"role": "user", "content":"count from 1 to 10"}]}' \
 # $(subst http://,http://ollama.,$(PATH_URL))/api/chat
 


### PR DESCRIPTION
## Summary

I observed E2E test(s) failing on main (`make test_e2e_tokenomics`):

```
                Error Trace:    /home/bwhite/Projects/pokt/poktroll/e2e/tests/init_test.go:492
                                                        /home/bwhite/Projects/pokt/poktroll/e2e/tests/session_steps_test.go:232
                                                        /home/bwhite/Projects/pokt/poktroll/e2e/tests/session_steps_test.go:163
                                                        /home/bwhite/.pkgx/go.dev/v1.23.0/src/reflect/value.go:581
                                                        /home/bwhite/.pkgx/go.dev/v1.23.0/src/reflect/value.go:365
                                                        /home/bwhite/go/pkg/mod/github.com/regen-network/gocuke@v1.1.0/run_step.go:103
                                                        /home/bwhite/go/pkg/mod/github.com/regen-network/gocuke@v1.1.0/run_scenario.go:121
                                                        /home/bwhite/go/pkg/mod/github.com/regen-network/gocuke@v1.1.0/run_scenario.go:70
                                                        /home/bwhite/go/pkg/mod/github.com/regen-network/gocuke@v1.1.0/run_doc.go:34
                Error:          Expected nil, but got: map[string]interface {}{"code":-32000, "data":map[string]interface {}{"retryable":"true"}, "message":"Endpoint (data/service node error): Received an empty response. The endpoint will be dropped from the selection pool. Please try again."}
```

Changes:
- Replace `X-App-Address` HTTP header with `App-Address`
- Replayce `target-service-id` HTTP header with `Target-Service-Id`

## Issue

PATH has deprecated `X-App-Address` in favor of `App-Address`. Update E2E tests to use the latter.

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [x] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [x] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
