### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/pkg/relayer/proxy/server_builder.go
+++ b/pkg/relayer/proxy/server_builder.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/pokt-network/poktroll/pkg/relayer"
 	"github.com/pokt-network/poktroll/pkg/relayer/config"


### PR DESCRIPTION
## Summary

< One line summary>

Since Go 1.21, the functions in x/exp used here can already be replaced by functions from the standard library.

Changes:
- < Change 1 >
- < Change 2 > 

## Issue

- Description: < Description > 
- Issue: #{ISSUE_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
