### PR TITLE
[Relayminer] Add submit proof retry logic to relayminer

### DIFF
--- a/testutil/testclient/testsupplier/client.go
+++ b/testutil/testclient/testsupplier/client.go
@@ -51,6 +51,62 @@ func NewClaimProofSupplierClientMap(
 ) *supplier.SupplierClientMap {
 	t.Helper()
 
+	supplierClientMock := newBaseClaimProofSupplierClientMock(ctx, t, supplierOperatorAddress, proofCount)
+	supplierClientMock.EXPECT().
+		SubmitProofs(
+			gomock.Eq(ctx),
+			gomock.AssignableToTypeOf(([]client.MsgSubmitProof)(nil)),
+		).
+		Return(nil).
+		Times(proofCount)
+
+	supplierClientMap := supplier.NewSupplierClientMap()
+	supplierClientMap.SupplierClients[supplierOperatorAddress] = supplierClientMock
+
+	return supplierClientMap
+}
+
+// TODO_IN_THIS_COMMIT: godoc...
+func NewClaimProofSupplierClientMapWithTransientSubmitProofsError(
+	ctx context.Context,
+	t *testing.T,
+	supplierOperatorAddress string,
+	proofCount int,
+	retryCount int,
+) *supplier.SupplierClientMap {
+	t.Helper()
+
+	supplierClientMock := newBaseClaimProofSupplierClientMock(ctx, t, supplierOperatorAddress, proofCount)
+	supplierClientMock.EXPECT().
+		SubmitProofs(
+			gomock.Eq(ctx),
+			gomock.AssignableToTypeOf(([]client.MsgSubmitProof)(nil)),
+		).
+		Return(nil).
+		Times(retryCount)
+	supplierClientMock.EXPECT().
+		SubmitProofs(
+			gomock.Eq(ctx),
+			gomock.AssignableToTypeOf(([]client.MsgSubmitProof)(nil)),
+		).
+		Return(nil).
+		Times(proofCount)
+
+	supplierClientMap := supplier.NewSupplierClientMap()
+	supplierClientMap.SupplierClients[supplierOperatorAddress] = supplierClientMock
+
+	return supplierClientMap
+}
+
+// TODO_IN_THIS_COMMIT: godoc...
+func newBaseClaimProofSupplierClientMock(
+	ctx context.Context,
+	t *testing.T,
+	supplierOperatorAddress string,
+	claimCount int,
+) *mockclient.MockSupplierClient {
+	t.Helper()
+
 	ctrl := gomock.NewController(t)
 	supplierClientMock := mockclient.NewMockSupplierClient(ctrl)
 
@@ -66,18 +122,7 @@ func NewClaimProofSupplierClientMap(
 			gomock.AssignableToTypeOf(([]client.MsgCreateClaim)(nil)),
 		).
 		Return(nil).
-		Times(1)
+		Times(claimCount)
 
-	supplierClientMock.EXPECT().
-		SubmitProofs(
-			gomock.Eq(ctx),
-			gomock.AssignableToTypeOf(([]client.MsgSubmitProof)(nil)),
-		).
-		Return(nil).
-		Times(proofCount)
-
-	supplierClientMap := supplier.NewSupplierClientMap()
-	supplierClientMap.SupplierClients[supplierOperatorAddress] = supplierClientMock
-
-	return supplierClientMap
+	return supplierClientMock
 }


### PR DESCRIPTION
## Summary

Extends the existing observable pipeline to retry proof submissions until a configurable max retry limit is reached (per session number), the sessions expire, or submission succeeds.

## Issue

- Description: Intermittent relayminer proof submission failure leads to supplier slashing.
- Issue: #1130

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
