### PR TITLE
[Upgrade] prepare v0.0.14 release

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -24,7 +24,10 @@ var allUpgrades = []upgrades.Upgrade{
 	// upgrades.Upgrade_0_0_12,
 
 	// v0.0.13 - this upgrade introduces morse migration module and websocket service handling.
-	upgrades.Upgrade_0_0_13,
+	// upgrades.Upgrade_0_0_13,
+
+	// v0.0.14 - upgrade to release latest features on TestNets to perform more load testing prior to MainNet launch.
+	upgrades.Upgrade_0_0_14,
 }
 
 // setUpgrades sets upgrade handlers for all upgrades and executes KVStore migration if an upgrade plan file exists.

--- a/app/upgrades/v0.0.14.go
+++ b/app/upgrades/v0.0.14.go
@@ -1,0 +1,17 @@
+package upgrades
+
+import (
+	storetypes "cosmossdk.io/store/types"
+)
+
+const Upgrade_0_0_14_PlanName = "v0.0.14"
+
+// Upgrade_0_0_14 handles the upgrade to release `v0.0.14`.
+// This is planned to be issued on both Pocket Network's Shannon Alpha & Beta TestNets.
+var Upgrade_0_0_14 = Upgrade{
+	PlanName: Upgrade_0_0_14_PlanName,
+	// No state changes in this upgrade.
+	CreateUpgradeHandler: defaultUpgradeHandler,
+	// No migrations in this upgrade.
+	StoreUpgrades: storetypes.StoreUpgrades{},
+}


### PR DESCRIPTION
## Summary

We need to get the latest features deployed to TestNets to unblock load testing.

Changes:
- Assigns `v0.0.14` plan to the default upgrade handler.

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Upgrade

## Sanity Checklist

- [x] Tested upgrade locally
