### PR TITLE
[DOCS] Add a video walkthrough for the Fullnode Cheatsheet

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,6 @@
 {
   "MD033": {
-    "allowed_elements": ["Tabs", "TabItem"]
+    "allowed_elements": ["Tabs", "TabItem", "ReactPlayer"]
   },
   "MD013": false,
   "MD046": false

--- a/docusaurus/docs/operate/cheat_sheets/full_node_cheatsheet.md
+++ b/docusaurus/docs/operate/cheat_sheets/full_node_cheatsheet.md
@@ -44,7 +44,7 @@ If you are using [Vultr](https://www.vultr.com/) for your deployment, you can fo
 <ReactPlayer
   playing={false}
   controls
-  url=""
+  url="https://github.com/user-attachments/assets/745cc1a4-28ee-4c02-8b22-858263e1f018"
 />
 
 ## Install and Run a Full Node using Cosmovisor

--- a/docusaurus/docs/operate/cheat_sheets/full_node_cheatsheet.md
+++ b/docusaurus/docs/operate/cheat_sheets/full_node_cheatsheet.md
@@ -20,7 +20,7 @@ See the [Full Node Walkthrough](../walkthroughs/full_node_walkthrough.md) if you
 ## Table of Contents <!-- omit in toc -->
 
 - [Pre-Requisites \& Requirements](#pre-requisites--requirements)
-- [Video Walkthrough](#video-walkthrough)
+- [10 Minute Video Walkthrough](#10-minute-video-walkthrough)
 - [Install and Run a Full Node using Cosmovisor](#install-and-run-a-full-node-using-cosmovisor)
   - [Verify successful installation using `curl`](#verify-successful-installation-using-curl)
   - [How are automatic upgrades handled out of the box?](#how-are-automatic-upgrades-handled-out-of-the-box)
@@ -40,8 +40,9 @@ If you are using [Vultr](https://www.vultr.com/) for your deployment, you can fo
 
 :::
 
-## Video Walkthrough
-~10 minute video walkthrough using this cheatsheet.
+## 10 Minute Video Walkthrough
+
+The following is a ~10 minute video walkthrough using this cheatsheet.
 
 <ReactPlayer
   playing={false}

--- a/docusaurus/docs/operate/cheat_sheets/full_node_cheatsheet.md
+++ b/docusaurus/docs/operate/cheat_sheets/full_node_cheatsheet.md
@@ -18,6 +18,7 @@ See the [Full Node Walkthrough](../walkthroughs/full_node_walkthrough.md) if you
 ## Table of Contents <!-- omit in toc -->
 
 - [Pre-Requisites \& Requirements](#pre-requisites--requirements)
+- [Video Walkthrough](#video-walkthrough)
 - [Install and Run a Full Node using Cosmovisor](#install-and-run-a-full-node-using-cosmovisor)
   - [Verify successful installation using `curl`](#verify-successful-installation-using-curl)
   - [How are automatic upgrades handled out of the box?](#how-are-automatic-upgrades-handled-out-of-the-box)
@@ -36,6 +37,15 @@ See the [Full Node Walkthrough](../walkthroughs/full_node_walkthrough.md) if you
 If you are using [Vultr](https://www.vultr.com/) for your deployment, you can following the [CLI Playbook we put together here](../../tools/playbooks/vultr.md) to speed things up.
 
 :::
+
+## Video Walkthrough
+~10 minute video walkthrough using this cheatsheet.
+
+<ReactPlayer
+  playing={false}
+  controls
+  url=""
+/>
 
 ## Install and Run a Full Node using Cosmovisor
 

--- a/docusaurus/docs/operate/cheat_sheets/full_node_cheatsheet.md
+++ b/docusaurus/docs/operate/cheat_sheets/full_node_cheatsheet.md
@@ -3,6 +3,8 @@ title: Full Node (~10 min)
 sidebar_position: 2
 ---
 
+import ReactPlayer from "react-player";
+
 ## Full Node Cheat Sheet <!-- omit in toc -->
 
 **🖨 🍝 instructions to get you up and running with a `Full Node` on Pocket Network using `Systemd` and `Cosmovisor` ✅**


### PR DESCRIPTION
## Summary

Adds a video walkthrough for the Fullnode cheatsheet

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [x] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
