### PR TITLE
[Tooling] chore: add support for local grove helm-charts repo in Tilt localnet

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -69,6 +69,13 @@ localnet_config_defaults = {
         "path": os.path.join("..", "helm-charts")
     },
 
+    # By default, we use the `helm_repo` function below to point to the remote repository
+    # but can update it to the locally cloned repo for testing & development
+    "grove_helm_chart_local_repo": {
+        "enabled": False,
+        "path": os.path.join("..", "grove-helm-charts")
+    },
+
     # By default, we use a pre-built PATH image, but can update it to use a local
     # repo instead.
     "path_local_repo": {
@@ -112,6 +119,13 @@ if localnet_config["helm_chart_local_repo"]["enabled"]:
 
 # Configure PATH references
 grove_chart_prefix = "buildwithgrove/"
+if localnet_config["grove_helm_chart_local_repo"]["enabled"]:
+    grove_helm_chart_local_repo = localnet_config["grove_helm_chart_local_repo"]["path"]
+    hot_reload_dirs.append(grove_helm_chart_local_repo)
+    print("Using local grove helm chart repo " + grove_helm_chart_local_repo)
+    # TODO_IMPROVE: Use os.path.join to make this more OS-agnostic.
+    grove_chart_prefix = grove_helm_chart_local_repo + "/charts/"
+
 # If using a local repo, set the path to the local repo; otherwise, use our own helm repo.
 path_local_repo = ""
 if localnet_config["path_local_repo"]["enabled"]:


### PR DESCRIPTION
## Summary

Add support for local grove helm-charts repo in Tilt localnet (equivalent to the other helm chart repo).

### How to use

Update your `localnet_config.yaml` to include the following section (the default, `enabled: false` will be generated on first run otherwise):
```
grove_helm_chart_local_repo:
  enabled: true
  path: ../grove-helm-charts
```


Changes:
- Update the default localnet_config.yaml
- Add a conditional branch to overwrite the `grove_chart_prefix` if `grove_helm_chart_local_repo.enabled` is true.

## Issue

N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
