### PR TITLE
[RelayMiner]: add forward capabilities to send request to suppliers

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -353,6 +353,7 @@ for x in range(localnet_config["relayminers"]["count"]):
             str(6069 + actor_number)
             + ":6060",  # Relayminer pprof port. relayminer1 - exposes 6070, relayminer2 exposes 6071, etc.
             str(7000 + actor_number) + ":8081", # Relayminer ping port. relayminer1 - exposes 7001, relayminer2 exposes 7002, etc.
+            str(10000 + actor_number) + ":10000", # Relayminer forward port. relayminer1 - exposes 10001, relayminer2 exposes 10002, etc.
         ],
     )
 

--- a/docusaurus/docs/operate/configs/relayminer_config.md
+++ b/docusaurus/docs/operate/configs/relayminer_config.md
@@ -215,7 +215,7 @@ forward:
   token: 8e8cff9152db92e960b00b4159b23f82084192f9d6c589337caab9705b3e0693
 ```
 
-Example query using `relayminer1` with `ollama` as supplier in Localnet environment:
+Example query to foward a request using the `relayminer1` to `ollama` service in Localnet environment:
 
 ```shell
 ?> cat data.json
@@ -224,7 +224,13 @@ Example query using `relayminer1` with `ollama` as supplier in Localnet environm
     "path": "/api/generate",
     "data": "{\"model\": \"qwen:0.5b\", \"prompt\": \"hello world.\", \"stream\": false}"
 }
