### PR TITLE
[DOCS] Revamping the Full Node Documentation

### DIFF
--- a/docusaurus/docs/operate/walkthroughs/full_node_walkthrough.md
+++ b/docusaurus/docs/operate/walkthroughs/full_node_walkthrough.md
@@ -44,17 +44,25 @@ to enable automatic binary upgrades.
 3. **Dedicated Server or Virtual Machine**: Any provider is acceptable.
 
 ## Instructions
-
+_This guide will walk you through Debian-based instructions._
 ### 1. Install Dependencies
 
 Update your package list and install necessary dependencies:
+
+**Install `curl`, `tar`, `wget`, `jq`**
 
 ```bash
 sudo apt-get update
 sudo apt-get install -y curl tar wget jq
 ```
 
-### 2. Create a New User
+**Install `go`**
+Follow the official `go` installation instructions [here](https://go.dev/doc/install).
+
+
+### 2. [OPTIONAL] Create a New User
+
+It is considered good practice to not run the binary as `root`. The below instructions will show you how to create a user with scope to run the node.
 
 Create a dedicated user to run `poktrolld`:
 
@@ -93,26 +101,7 @@ source ~/.profile
 
 ### 4. Install Cosmovisor
 
-**Option 1**: You can follow the official Cosmovisor installation instructions [here](https://docs.cosmos.network/main/build/tooling/cosmovisor#installation).
-
-**Option 2**: You can simply copy-paste the following commands to download and install Cosmovisor:
-
-```bash
-mkdir -p $HOME/.local/bin
-COSMOVISOR_VERSION="v1.6.0"
-
-ARCH=$(uname -m)
-if [ "$ARCH" = "x86_64" ]; then
-    ARCH="amd64"
-elif [ "$ARCH" = "aarch64" ]; then
-    ARCH="arm64"
-fi
-
-curl -L "https://github.com/cosmos/cosmos-sdk/releases/download/cosmovisor%2F${COSMOVISOR_VERSION}/cosmovisor-${COSMOVISOR_VERSION}-linux-${ARCH}.tar.gz" | tar -zxvf - -C $HOME/.local/bin
-
-echo 'export PATH=$HOME/.local/bin:$PATH' >> ~/.profile
-source ~/.profile
-```
+Follow the official Cosmovisor installation instructions [here](https://docs.cosmos.network/main/build/tooling/cosmovisor#installation).
 
 ### 5. Install `poktrolld`
 

--- a/docusaurus/docs/tools/user_guide/poktrolld_cli.md
+++ b/docusaurus/docs/tools/user_guide/poktrolld_cli.md
@@ -14,13 +14,13 @@ brew install poktrolld
 
 ## Table of Contents <!-- omit in toc -->
 
-- [MacOS \& Linux Users](#macos--linux-users)
+- [MacOS Users](#macos-users)
   - [Using Homebrew (recommended)](#using-homebrew-recommended)
   - [Using release binaries (if you don't have brew)](#using-release-binaries-if-you-dont-have-brew)
   - [From Source (danger zone)](#from-source-danger-zone)
 - [Windows Users (why!?)](#windows-users-why)
 
-## MacOS & Linux Users
+## MacOS Users
 
 ### Using Homebrew (recommended)
 
@@ -112,7 +112,7 @@ This method is only recommended for **ADVANCED** users as it requires working wi
 Ensure you have the following installed:
 
 - [Go](https://go.dev/doc/install) (version 1.23 or later)
-  - Make sure to add `export PATH=$PATH:$(go env GOPATH)/bin/` to your `.bashrc` or `.zshrc` file.
+- [Make](https://www.gnu.org/software/make/)
 - [Ignite CLI](https://docs.ignite.com/welcome/install)
 
 #### Installing poktrolld <!-- omit in toc -->
@@ -144,10 +144,9 @@ poktrolld --help
 
 :::danger
 
-Why? 🥴 ⁉️
-
-:::
-
 Currently, we do not support native Windows installation. Windows users are encouraged
 to use [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/install)
 and follow the Linux installation instructions.
+
+:::
+


### PR DESCRIPTION
## Summary

Some edits and fixes to the existing Fullnode documentation

Changes:
- Fixes and tweaks to https://dev.poktroll.com/operate/walkthroughs/full_node_walkthrough
- Fixes and tweaks to 

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
