### PR TITLE
[Docs] Update titles for guides and deployments with approximate time & deprecation

### DIFF
--- a/docusaurus/docs/operate/cheat_sheets/_category_.json
+++ b/docusaurus/docs/operate/cheat_sheets/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Stake & Deploy Cheat Sheets",
+  "label": "Cheat Sheets to Stake & Deploy (Intermediate)",
   "position": 1,
   "link": {
     "type": "generated-index",

--- a/docusaurus/docs/operate/cheat_sheets/docker_compose_debian_cheatsheet.md
+++ b/docusaurus/docs/operate/cheat_sheets/docker_compose_debian_cheatsheet.md
@@ -1,11 +1,11 @@
 ---
-sidebar_position: 6
-title: Docker Compose Cheat Sheet
+sidebar_position: 7
+title: "[Deprecated] Docker Compose Cheat Sheet (> 1 hour)"
 ---
 
 import ReactPlayer from "react-player";
 
-# Docker Compose Cheat Sheet <!-- omit in toc -->
+## Docker Compose Cheat Sheet <!-- omit in toc -->
 
 - [Results](#results)
 - [Deploy your server](#deploy-your-server)

--- a/docusaurus/docs/operate/cheat_sheets/full_node_cheatsheet.md
+++ b/docusaurus/docs/operate/cheat_sheets/full_node_cheatsheet.md
@@ -1,6 +1,6 @@
 ---
-title: Full Node Cheat Sheet
-sidebar_position: 1
+title: Full Node Cheat Sheet (~10 min)
+sidebar_position: 2
 ---
 
 **🖨 🍝 instructions to get you up and running with a `Full Node` on Pocket Network using `Systemd` and `Cosmovisor` ✅**

--- a/docusaurus/docs/operate/cheat_sheets/gateway_cheatsheet.md
+++ b/docusaurus/docs/operate/cheat_sheets/gateway_cheatsheet.md
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 4
-title: Gateway Cheat Sheet
+sidebar_position: 6
+title: App & PATH Gateway (~30 min)
 ---
 
 ## Gateway Cheat Sheet <!-- omit in toc -->

--- a/docusaurus/docs/operate/cheat_sheets/service_cheatsheet.md
+++ b/docusaurus/docs/operate/cheat_sheets/service_cheatsheet.md
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 2
-title: Service Cheat Sheet
+sidebar_position: 1
+title: Service Cheat Sheet (~ 5 min)
 ---
 
 ## Service Cheat Sheet <!-- omit in toc -->

--- a/docusaurus/docs/operate/cheat_sheets/supplier_cheatsheet.md
+++ b/docusaurus/docs/operate/cheat_sheets/supplier_cheatsheet.md
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 3
-title: Supplier (RelayMiner) Cheat Sheet
+sidebar_position: 4
+title: Supplier & ReplayMiner (~20 min)
 ---
 
 ## Supplier Cheat Sheet <!-- omit in toc -->

--- a/docusaurus/docs/operate/cheat_sheets/validator_cheatsheet.md
+++ b/docusaurus/docs/operate/cheat_sheets/validator_cheatsheet.md
@@ -1,6 +1,6 @@
 ---
-title: Validator Cheat Sheet
-sidebar_position: 6
+title: Validator (~15 min)
+sidebar_position: 3
 ---
 
 ## Validator Cheat Sheet <!-- omit in toc -->

--- a/docusaurus/docs/operate/walkthroughs/_category_.json
+++ b/docusaurus/docs/operate/walkthroughs/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Stake & Deploy Walkthroughs",
+  "label": "Complete Walkthroughs to Stake & Deploy (Advanced)",
   "position": 2,
   "link": {
     "type": "generated-index",

--- a/docusaurus/docs/operate/walkthroughs/docker_compose_walkthrough.md
+++ b/docusaurus/docs/operate/walkthroughs/docker_compose_walkthrough.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 7
-title: Docker Compose Walkthrough
+title: "[Deprecated] Docker Compose Walkthrough (> 1 hour)"
 ---
 
 import ReactPlayer from "react-player";
 
-# Docker Compose Walkthrough <!-- omit in toc -->
+## [Deprecated] Docker Compose Walkthrough <!-- omit in toc -->
 
 - [Introduction and Cheat Sheet](#introduction-and-cheat-sheet)
 - [Key Terms in Morse and Shannon](#key-terms-in-morse-and-shannon)

--- a/docusaurus/docs/operate/walkthroughs/full_node_docker.md
+++ b/docusaurus/docs/operate/walkthroughs/full_node_docker.md
@@ -1,5 +1,5 @@
 ---
-title: Full Node (Docker)
+title: Full Node - Docker (~30 min)
 sidebar_position: 3
 ---
 

--- a/docusaurus/docs/operate/walkthroughs/full_node_walkthrough.md
+++ b/docusaurus/docs/operate/walkthroughs/full_node_walkthrough.md
@@ -1,5 +1,5 @@
 ---
-title: Full Node Walkthrough
+title: Full Node - Binary (~30 min)
 sidebar_position: 1
 ---
 

--- a/docusaurus/docs/operate/walkthroughs/gateway_walkthrough.md
+++ b/docusaurus/docs/operate/walkthroughs/gateway_walkthrough.md
@@ -1,5 +1,5 @@
 ---
-title: Gateway Walkthrough
+title: App & PATH Gateway (1 hour)
 sidebar_position: 6
 ---
 

--- a/docusaurus/docs/operate/walkthroughs/supplier_walkthrough.md
+++ b/docusaurus/docs/operate/walkthroughs/supplier_walkthrough.md
@@ -1,9 +1,9 @@
 ---
-title: RelayMiner (Supplier) Walkthrough
+title: Supplier & RelayMiner (~30 min)
 sidebar_position: 5
 ---
 
-# Run a RelayMiner (Supplier) <!-- omit in toc -->
+## Run a RelayMiner (Supplier) <!-- omit in toc -->
 
 TODO_BETA(@olshansk): Update this page with all the details.
 

--- a/docusaurus/docs/operate/walkthroughs/validator_walkthrough.md
+++ b/docusaurus/docs/operate/walkthroughs/validator_walkthrough.md
@@ -1,5 +1,5 @@
 ---
-title: Validator Walkthrough
+title: Validator (~30 min)
 sidebar_position: 4
 ---
 


### PR DESCRIPTION
## Summary

As more people look at the docs, I want to be clear & navigate them to the appropriate location:
- **Intermediate vs Advanced**: I'm trying to scare of people from going to the advanced section unless they're ready for it 
- **Time allocated**: I understand this is wrong, and we'll update it in the future, but trying to get something in the door to attract users to the right place
- **Deprecated notice**: I know docker compose is not deprecated yet, but I only want people "in the know" to keep using it for now

![Screenshot 2025-03-12 at 6 04 20 PM](https://github.com/user-attachments/assets/12a79508-e892-4933-b774-5e54b64a2ed1)


## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)