-?> curl -X POST -H "token: 8e8cff9152db92e960b00b4159b23f82084192f9d6c589337caab9705b3e0693" -H "service-id: ollama" localhost:10001/services/ollama/forward --data-binary "@data.json"
+?> curl -X POST -H "token: 8e8cff9152db92e960b00b4159b23f82084192f9d6c589337caab9705b3e0693" localhost:10001/services/ollama/forward --data-binary "@data.json"
+```
+
+Example query to foward a websocket connection using the  `relayminer1` to `anvilws` service in Localnet environment:
+
+```shell
+?>  websocat -H="token: 8e8cff9152db92e960b00b4159b23f82084192f9d6c589337caab9705b3e0693" ws://localhost:10001/services/anvilws/forward
 ```
 
 Helpers to generate token in Makefile:

--- a/docusaurus/docs/operate/configs/relayminer_config.md
+++ b/docusaurus/docs/operate/configs/relayminer_config.md
@@ -200,8 +200,8 @@ Configures a `forward` server to send request to a supplier for a given
 service name. It is intended for operational use only (e.g., a relayminer
 operator may need to send requests to suppliers to verify the correctness
 of their responses going through the relayminer proxy).
-Requests forwarded via this endpoint bypass the miner and session
-manager mechanisms.
+Requests forwarded via this endpoint bypass the miner, meter and session
+mechanisms.
 To prevent misuse by unauthorized users, this endpoint requires
 authentication. A token can be defined using a 32 bytes hexadecimal
 `token`.

--- a/docusaurus/docs/operate/configs/relayminer_config.md
+++ b/docusaurus/docs/operate/configs/relayminer_config.md
@@ -24,6 +24,7 @@ You can find a fully featured example configuration at [relayminer_config_full_e
   - [`metrics`](#metrics)
   - [`pprof`](#pprof)
   - [`ping`](#ping)
+  - [`forward`](#forward)
 - [Pocket node connectivity](#pocket-node-connectivity)
   - [`query_node_rpc_url`](#query_node_rpc_url)
   - [`query_node_grpc_url`](#query_node_grpc_url)
@@ -189,6 +190,47 @@ Example configuration:
 ping:
   enabled: true
   addr: localhost:8081
+```
+
+### `forward`
+
+_`Optional`_
+
+Configures a `forward` server to send request to a supplier for a given
+service name. It is intended for operational use only (e.g., a relayminer
+operator may need to send requests to suppliers to verify the correctness
+of their responses going through the relayminer proxy).
+Requests forwarded via this endpoint bypass the miner and session
+manager mechanisms.
+To prevent misuse by unauthorized users, this endpoint requires
+authentication. A token can be defined using a 32 bytes hexadecimal
+`token`.
+
+Example configuration:
+
+```yaml
+forward:
+  enabled: true
+  addr: localhost:8082
+  token: 8e8cff9152db92e960b00b4159b23f82084192f9d6c589337caab9705b3e0693
+```
+
+Example query using `relayminer1` with `ollama` as supplier in Localnet environment:
+
+```shell
+?> cat data.json
+{
+    "method": "POST",
+    "path": "/api/generate",
+    "data": "{\"model\": \"qwen:0.5b\", \"prompt\": \"hello world.\", \"stream\": false}"
+}
+?> curl -X POST -H "token: 8e8cff9152db92e960b00b4159b23f82084192f9d6c589337caab9705b3e0693" -H "service-id: ollama" localhost:10001/services/ollama/forward --data-binary "@data.json"
+```
+
+Helpers to generate token in Makefile:
+
+```shell
+?> make relayminer_forward_token_gen
 ```
 
 ## Pocket node connectivity

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 require (
 	cosmossdk.io/x/tx v0.13.8
 	github.com/foxcpp/go-mockdns v1.1.0
+	github.com/go-chi/chi/v5 v5.1.0
 	github.com/go-playground/validator/v10 v10.15.5
 	github.com/jhump/protoreflect v1.16.0
 	github.com/mitchellh/mapstructure v1.5.0
@@ -175,7 +176,6 @@ require (
 	github.com/getsentry/sentry-go v0.27.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gin-gonic/gin v1.9.1 // indirect
-	github.com/go-chi/chi/v5 v5.1.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 require (
 	cosmossdk.io/x/tx v0.13.8
 	github.com/foxcpp/go-mockdns v1.1.0
+	github.com/go-playground/validator/v10 v10.15.5
 	github.com/jhump/protoreflect v1.16.0
 	github.com/mitchellh/mapstructure v1.5.0
 	go.uber.org/mock v0.5.0
@@ -170,6 +171,7 @@ require (
 	github.com/felixge/fgprof v0.9.4 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gin-gonic/gin v1.9.1 // indirect
@@ -178,7 +180,8 @@ require (
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/go-playground/validator/v10 v10.15.5 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/gofrs/uuid/v5 v5.2.0 // indirect
@@ -223,6 +226,7 @@ require (
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/leodido/go-urn v1.2.4 // indirect
 	github.com/lib/pq v1.10.7 // indirect
 	github.com/linxGnu/grocksdb v1.8.14 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -551,6 +551,8 @@ github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ4
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
@@ -1140,6 +1142,7 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/localnet/kubernetes/values-relayminer-common.yaml
+++ b/localnet/kubernetes/values-relayminer-common.yaml
@@ -14,3 +14,7 @@ config:
   ping:
     enabled: true
     addr: localhost:8081
+  forward:
+    enabled: true
+    addr: localhost:10000
+    token: 8cc09793290cd64d8a9bc80eaae4fbeef5f7cf797b0c70e078d2a5b81d74f12c

--- a/localnet/poktrolld/config/relayminer_config.yaml
+++ b/localnet/poktrolld/config/relayminer_config.yaml
@@ -26,3 +26,7 @@ pprof:
 ping:
   enabled: false
   addr: localhost:8082
+forward:
+  enabled: false
+  addr: localhost:10000
+  token: 8cc09793290cd64d8a9bc80eaae4fbeef5f7cf797b0c70e078d2a5b81d74f12c

--- a/localnet/poktrolld/config/relayminer_config_full_example.yaml
+++ b/localnet/poktrolld/config/relayminer_config_full_example.yaml
@@ -24,6 +24,12 @@ ping:
   enabled: false
   addr: localhost:8081
 
+# Forward server configuration to send request to suppliers backend URL.
+forward:
+  enabled: false
+  addr: localhost:10000
+  token: 8cc09793290cd64d8a9bc80eaae4fbeef5f7cf797b0c70e078d2a5b81d74f12c
+
 pocket_node:
   # Pocket node URL exposing the CometBFT JSON-RPC API.
   # Used by the Cosmos client SDK, event subscriptions, etc.

--- a/localnet/poktrolld/config/relayminer_config_localnet_vscode.yaml
+++ b/localnet/poktrolld/config/relayminer_config_localnet_vscode.yaml
@@ -56,3 +56,7 @@ pprof:
 ping:
   enabled: false
   addr: localhost:8081
+forward:
+  enabled: false
+  addr: localhost:10000
+  token: 8cc09793290cd64d8a9bc80eaae4fbeef5f7cf797b0c70e078d2a5b81d74f12c

--- a/makefiles/relay.mk
+++ b/makefiles/relay.mk
@@ -31,3 +31,7 @@ send_relay_path_WEBSOCKET: test_e2e_env ## Send a WEBSOCKET relay through PATH t
 
 # TODO_MAINNET(@olshansk): Add all the permissionless/delegated/centralized variations once
 # the following documentation is ready: https://www.notion.so/buildwithgrove/Different-Modes-of-Operation-PATH-LocalNet-Discussions-122a36edfff6805e9090c9a14f72f3b5?pvs=4#151a36edfff680d681a2dd7f4e5fee55
+
+.PHONY: relayminer_forward_token_gen
+relayminer_forward_token_gen:
+	@openssl rand -hex 32 | tr -d "\n"

--- a/pkg/relayer/cmd/cmd.go
+++ b/pkg/relayer/cmd/cmd.go
@@ -167,6 +167,12 @@ func runRelayer(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	if relayMinerConfig.Forward.Enabled {
+		if err := relayMiner.ServeForward(ctx, "tcp", relayMinerConfig.Forward.Addr, relayMinerConfig.Forward.Token); err != nil {
+			return fmt.Errorf("serve forward: %w", err)
+		}
+	}
+
 	// Start the relay miner
 	logger.Info().Msg("Starting relay miner...")
 	if err := relayMiner.Start(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/pkg/relayer/config/errors.go
+++ b/pkg/relayer/config/errors.go
@@ -11,4 +11,5 @@ var (
 	ErrRelayMinerConfigEmpty                 = sdkerrors.Register(codespace, 2104, "empty RelayMiner config")
 	ErrRelayMinerConfigInvalidSupplier       = sdkerrors.Register(codespace, 2105, "invalid supplier in RelayMiner config")
 	ErrRelayMinerConfigInvalidServer         = sdkerrors.Register(codespace, 2106, "invalid server in RelayMiner config")
+	ErrRelayerMinerWrongForwardToken         = sdkerrors.Register(codespace, 2107, "wrong or empty forward.token in configuration file. (you can use 'make relayminer_forward_token_gen' command to generate a token)")
 )

--- a/pkg/relayer/config/relayminer_configs_reader.go
+++ b/pkg/relayer/config/relayminer_configs_reader.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"regexp"
+
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -45,6 +47,19 @@ func ParseRelayMinerConfigs(configContent []byte) (*RelayMinerConfig, error) {
 	relayMinerConfig.Ping = &RelayMinerPingConfig{
 		Enabled: yamlRelayMinerConfig.Ping.Enabled,
 		Addr:    yamlRelayMinerConfig.Ping.Addr,
+	}
+
+	if yamlRelayMinerConfig.Forward.Enabled {
+		// accepts 32 bytes hexadecimal
+		if matched, _ := regexp.MatchString(`^[a-fA-F0-9]{64}$`, yamlRelayMinerConfig.Forward.Token); !matched {
+			return nil, ErrRelayerMinerWrongForwardToken
+		}
+	}
+
+	relayMinerConfig.Forward = &RelayMinerForwardConfig{
+		Enabled: yamlRelayMinerConfig.Forward.Enabled,
+		Addr:    yamlRelayMinerConfig.Forward.Addr,
+		Token:   yamlRelayMinerConfig.Forward.Token,
 	}
 
 	// Hydrate the pocket node urls

--- a/pkg/relayer/config/types.go
+++ b/pkg/relayer/config/types.go
@@ -25,6 +25,7 @@ type YAMLRelayMinerConfig struct {
 	SmtStorePath           string                         `yaml:"smt_store_path"`
 	Suppliers              []YAMLRelayMinerSupplierConfig `yaml:"suppliers"`
 	Ping                   YAMLRelayMinerPingConfig       `yaml:"ping"`
+	Forward                YAMLRelayMinerForwardConfig    `yaml:"forward"`
 }
 
 // YAMLRelayMinerPingConfig represents the configuration to expose a ping server.
@@ -32,6 +33,18 @@ type YAMLRelayMinerPingConfig struct {
 	Enabled bool `yaml:"enabled"`
 	// Addr is the address to bind to (format: 'hostname:port') where 'hostname' can be a DNS name or an IP
 	Addr string `yaml:"addr"`
+}
+
+// YAMLRelayMinerForwardConfig represents the configuration to expose a forward
+// request server.
+type YAMLRelayMinerForwardConfig struct {
+	Enabled bool `yaml:"enabled"`
+
+	// Addr is the address to bind to (format: 'hostname:port') where 'hostname' can be a DNS name or an IP.
+	Addr string `yaml:"addr"`
+
+	// Token must represent an 32 bytes hexadecimal string. (mandatory flag when activating forwarding capabilities)
+	Token string `yaml:"token"`
 }
 
 // YAMLRelayMinerPocketNodeConfig is the structure used to unmarshal the pocket
@@ -92,6 +105,7 @@ type RelayMinerConfig struct {
 	Servers                map[string]*RelayMinerServerConfig
 	SmtStorePath           string
 	Ping                   *RelayMinerPingConfig
+	Forward                *RelayMinerForwardConfig
 }
 
 // TODO_TECHDEBT(@red-0ne): Remove this structure altogether. See the discussion here for ref:
@@ -102,6 +116,17 @@ type RelayMinerPingConfig struct {
 	Enabled bool
 	// Addr is the address to bind to (format: hostname:port) where 'hostname' can be a DNS name or an IP
 	Addr string
+}
+
+// RelayMinerForwardConfig is the structure resulting from parsing the
+// forward server configuration.
+type RelayMinerForwardConfig struct {
+	Enabled bool
+	// Addr is the address to bind to (format: 'hostname:port') where 'hostname' can be a DNS name or an IP.
+	Addr string
+
+	// Token must represent an 32 bytes hexadecimal string. (mandatory flag when activating forwarding capabilities).
+	Token string
 }
 
 // RelayMinerPocketNodeConfig is the structure resulting from parsing the pocket

--- a/pkg/relayer/config/types.go
+++ b/pkg/relayer/config/types.go
@@ -1,6 +1,9 @@
 package config
 
-import "net/url"
+import (
+	"net/http"
+	"net/url"
+)
 
 type RelayMinerServerType int
 
@@ -198,6 +201,17 @@ type RelayMinerSupplierServiceConfig struct {
 	// authentication then this field must be populated accordingly.
 	// For example: { "Authorization": "Bearer <token>" }
 	Headers map[string]string
+}
+
+// HTTP returns the supplier's service config http header.
+func (c RelayMinerSupplierServiceConfig) HeadersHTTP() http.Header {
+	header := make(http.Header)
+
+	for k, v := range c.Headers {
+		header.Add(k, v)
+	}
+
+	return header
 }
 
 // RelayMinerSupplierServiceAuthentication is the structure resulting from parsing

--- a/pkg/relayer/interface.go
+++ b/pkg/relayer/interface.go
@@ -61,7 +61,7 @@ type RelayerProxy interface {
 	// PingAll tests the connectivity between all the managed relay servers and their respective backend URLs.
 	PingAll(ctx context.Context) error
 
-	// Forward sends a request to appropriate relay server that managed the given service id.
+	// Forward sends a request to the relay server that managed the given service id.
 	Forward(ctx context.Context, serviceID string, w http.ResponseWriter, r *http.Request) error
 }
 

--- a/pkg/relayer/interface.go
+++ b/pkg/relayer/interface.go
@@ -7,6 +7,7 @@ package relayer
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/pokt-network/smt"
 
@@ -59,6 +60,9 @@ type RelayerProxy interface {
 
 	// PingAll tests the connectivity between all the managed relay servers and their respective backend URLs.
 	PingAll(ctx context.Context) error
+
+	// Forward sends a request to appropriate relay server that managed the given service id.
+	Forward(ctx context.Context, serviceID string, w http.ResponseWriter, r *http.Request) error
 }
 
 type RelayerProxyOption func(RelayerProxy)
@@ -94,6 +98,9 @@ type RelayServer interface {
 
 	// Ping tests the connection between the relay server and its backend URL.
 	Ping(ctx context.Context) error
+
+	// Forward sends a request to the supplier service.
+	Forward(ctx context.Context, serviceID string, w http.ResponseWriter, r *http.Request) error
 }
 
 // RelayServers aggregates a slice of RelayServer interface.

--- a/pkg/relayer/proxy/async.go
+++ b/pkg/relayer/proxy/async.go
@@ -2,10 +2,12 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/gorilla/websocket"
 
+	"github.com/pokt-network/poktroll/pkg/relayer/config"
 	proxyws "github.com/pokt-network/poktroll/pkg/relayer/proxy/websockets"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
@@ -93,6 +95,62 @@ func (server *relayMinerHTTPServer) handleAsyncConnection(
 	go bridge.Run(claimWindowOpenHeight)
 
 	logger.Info().Msg("websocket connection established with client")
+
+	return nil
+}
+
+func (server *relayMinerHTTPServer) forwardAsyncConnection(ctx context.Context, supplierConfig *config.RelayMinerSupplierConfig, w http.ResponseWriter, req *http.Request) error {
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+
+	clientConn, err := upgrader.Upgrade(w, req, nil)
+	if err != nil {
+		fmt.Errorf("client connection upgrade client to ws: %w", err)
+	}
+
+	serviceConn, err := proxyws.ConnectServiceBackend(supplierConfig.ServiceConfig.BackendUrl, supplierConfig.ServiceConfig.HeadersHTTP())
+	if err != nil {
+		fmt.Errorf("service connection upgrade to ws: %w", err)
+	}
+
+	forwardFn := func(from, to *websocket.Conn) {
+		defer from.Close()
+		defer to.Close()
+
+		isNormalCloseConnection := func(err error) bool {
+			return websocket.IsCloseError(err,
+				websocket.CloseNormalClosure,
+				websocket.CloseGoingAway,
+				websocket.CloseAbnormalClosure)
+		}
+
+		for {
+			msgType, msg, err := from.ReadMessage()
+			if err != nil {
+				if isNormalCloseConnection(err) {
+					return
+				}
+
+				server.logger.Error().
+					Msgf("from read message: %w", err)
+				return
+			}
+
+			if err := to.WriteMessage(msgType, msg); err != nil {
+				if isNormalCloseConnection(err) {
+					return
+				}
+
+				server.logger.Error().
+					Msgf("to write message: %w", err)
+				return
+			}
+		}
+	}
+
+	go forwardFn(clientConn, serviceConn)
+	forwardFn(serviceConn, clientConn)
 
 	return nil
 }

--- a/pkg/relayer/proxy/async.go
+++ b/pkg/relayer/proxy/async.go
@@ -99,6 +99,9 @@ func (server *relayMinerHTTPServer) handleAsyncConnection(
 	return nil
 }
 
+// forwardAsyncConnection instantiates two websocket connections that:
+// - receive and foward message from the client to the supplier (backend URL).
+// - receive and forward mesage from the supplier (backend URL) to the client.
 func (server *relayMinerHTTPServer) forwardAsyncConnection(ctx context.Context, supplierConfig *config.RelayMinerSupplierConfig, w http.ResponseWriter, req *http.Request) error {
 	upgrader := websocket.Upgrader{
 		CheckOrigin: func(r *http.Request) bool { return true },

--- a/pkg/relayer/proxy/errors.go
+++ b/pkg/relayer/proxy/errors.go
@@ -15,4 +15,5 @@ var (
 	ErrRelayerProxyRateLimited               = sdkerrors.Register(codespace, 7, "offchain rate limit hit by relayer proxy")
 	ErrRelayerProxyCalculateRelayCost        = sdkerrors.Register(codespace, 8, "failed to calculate relay cost")
 	ErrRelayerProxySupplierNotReachable      = sdkerrors.Register(codespace, 9, "supplier(s) not reachable")
+	ErrRelayerProxyServiceIDNotFound         = sdkerrors.Register(codespace, 10, "service id not found")
 )

--- a/pkg/relayer/proxy/http_server.go
+++ b/pkg/relayer/proxy/http_server.go
@@ -159,7 +159,9 @@ func (server *relayMinerHTTPServer) Ping(ctx context.Context) error {
 	return nil
 }
 
-// Forward reads the forward payload request and sends a request to a managed service id.
+// Forward sends request to the appropriate service.
+// - It checks if the service id is managed by the relayminer.
+// - It checks wether it needs to forward a websocket connection or send a http request.
 func (server *relayMinerHTTPServer) Forward(ctx context.Context, serviceID string, w http.ResponseWriter, req *http.Request) error {
 	supplierConfig, ok := server.serverConfig.SupplierConfigsMap[serviceID]
 	if !ok {

--- a/pkg/relayer/proxy/http_server.go
+++ b/pkg/relayer/proxy/http_server.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"time"
 

--- a/pkg/relayer/proxy/http_server.go
+++ b/pkg/relayer/proxy/http_server.go
@@ -1,13 +1,19 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"path"
 	"time"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	validate "github.com/go-playground/validator/v10"
 
 	"github.com/pokt-network/poktroll/pkg/client"
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -154,6 +160,110 @@ func (server *relayMinerHTTPServer) Ping(ctx context.Context) error {
 			return errors.New("ping failed")
 		}
 
+	}
+
+	return nil
+}
+
+// forwardPayload represents the request body format to forward a request to
+// the supplier.
+type forwardPayload struct {
+	Method  string            `json:"method" validate:"required,oneof=GET PATCH PUT CONNECT TRACE DELETE POST HEAD OPTIONS"`
+	Path    string            `json:"path" validate:"required"`
+	Headers map[string]string `json:"headers"`
+	Data    string            `json:"data"`
+}
+
+// toHeaders instantiates an http.Header based on the Headers field.
+func (p forwardPayload) toHeaders() http.Header {
+	h := http.Header{}
+
+	for k, v := range p.Headers {
+		h.Set(k, v)
+	}
+
+	return h
+}
+
+// Validate returns true if the payload format is correct.
+func (p forwardPayload) Validate() error {
+	var err error
+	if structErr := validate.New().Struct(&p); structErr != nil {
+		for _, e := range structErr.(validate.ValidationErrors) {
+			err = errors.Join(err, e)
+		}
+	}
+
+	return err
+}
+
+// Forward reads the forward payload request and sends a request to a managed service id.
+func (server *relayMinerHTTPServer) Forward(ctx context.Context, serviceID string, w http.ResponseWriter, req *http.Request) error {
+	supplierConfig, ok := server.serverConfig.SupplierConfigsMap[serviceID]
+	if !ok {
+		return ErrRelayerProxyServiceIDNotFound
+	}
+
+	b, err := io.ReadAll(req.Body)
+	if err != nil {
+		return err
+	}
+
+	var payload forwardPayload
+	if err := json.Unmarshal(b, &payload); err != nil {
+		return err
+	}
+
+	if err := payload.Validate(); err != nil {
+		return err
+	}
+
+	url := *supplierConfig.ServiceConfig.BackendUrl
+	url.Path = path.Join(url.Path, payload.Path)
+
+	forwardReq := &http.Request{
+		Method: payload.Method,
+		Body:   io.NopCloser(bytes.NewBufferString(payload.Data)),
+		URL:    &url,
+		Header: payload.toHeaders(),
+	}
+
+	c := http.Client{
+		Transport: http.DefaultTransport,
+	}
+
+	// forward request to the supplier.
+	resp, err := c.Do(forwardReq)
+	if err != nil {
+		server.logger.Error().Fields(map[string]any{
+			"service_id": serviceID,
+			"method":     payload.Method,
+			"path":       payload.Path,
+			"headers":    payload.Headers,
+		}).Err(err).Msg("failed to send forward http request")
+
+		if nErr, ok := err.(net.Error); ok && nErr.Timeout() {
+			http.Error(w, fmt.Sprintf("relayminer: foward http request timeout exceeded"), http.StatusGatewayTimeout)
+		} else {
+			http.Error(w, fmt.Sprintf("relayminer: error forward http request: %s", err.Error()), http.StatusInternalServerError)
+		}
+		return err
+	}
+
+	w.WriteHeader(resp.StatusCode)
+
+	// streaming supplier's output to the client.
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		server.logger.Error().Fields(map[string]any{
+			"service_id": serviceID,
+			"method":     payload.Method,
+			"path":       payload.Path,
+			"headers":    payload.Headers,
+		}).Err(err).Msg("failed to write forward http reponse")
+
+		http.Error(w, fmt.Sprintf("relayminer: error on forward http response: %s", err.Error()), http.StatusInternalServerError)
+
+		return err
 	}
 
 	return nil

--- a/pkg/relayer/proxy/http_server.go
+++ b/pkg/relayer/proxy/http_server.go
@@ -1,19 +1,12 @@
 package proxy
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
-	"net"
 	"net/http"
-	"path"
 	"time"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
-	validate "github.com/go-playground/validator/v10"
 
 	"github.com/pokt-network/poktroll/pkg/client"
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -165,38 +158,6 @@ func (server *relayMinerHTTPServer) Ping(ctx context.Context) error {
 	return nil
 }
 
-// forwardPayload represents the request body format to forward a request to
-// the supplier.
-type forwardPayload struct {
-	Method  string            `json:"method" validate:"required,oneof=GET PATCH PUT CONNECT TRACE DELETE POST HEAD OPTIONS"`
-	Path    string            `json:"path" validate:"required"`
-	Headers map[string]string `json:"headers"`
-	Data    string            `json:"data"`
-}
-
-// toHeaders instantiates an http.Header based on the Headers field.
-func (p forwardPayload) toHeaders() http.Header {
-	h := http.Header{}
-
-	for k, v := range p.Headers {
-		h.Set(k, v)
-	}
-
-	return h
-}
-
-// Validate returns true if the payload format is correct.
-func (p forwardPayload) Validate() error {
-	var err error
-	if structErr := validate.New().Struct(&p); structErr != nil {
-		for _, e := range structErr.(validate.ValidationErrors) {
-			err = errors.Join(err, e)
-		}
-	}
-
-	return err
-}
-
 // Forward reads the forward payload request and sends a request to a managed service id.
 func (server *relayMinerHTTPServer) Forward(ctx context.Context, serviceID string, w http.ResponseWriter, req *http.Request) error {
 	supplierConfig, ok := server.serverConfig.SupplierConfigsMap[serviceID]
@@ -204,69 +165,11 @@ func (server *relayMinerHTTPServer) Forward(ctx context.Context, serviceID strin
 		return ErrRelayerProxyServiceIDNotFound
 	}
 
-	b, err := io.ReadAll(req.Body)
-	if err != nil {
-		return err
+	if isWebSocketRequest(req) {
+		return server.forwardAsyncConnection(ctx, supplierConfig, w, req)
+	} else {
+		return server.forwardHTTP(ctx, supplierConfig, w, req)
 	}
-
-	var payload forwardPayload
-	if err := json.Unmarshal(b, &payload); err != nil {
-		return err
-	}
-
-	if err := payload.Validate(); err != nil {
-		return err
-	}
-
-	url := *supplierConfig.ServiceConfig.BackendUrl
-	url.Path = path.Join(url.Path, payload.Path)
-
-	forwardReq := &http.Request{
-		Method: payload.Method,
-		Body:   io.NopCloser(bytes.NewBufferString(payload.Data)),
-		URL:    &url,
-		Header: payload.toHeaders(),
-	}
-
-	c := http.Client{
-		Transport: http.DefaultTransport,
-	}
-
-	// forward request to the supplier.
-	resp, err := c.Do(forwardReq)
-	if err != nil {
-		server.logger.Error().Fields(map[string]any{
-			"service_id": serviceID,
-			"method":     payload.Method,
-			"path":       payload.Path,
-			"headers":    payload.Headers,
-		}).Err(err).Msg("failed to send forward http request")
-
-		if nErr, ok := err.(net.Error); ok && nErr.Timeout() {
-			http.Error(w, fmt.Sprintf("relayminer: foward http request timeout exceeded"), http.StatusGatewayTimeout)
-		} else {
-			http.Error(w, fmt.Sprintf("relayminer: error forward http request: %s", err.Error()), http.StatusInternalServerError)
-		}
-		return err
-	}
-
-	w.WriteHeader(resp.StatusCode)
-
-	// streaming supplier's output to the client.
-	if _, err := io.Copy(w, resp.Body); err != nil {
-		server.logger.Error().Fields(map[string]any{
-			"service_id": serviceID,
-			"method":     payload.Method,
-			"path":       payload.Path,
-			"headers":    payload.Headers,
-		}).Err(err).Msg("failed to write forward http reponse")
-
-		http.Error(w, fmt.Sprintf("relayminer: error on forward http response: %s", err.Error()), http.StatusInternalServerError)
-
-		return err
-	}
-
-	return nil
 }
 
 // ServeHTTP listens for incoming relay requests. It implements the respective

--- a/pkg/relayer/proxy/http_server_test.go
+++ b/pkg/relayer/proxy/http_server_test.go
@@ -1,0 +1,112 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/pokt-network/poktroll/pkg/polylog"
+	"github.com/pokt-network/poktroll/pkg/relayer/config"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSynchronousRPCServer_Forward(t *testing.T) {
+	tests := []struct {
+		name                    string
+		inServiceID             string
+		inReqBody               []byte
+		mockManagedServiceID    string
+		mockSupplierHTTPHandler http.HandlerFunc
+		expectedForwardBody     string
+		expectedStatusCode      int
+		expectedError           error
+	}{
+		{
+			name:        "OK",
+			inServiceID: "023",
+			inReqBody:   []byte(`{"method": "POST", "path": "/", "data": "{\"in\": \"ping\"}"}`),
+			mockSupplierHTTPHandler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				b, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+
+				require.Equal(t, `{"in": "ping"}`, string(b))
+
+				rw.WriteHeader(http.StatusOK)
+				rw.Write([]byte(`{"out": "pong"}`))
+			}),
+			mockManagedServiceID: "023",
+			expectedStatusCode:   http.StatusOK,
+			expectedForwardBody:  `{"out": "pong"}`,
+		},
+		{
+			name:        "OK - With error on supplier",
+			inServiceID: "024",
+			inReqBody:   []byte(`{"method": "POST", "path": "/", "data": "{\"in\": \"ping\"}"}`),
+			mockSupplierHTTPHandler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				b, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+
+				require.Equal(t, `{"in": "ping"}`, string(b))
+
+				rw.WriteHeader(http.StatusInternalServerError)
+				rw.Write([]byte(`{"error": "failed"}`))
+			}),
+			mockManagedServiceID: "024",
+			expectedStatusCode:   http.StatusInternalServerError,
+			expectedForwardBody:  `{"error": "failed"}`,
+		},
+		{
+			name:          "NOK - Service id not found",
+			inServiceID:   "022",
+			inReqBody:     []byte(`{"method": "POST", "path": "/", "data": "{\"in\": \"ping\"}"}`),
+			expectedError: ErrRelayerProxyServiceIDNotFound,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := httptest.NewServer(test.mockSupplierHTTPHandler)
+			defer srv.Close()
+
+			req := httptest.NewRequest("POST", "/", io.NopCloser(bytes.NewBuffer(test.inReqBody)))
+
+			url, err := url.Parse(srv.URL)
+			require.NoError(t, err)
+
+			sync := &relayMinerHTTPServer{
+				serverConfig: &config.RelayMinerServerConfig{
+					SupplierConfigsMap: map[string]*config.RelayMinerSupplierConfig{
+						test.mockManagedServiceID: &config.RelayMinerSupplierConfig{
+							ServiceConfig: &config.RelayMinerSupplierServiceConfig{
+								BackendUrl: url,
+							},
+						},
+					},
+				},
+				logger: polylog.DefaultContextLogger,
+			}
+
+			respRecorder := httptest.NewRecorder()
+
+			err = sync.Forward(context.Background(), test.inServiceID, respRecorder, req)
+			if test.expectedError != nil {
+				require.Error(t, err)
+				require.True(t, errors.Is(err, test.expectedError))
+			} else {
+				require.NoError(t, err)
+
+				b, err := io.ReadAll(respRecorder.Body)
+				require.NoError(t, err)
+
+				require.JSONEq(t, test.expectedForwardBody, string(b))
+				require.Equal(t, test.expectedStatusCode, respRecorder.Result().StatusCode)
+			}
+		})
+	}
+}

--- a/pkg/relayer/proxy/sync.go
+++ b/pkg/relayer/proxy/sync.go
@@ -235,8 +235,8 @@ func (server *relayMinerHTTPServer) sendRelayResponse(
 	return err
 }
 
-// forwardPayload represents the request body format to forward a request to
-// the supplier.
+// forwardPayload represents the HTTP request body format to forward a request
+// to the supplier.
 type forwardPayload struct {
 	Method  string            `json:"method" validate:"required,oneof=GET PATCH PUT CONNECT TRACE DELETE POST HEAD OPTIONS"`
 	Path    string            `json:"path" validate:"required"`
@@ -255,7 +255,8 @@ func (p forwardPayload) toHeaders() http.Header {
 	return h
 }
 
-// Validate returns true if the payload format is correct.
+// Validate returns true if the payload format is correct based on the
+// value validation rules.
 func (p forwardPayload) Validate() error {
 	var err error
 	if structErr := validate.New().Struct(&p); structErr != nil {
@@ -267,6 +268,11 @@ func (p forwardPayload) Validate() error {
 	return err
 }
 
+// forwardHTTP forward a HTTP request:
+// - It reads the entire payload from the client.
+// - It validates the input payload.
+// - It sends the request to the supplier backend URL.
+// - It streams back the response to the client.
 func (server *relayMinerHTTPServer) forwardHTTP(ctx context.Context, supplierConfig *config.RelayMinerSupplierConfig, w http.ResponseWriter, req *http.Request) error {
 	b, err := io.ReadAll(req.Body)
 	if err != nil {

--- a/pkg/relayer/proxy/websockets/bridge.go
+++ b/pkg/relayer/proxy/websockets/bridge.go
@@ -2,7 +2,6 @@ package websockets
 
 import (
 	"context"
-	"net/http"
 	"sync"
 
 	"github.com/gorilla/websocket"
@@ -114,13 +113,8 @@ func NewBridge(
 ) (*bridge, error) {
 	bridgeLogger := logger.With("component", "bridge")
 
-	header := make(http.Header)
-	for headerKey, headerValue := range serviceConfig.Headers {
-		header.Add(headerKey, headerValue)
-	}
-
 	// Connect to the service backend.
-	serviceBackendWSConn, err := connectServiceBackend(serviceConfig.BackendUrl, header)
+	serviceBackendWSConn, err := ConnectServiceBackend(serviceConfig.BackendUrl, serviceConfig.HeadersHTTP())
 	if err != nil {
 		bridgeLogger.Error().Err(err).Msg("failed to connect to the service backend")
 		return nil, ErrWebsocketsBridge.Wrapf("failed to connect to the service backend: %v", err)

--- a/pkg/relayer/proxy/websockets/connection.go
+++ b/pkg/relayer/proxy/websockets/connection.go
@@ -81,9 +81,9 @@ type connection struct {
 	isClosed atomic.Bool
 }
 
-// connectServiceBackend establishes a websocket connection established by the
+// ConnectServiceBackend establishes a websocket connection established by the
 // relay miner client to the service backend endpoint.
-func connectServiceBackend(serviceBackendUrl *url.URL, header http.Header) (*websocket.Conn, error) {
+func ConnectServiceBackend(serviceBackendUrl *url.URL, header http.Header) (*websocket.Conn, error) {
 	// Create a new websocket dialer according to the service backend URL scheme.
 	// If the scheme is `wss`, we need to create a new dialer with a custom TLS
 	// configuration.

--- a/pkg/relayer/relayminer.go
+++ b/pkg/relayer/relayminer.go
@@ -194,7 +194,7 @@ func (rel *relayMiner) ServeForward(ctx context.Context, network, addr, token st
 	}
 
 	muxRouter := chi.NewRouter()
-	muxRouter.Method("POST", "/services/{service_id}/forward", rel.newForwardHandlerFn(ctx, token))
+	muxRouter.HandleFunc("/services/{service_id}/forward", rel.newForwardHandlerFn(ctx, token))
 
 	go func() {
 		if err := http.Serve(ln, muxRouter); err != nil {
@@ -215,7 +215,7 @@ func (rel *relayMiner) newForwardHandlerFn(ctx context.Context, token string) ht
 			return
 		}
 
-		serviceID := r.Header.Get("service-id")
+		serviceID := chi.URLParam(r, "service_id")
 		if serviceID == "" {
 			rel.logger.Error().Msg("service id not found while forwarding request")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/relayer/relayminer.go
+++ b/pkg/relayer/relayminer.go
@@ -3,12 +3,14 @@ package relayer
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/pprof"
 	"net/url"
 
 	"cosmossdk.io/depinject"
+	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -180,5 +182,50 @@ func (rel *relayMiner) newPinghandlerFn(ctx context.Context) http.Handler {
 		}
 
 		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+// ServeForward exposes a forward HTTP server for administrators to send request to
+// specific service.
+func (rel *relayMiner) ServeForward(ctx context.Context, network, addr, token string) error {
+	ln, err := net.Listen(network, addr)
+	if err != nil {
+		return fmt.Errorf("net listen: %w", err)
+	}
+
+	muxRouter := chi.NewRouter()
+	muxRouter.Method("POST", "/services/{service_id}/forward", rel.newForwardHandlerFn(ctx, token))
+
+	go func() {
+		if err := http.Serve(ln, muxRouter); err != nil {
+			rel.logger.Error().Err(err).
+				Msg("unexpected error occured while serving forward server")
+			return
+		}
+	}()
+
+	return nil
+}
+
+func (rel *relayMiner) newForwardHandlerFn(ctx context.Context, token string) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqToken := r.Header.Get("token")
+		if reqToken != token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		serviceID := r.Header.Get("service-id")
+		if serviceID == "" {
+			rel.logger.Error().Msg("service id not found while forwarding request")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		rel.logger.Debug().Fields(map[string]any{
+			"service_id": serviceID,
+		}).Msg("forwarding request to supplier...")
+
+		rel.relayerProxy.Forward(ctx, serviceID, w, r)
 	})
 }

--- a/pkg/relayer/relayminer.go
+++ b/pkg/relayer/relayminer.go
@@ -217,14 +217,13 @@ func (rel *relayMiner) newForwardHandlerFn(ctx context.Context, token string) ht
 
 		serviceID := chi.URLParam(r, "service_id")
 		if serviceID == "" {
-			rel.logger.Error().Msg("service id not found while forwarding request")
-			w.WriteHeader(http.StatusInternalServerError)
+			rel.logger.Error().Msg("service id not found in URL while forwarding request")
+			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 
-		rel.logger.Debug().Fields(map[string]any{
-			"service_id": serviceID,
-		}).Msg("forwarding request to supplier...")
+		rel.logger.Debug().Str("service_id", serviceID).
+			Msg("forwarding request to supplier...")
 
 		rel.relayerProxy.Forward(ctx, serviceID, w, r)
 	})


### PR DESCRIPTION
## Summary

This PR aims to add capabilities to forward requests to HTTP and a WebSocket server in the relayminer. 

It sets up a configurable authenticated endpoint (/services/{service_id}/forward) whose responsibility would be to forward raw requests from the Relay Server to the service ID (more precisely, service node or data node).

## Issue

- Issue: https://github.com/pokt-network/poktroll/issues/447

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
