### PR TITLE
[Upgrade] TestNet v0.0.13 upgrade

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -21,7 +21,10 @@ var allUpgrades = []upgrades.Upgrade{
 	// upgrades.Upgrade_0_0_11,
 
 	// v0.0.12 - the first upgrade going live on both Alpha and Beta TestNets.
-	upgrades.Upgrade_0_0_12,
+	// upgrades.Upgrade_0_0_12,
+
+	// v0.0.13 - this upgrade introduces morse migration module and websocket service handling.
+	upgrades.Upgrade_0_0_13,
 }
 
 // setUpgrades sets upgrade handlers for all upgrades and executes KVStore migration if an upgrade plan file exists.

--- a/app/upgrades/v0.0.13.go
+++ b/app/upgrades/v0.0.13.go
@@ -1,0 +1,74 @@
+package upgrades
+
+import (
+	"context"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	cosmosTypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/pokt-network/poktroll/app/keepers"
+	migrationtypes "github.com/pokt-network/poktroll/x/migration/types"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+)
+
+const Upgrade_0_0_13_PlanName = "v0.0.13"
+
+// Upgrade_0_0_13 handles the upgrade to release `v0.0.13`.
+// This is planned to be issued on both Pocket Network's Shannon Alpha & Beta TestNets.
+var Upgrade_0_0_13 = Upgrade{
+	PlanName: Upgrade_0_0_13_PlanName,
+	CreateUpgradeHandler: func(mm *module.Manager,
+		keepers *keepers.Keepers,
+		configurator module.Configurator,
+	) upgradetypes.UpgradeHandler {
+		applyNewParameters := func(ctx context.Context) (err error) {
+			logger := cosmosTypes.UnwrapSDKContext(ctx).Logger()
+			logger.Info("Starting parameter updates", "upgrade_plan_name", Upgrade_0_0_13_PlanName)
+
+			sharedParams := keepers.SharedKeeper.GetParams(ctx)
+			sharedParams.GatewayUnbondingPeriodSessions = sharedtypes.DefaultGatewayUnbondingPeriodSessions
+			err = keepers.SharedKeeper.SetParams(ctx, sharedParams)
+			if err != nil {
+				logger.Error("Failed to set shared params", "error", err)
+				return err
+			}
+			logger.Info("Successfully updated shared params", "new_params", sharedParams)
+
+			return nil
+		}
+
+		// Returns the upgrade handler for v0.0.13
+		return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+			logger := cosmosTypes.UnwrapSDKContext(ctx).Logger()
+			logger.Info("Starting upgrade handler", "upgrade_plan_name", Upgrade_0_0_13_PlanName)
+
+			logger.Info("Starting parameter updates section", "upgrade_plan_name", Upgrade_0_0_13_PlanName)
+			// Update all governance parameter changes.
+			// This includes adding params, removing params and changing values of existing params.
+			err := applyNewParameters(ctx)
+			if err != nil {
+				logger.Error("Failed to apply new parameters",
+					"upgrade_plan_name", Upgrade_0_0_13_PlanName,
+					"error", err)
+				return vm, err
+			}
+
+			logger.Info("Starting module migrations section", "upgrade_plan_name", Upgrade_0_0_13_PlanName)
+			vm, err = mm.RunMigrations(ctx, configurator, vm)
+			if err != nil {
+				logger.Error("Failed to run migrations",
+					"upgrade_plan_name", Upgrade_0_0_13_PlanName,
+					"error", err)
+				return vm, err
+			}
+
+			logger.Info("Successfully completed upgrade handler", "upgrade_plan_name", Upgrade_0_0_13_PlanName)
+			return vm, nil
+		}
+	},
+	// Add the migration module KVStore in this upgrade.
+	StoreUpgrades: storetypes.StoreUpgrades{
+		Added: []string{migrationtypes.StoreKey},
+	},
+}

--- a/app/upgrades/v0.0.13.go
+++ b/app/upgrades/v0.0.13.go
@@ -28,6 +28,13 @@ var Upgrade_0_0_13 = Upgrade{
 
 			sharedParams := keepers.SharedKeeper.GetParams(ctx)
 			sharedParams.GatewayUnbondingPeriodSessions = sharedtypes.DefaultGatewayUnbondingPeriodSessions
+
+			// Ensure that the new parameters are valid
+			if err := sharedParams.ValidateBasic(); err != nil {
+				logger.Error("Failed to validate shared params", "error", err)
+				return err
+			}
+
 			err = keepers.SharedKeeper.SetParams(ctx, sharedParams)
 			if err != nil {
 				logger.Error("Failed to set shared params", "error", err)
@@ -69,6 +76,7 @@ var Upgrade_0_0_13 = Upgrade{
 	},
 	// Add the migration module KVStore in this upgrade.
 	StoreUpgrades: storetypes.StoreUpgrades{
+		// Add the new morse migration module KVStore to the upgrade plan.
 		Added: []string{migrationtypes.StoreKey},
 	},
 }

--- a/app/upgrades/v0.0.13.go
+++ b/app/upgrades/v0.0.13.go
@@ -30,7 +30,7 @@ var Upgrade_0_0_13 = Upgrade{
 			sharedParams.GatewayUnbondingPeriodSessions = sharedtypes.DefaultGatewayUnbondingPeriodSessions
 
 			// Ensure that the new parameters are valid
-			if err := sharedParams.ValidateBasic(); err != nil {
+			if err = sharedParams.ValidateBasic(); err != nil {
 				logger.Error("Failed to validate shared params", "error", err)
 				return err
 			}

--- a/docusaurus/docs/operate/upgrades/upgrade_procedure.md
+++ b/docusaurus/docs/operate/upgrades/upgrade_procedure.md
@@ -55,6 +55,8 @@ An upgrade is necessary whenever there's an API, State Machine, or other Consens
    - Refer to `historical.go` for past upgrades and examples.
    - Consult Cosmos-sdk documentation on upgrades for additional guidance on [building-apps/app-upgrade](https://docs.cosmos.network/main/build/building-apps/app-upgrade) and [modules/upgrade](https://docs.cosmos.network/main/build/modules/upgrade).
 
+3. Update the `app/upgrades.go` file to include the new upgrade plan in `allUpgrades`.
+
 :::info
 
 Creating a new upgrade plan **MUST BE DONE** even if there are no state changes.


### PR DESCRIPTION
## Summary

Introduces `v0.0.13` upgrade handler with migration module and parameter updates.

### Primary Changes:
- Adds `v0.0.13` upgrade handler with parameter updates and migrations support
- Integrates morse `migration` module KVStore into the upgrade process
- Updates `GatewayUnbondingPeriodSessions` parameter to default value

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Other (Chain upgrade)

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [x] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
