### PR TITLE
[Tokenomics] Duplicate unbonding of slashed suppliers

### DIFF
--- a/x/tokenomics/keeper/keeper_settle_pending_claims_test.go
+++ b/x/tokenomics/keeper/keeper_settle_pending_claims_test.go
@@ -782,8 +782,8 @@ func (s *TestSuite) TestSettlePendingClaims_ClaimExpired_SupplierUnstaked() {
 			ServiceId:          testServiceId,
 			BlockHeight:        1,
 		}
-		sessionRes, err := s.keepers.GetSession(sdkCtx, sessionReq)
-		require.NoError(t, err)
+		sessionRes, sessionErr := s.keepers.GetSession(sdkCtx, sessionReq)
+		require.NoError(t, sessionErr)
 		sessionHeader := sessionRes.Session.Header
 		merkleRoot := testproof.SmstRootWithSumAndCount(1000, 1000)
 		claim := testtree.NewClaim(t, s.claim.SupplierOperatorAddress, sessionHeader, merkleRoot)

--- a/x/tokenomics/keeper/keeper_settle_pending_claims_test.go
+++ b/x/tokenomics/keeper/keeper_settle_pending_claims_test.go
@@ -784,6 +784,7 @@ func (s *TestSuite) TestSettlePendingClaims_ClaimExpired_SupplierUnstaked() {
 		}
 		sessionRes, sessionErr := s.keepers.GetSession(sdkCtx, sessionReq)
 		require.NoError(t, sessionErr)
+
 		sessionHeader := sessionRes.Session.Header
 		merkleRoot := testproof.SmstRootWithSumAndCount(1000, 1000)
 		claim := testtree.NewClaim(t, s.claim.SupplierOperatorAddress, sessionHeader, merkleRoot)
@@ -819,7 +820,8 @@ func (s *TestSuite) TestSettlePendingClaims_ClaimExpired_SupplierUnstaked() {
 	// Validate the slashing events
 	for i, slashingEvent := range slashingEvents {
 		proofMissingPenalty := cosmostypes.NewInt64Coin(volatile.DenomuPOKT, 0)
-		// The first slashing should burn all the supplier's stake.
+		// The current slashing mechanism burns the whole supplier's stake, which
+		// means that the first ocurrence will take the whole stake.
 		if i == 0 {
 			proofMissingPenalty = *s.keepers.ProofKeeper.GetParams(sdkCtx).ProofMissingPenalty
 		}

--- a/x/tokenomics/keeper/settle_pending_claims.go
+++ b/x/tokenomics/keeper/settle_pending_claims.go
@@ -636,7 +636,8 @@ func (k Keeper) slashSupplierStake(
 	// However, claims are only processed when sessions end.
 	// INVESTIGATION: This requires an investigation if the race condition exists
 	// at all and fixed only if it does.
-	if supplierToSlash.GetStake().IsLT(*minSupplierStakeCoin) {
+	// Ensure that a slashed supplier going below min stake is unbonded only once.
+	if supplierToSlash.GetStake().IsLT(*minSupplierStakeCoin) && !supplierToSlash.IsUnbonding() {
 		sharedParams := k.sharedKeeper.GetParams(ctx)
 		sdkCtx := cosmostypes.UnwrapSDKContext(ctx)
 		currentHeight := sdkCtx.BlockHeight()
@@ -663,12 +664,16 @@ func (k Keeper) slashSupplierStake(
 		}
 		supplierToSlash.ServiceConfigHistory = append(supplierToSlash.ServiceConfigHistory, serviceConfigsUpdate)
 
-		unbondingEndHeight := sharedtypes.GetSupplierUnbondingEndHeight(&sharedParams, &supplierToSlash)
 		events = append(events, &suppliertypes.EventSupplierUnbondingBegin{
-			Supplier:           &supplierToSlash,
-			Reason:             suppliertypes.SupplierUnbondingReason_SUPPLIER_UNBONDING_REASON_BELOW_MIN_STAKE,
-			SessionEndHeight:   unstakeSessionEndHeight,
-			UnbondingEndHeight: unbondingEndHeight,
+			Supplier:         &supplierToSlash,
+			Reason:           suppliertypes.SupplierUnbondingReason_SUPPLIER_UNBONDING_REASON_BELOW_MIN_STAKE,
+			SessionEndHeight: unstakeSessionEndHeight,
+			// Handling unbonding for slashed suppliers:
+			// - Initiate unbonding at the current session end height (earliest possible time)
+			// - Supplier remains staked during current session to preserve the active suppliers set
+			// - Supplier will still appear in current sessions but won't receive rewards in next settlement
+			// - If this settlement coincides with session end, supplier won't service further relays
+			UnbondingEndHeight: unstakeSessionEndHeight,
 		})
 	}
 


### PR DESCRIPTION
## Summary

Fix duplicate unbonding of slashed suppliers by adding condition to check if already unbonding

### Primary Changes:
- Add condition to check if supplier `IsUnbonding()` before initiating the unbonding process
- Ensure suppliers with multiple invalid claims are only unbonded once
- Unbond the supplier at the end height of the current session

### Secondary changes:
- Update  test `TestSettlePendingClaims_ClaimExpired_SupplierUnstaked` to verify the fix
- Test confirms supplier stake reduction, unbonding status, slashing events and single unbonding event emission

## Issue

![image](https://github.com/user-attachments/assets/9c5eadc0-4cee-43fc-88c4-38570cf0ebfd)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [x] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
