### PR TITLE
[Bug] Fix missing supplier begin blocker

### DIFF
--- a/x/supplier/module/module.go
+++ b/x/supplier/module/module.go
@@ -148,8 +148,9 @@ func (AppModule) ConsensusVersion() uint64 { return 1 }
 
 // BeginBlock contains the logic that is automatically triggered at the beginning of each block.
 // The begin block implementation is optional.
-func (am AppModule) BeginBlock(_ context.Context) error {
-	return nil
+func (am AppModule) BeginBlock(goCtx context.Context) error {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	return BeginBlocker(ctx, am.supplierKeeper)
 }
 
 // EndBlock contains the logic that is automatically triggered at the end of each block.


### PR DESCRIPTION
## Summary

Call `BeginBlocker` execution in `Supplier` module's `BeginBlock` handler

## Issue

![image](https://github.com/user-attachments/assets/2aa6866e-40ab-4953-a657-0f067653e56d)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [x] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
