### PR TITLE
[Migration Module] refactor: remove unused gateway keeper dependency

### DIFF
--- a/testutil/integration/app.go
+++ b/testutil/integration/app.go
@@ -527,7 +527,6 @@ func NewCompleteIntegrationApp(t *testing.T, opts ...IntegrationAppOptionFn) *Ap
 		accountKeeper,
 		bankKeeper,
 		sharedKeeper,
-		gatewayKeeper,
 		applicationKeeper,
 		supplierKeeper,
 	)

--- a/testutil/keeper/migration.go
+++ b/testutil/keeper/migration.go
@@ -31,7 +31,6 @@ import (
 type MigrationKeeperConfig struct {
 	bankKeeper     migrationtypes.BankKeeper
 	sharedKeeper   migrationtypes.SharedKeeper
-	gatewayKeeper  migrationtypes.GatewayKeeper
 	appKeeper      migrationtypes.ApplicationKeeper
 	supplierKeeper migrationtypes.SupplierKeeper
 }
@@ -74,7 +73,6 @@ func MigrationKeeper(
 		mockAccountKeeper,
 		cfg.bankKeeper,
 		cfg.sharedKeeper,
-		cfg.gatewayKeeper,
 		cfg.appKeeper,
 		cfg.supplierKeeper,
 	)
@@ -93,13 +91,6 @@ func MigrationKeeper(
 func WithBankKeeper(bankKeeper migrationtypes.BankKeeper) MigrationKeeperOptionFn {
 	return func(cfg *MigrationKeeperConfig) {
 		cfg.bankKeeper = bankKeeper
-	}
-}
-
-// WithGatewayKeeper assigns the given GatewayKeeper to the MigrationKeeperConfig.
-func WithGatewayKeeper(gatewayKeeper migrationtypes.GatewayKeeper) MigrationKeeperOptionFn {
-	return func(cfg *MigrationKeeperConfig) {
-		cfg.gatewayKeeper = gatewayKeeper
 	}
 }
 
@@ -124,6 +115,8 @@ func WithSupplierKeeper(supplierKeeper migrationtypes.SupplierKeeper) MigrationK
 //   - SendCoinsFromModuleToAccount
 //
 // 2. A Mocked shared keeper which responds to the Params method with the default params.
+// 3. A Mocked app keeper.
+// 4. A Mocked supplier keeper.
 func defaultConfigWithMocks(ctrl *gomock.Controller) *MigrationKeeperConfig {
 	mockBankKeeper := mocks.NewMockBankKeeper(ctrl)
 	mockBankKeeper.EXPECT().
@@ -140,14 +133,6 @@ func defaultConfigWithMocks(ctrl *gomock.Controller) *MigrationKeeperConfig {
 	sharedKeeper.EXPECT().
 		GetParams(gomock.Any()).
 		Return(sharedtypes.DefaultParams()).
-		AnyTimes()
-
-	mockGatewayKeeper := mocks.NewMockGatewayKeeper(ctrl)
-	mockGatewayKeeper.EXPECT().
-		GetGateway(gomock.Any(), gomock.Any()).
-		AnyTimes()
-	mockGatewayKeeper.EXPECT().
-		SetGateway(gomock.Any(), gomock.Any()).
 		AnyTimes()
 
 	mockAppKeeper := mocks.NewMockApplicationKeeper(ctrl)
@@ -169,7 +154,6 @@ func defaultConfigWithMocks(ctrl *gomock.Controller) *MigrationKeeperConfig {
 	return &MigrationKeeperConfig{
 		bankKeeper:     mockBankKeeper,
 		sharedKeeper:   sharedKeeper,
-		gatewayKeeper:  mockGatewayKeeper,
 		appKeeper:      mockAppKeeper,
 		supplierKeeper: mockSupplierKeeper,
 	}

--- a/testutil/keeper/tokenomics.go
+++ b/testutil/keeper/tokenomics.go
@@ -535,7 +535,6 @@ func NewTokenomicsModuleKeepers(
 		accountKeeper,
 		bankKeeper,
 		sharedKeeper,
-		gatewayKeeper,
 		appKeeper,
 		supplierKeeper,
 	)

--- a/x/migration/keeper/keeper.go
+++ b/x/migration/keeper/keeper.go
@@ -24,7 +24,6 @@ type (
 		accountKeeper  types.AccountKeeper
 		bankKeeper     types.BankKeeper
 		sharedKeeper   types.SharedKeeper
-		gatewayKeeper  types.GatewayKeeper
 		appKeeper      types.ApplicationKeeper
 		supplierKeeper types.SupplierKeeper
 	}
@@ -38,7 +37,6 @@ func NewKeeper(
 	accountKeeper types.AccountKeeper,
 	bankKeeper types.BankKeeper,
 	sharedKeeper types.SharedKeeper,
-	gatewayKeeper types.GatewayKeeper,
 	appKeeper types.ApplicationKeeper,
 	supplierKeeper types.SupplierKeeper,
 ) Keeper {
@@ -54,7 +52,6 @@ func NewKeeper(
 		accountKeeper:  accountKeeper,
 		bankKeeper:     bankKeeper,
 		sharedKeeper:   sharedKeeper,
-		gatewayKeeper:  gatewayKeeper,
 		appKeeper:      appKeeper,
 		supplierKeeper: supplierKeeper,
 	}

--- a/x/migration/module/module.go
+++ b/x/migration/module/module.go
@@ -192,7 +192,6 @@ type ModuleInputs struct {
 	AccountKeeper     types.AccountKeeper
 	BankKeeper        types.BankKeeper
 	SharedKeeper      types.SharedKeeper
-	GatewayKeeper     types.GatewayKeeper
 	ApplicationKeeper types.ApplicationKeeper
 	SupplierKeeper    types.SupplierKeeper
 }
@@ -218,7 +217,6 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		in.AccountKeeper,
 		in.BankKeeper,
 		in.SharedKeeper,
-		in.GatewayKeeper,
 		in.ApplicationKeeper,
 		in.SupplierKeeper,
 	)

--- a/x/migration/types/expected_keepers.go
+++ b/x/migration/types/expected_keepers.go
@@ -1,4 +1,4 @@
-//go:generate go run go.uber.org/mock/mockgen -destination ../../../testutil/migration/mocks/expected_keepers_mock.go -package mocks . AccountKeeper,BankKeeper,SharedKeeper,GatewayKeeper,ApplicationKeeper,SupplierKeeper
+//go:generate go run go.uber.org/mock/mockgen -destination ../../../testutil/migration/mocks/expected_keepers_mock.go -package mocks . AccountKeeper,BankKeeper,SharedKeeper,ApplicationKeeper,SupplierKeeper
 
 package types
 
@@ -8,7 +8,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	apptypes "github.com/pokt-network/poktroll/x/application/types"
-	"github.com/pokt-network/poktroll/x/gateway/types"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
 
@@ -24,11 +23,6 @@ type BankKeeper interface {
 	MintCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
 	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	// Methods imported from bank should be defined here
-}
-
-type GatewayKeeper interface {
-	GetGateway(ctx context.Context, address string) (gateway types.Gateway, found bool)
-	SetGateway(ctx context.Context, gateway types.Gateway)
 }
 
 type ApplicationKeeper interface {


### PR DESCRIPTION
## Summary

Remove unused gateway keeper from the migration module.

## Issue

- Issue: #1034

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
