### PR TITLE
[WIP] Implement historical params with height-based retrieval

### DIFF
--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -293,6 +293,8 @@ type SessionQueryClient interface {
 type SharedQueryClient interface {
 	// GetParams queries the chain for the current shared module parameters.
 	GetParams(ctx context.Context) (*sharedtypes.Params, error)
+	// GetParamsAtHeight queries the chain for the shared module parameters at a given height.
+	GetParamsAtHeight(ctx context.Context, queryHeight int64) (*sharedtypes.Params, error)
 	// GetSessionGracePeriodEndHeight returns the block height at which the grace period
 	// for the session that includes queryHeight elapses.
 	// The grace period is the number of blocks after the session ends during which relays
@@ -311,7 +313,7 @@ type SharedQueryClient interface {
 	// for the session that includes queryHeight can be committed for a given supplier.
 	GetEarliestSupplierProofCommitHeight(ctx context.Context, queryHeight int64, supplierOperatorAddr string) (int64, error)
 	// GetComputeUnitsToTokensMultiplier returns the multiplier used to convert compute units to tokens.
-	GetComputeUnitsToTokensMultiplier(ctx context.Context) (uint64, error)
+	GetComputeUnitsToTokensMultiplier(ctx context.Context, queryHeight int64) (uint64, error)
 }
 
 // BlockQueryClient defines an interface that enables the querying of
@@ -355,10 +357,11 @@ type BankQueryClient interface {
 	GetBalance(ctx context.Context, address string) (*cosmostypes.Coin, error)
 }
 
-// ParamsCache is an interface for a simple in-memory cache implementation for onchain module parameter quueries.
+// ParamsCache is an interface for a simple in-memory historical cache
+// implementation for onchain module parameter quueries.
 // It does not involve key-value pairs, but only stores a single value.
 type ParamsCache[T any] interface {
-	Get() (T, bool)
-	Set(T)
-	Clear()
+	GetLatest() (T, bool)
+	GetAtHeight(height int64) (T, bool)
+	SetAtHeight(value T, height int64)
 }

--- a/pkg/client/query/cache/noop.go
+++ b/pkg/client/query/cache/noop.go
@@ -17,23 +17,21 @@ func NewNoOpParamsCache[T any]() *noOpParamsCache[T] {
 	return &noOpParamsCache[T]{}
 }
 
-// Get returns the value stored in the cache.
+// GetLatest returns the latest value stored in the cache.
 // A boolean is returned as the second value to indicate if the value was found in the cache.
-func (c *noOpParamsCache[T]) Get() (value T, found bool) {
+func (c *noOpParamsCache[T]) GetLatest() (value T, found bool) {
 	var zeroValue T
 	return zeroValue, false
 }
 
-// Set stores a value in the cache.
-func (c *noOpParamsCache[T]) Set(_ T) {
+// GetAtHeight returns the value stored in the cache at the given height.
+func (c *noOpParamsCache[T]) GetAtHeight(height int64) (value T, found bool) {
+	var zeroValue T
+	return zeroValue, false
 }
 
-// Delete removes the value from the cache.
-func (c *noOpParamsCache[T]) Delete() {
-}
-
-// Clear empties the cache.
-func (c *noOpParamsCache[T]) Clear() {
+// Set stores a value in the cache at the given height.
+func (c *noOpParamsCache[T]) SetAtHeight(value T, height int64) {
 }
 
 // noOpKeyValueCache is a no-op implementation of a KeyValueCache.

--- a/pkg/client/query/cache/paramscache.go
+++ b/pkg/client/query/cache/paramscache.go
@@ -11,41 +11,36 @@ var _ client.ParamsCache[any] = (*paramsCache[any])(nil)
 // singleValueCache is the key used to store the value in the cache.
 const singleValueCache = ""
 
-// paramsCache is a simple in-memory cache implementation for query parameters.
+// paramsCache is a simple in-memory historical cache implementation for query parameters.
 // It does not involve key-value pairs, but only stores a single value.
 type paramsCache[T any] struct {
-	keyValueCache cache.KeyValueCache[T]
+	historicalKeyValueCache cache.HistoricalKeyValueCache[T]
 }
 
 // NewParamsCache returns a new instance of a ParamsCache.
 func NewParamsCache[T any](opts ...memory.KeyValueCacheOptionFn) (*paramsCache[T], error) {
-	keyValueCache, err := memory.NewKeyValueCache[T](opts...)
+	historicalKeyValueCache, err := memory.NewHistoricalKeyValueCache[T](opts...)
 	if err != nil {
 		return nil, err
 	}
 
 	return &paramsCache[T]{
-		keyValueCache,
+		historicalKeyValueCache,
 	}, nil
 }
 
-// Get returns the value stored in the cache.
+// GetLatest returns the latest value stored in the cache.
 // A boolean is returned as the second value to indicate if the value was found in the cache.
-func (c *paramsCache[T]) Get() (value T, found bool) {
-	return c.keyValueCache.Get(singleValueCache)
+func (c *paramsCache[T]) GetLatest() (value T, found bool) {
+	return c.historicalKeyValueCache.GetLatestVersion(singleValueCache)
 }
 
-// Set stores a value in the cache.
-func (c *paramsCache[T]) Set(value T) {
-	c.keyValueCache.Set(singleValueCache, value)
+// GetAtHeight returns the value stored in the cache at the given height.
+func (c *paramsCache[T]) GetAtHeight(height int64) (value T, found bool) {
+	return c.historicalKeyValueCache.GetVersionLTE(singleValueCache, height)
 }
 
-// Delete removes the value from the cache.
-func (c *paramsCache[T]) Delete() {
-	c.keyValueCache.Delete(singleValueCache)
-}
-
-// Clear empties the cache.
-func (c *paramsCache[T]) Clear() {
-	c.keyValueCache.Delete(singleValueCache)
+// Set stores a value in the cache at the given height.
+func (c *paramsCache[T]) SetAtHeight(value T, height int64) {
+	c.historicalKeyValueCache.SetVersion(singleValueCache, value, height)
 }

--- a/pkg/client/query/sharedquerier.go
+++ b/pkg/client/query/sharedquerier.go
@@ -22,6 +22,7 @@ type sharedQuerier struct {
 	clientConn    grpc.ClientConn
 	sharedQuerier sharedtypes.QueryClient
 	blockQuerier  client.BlockQueryClient
+	blockClient   client.BlockClient
 	logger        polylog.Logger
 
 	// blockHashCache caches blockQuerier.Block requests
@@ -35,7 +36,11 @@ type sharedQuerier struct {
 //
 // Required dependencies:
 // - clientCtx (grpc.ClientConn)
+// - polylog.Logger
 // - client.BlockQueryClient
+// - client.BlockClient
+// - cache.KeyValueCache[BlockHash]
+// - client.ParamsCache[sharedtypes.Params]
 func NewSharedQuerier(deps depinject.Config) (client.SharedQueryClient, error) {
 	querier := &sharedQuerier{}
 
@@ -44,6 +49,7 @@ func NewSharedQuerier(deps depinject.Config) (client.SharedQueryClient, error) {
 		&querier.clientConn,
 		&querier.logger,
 		&querier.blockQuerier,
+		&querier.blockClient,
 		&querier.blockHashCache,
 		&querier.paramsCache,
 	); err != nil {
@@ -56,15 +62,14 @@ func NewSharedQuerier(deps depinject.Config) (client.SharedQueryClient, error) {
 }
 
 // GetParams queries & returns the shared module onchain parameters.
-//
-// TODO_TECHDEBT(#543): We don't really want to have to query the params for every method call.
-// Once `ModuleParamsClient` is implemented, use its replay observable's `#Last()` method
-// to get the most recently (asynchronously) observed (and cached) value.
 func (sq *sharedQuerier) GetParams(ctx context.Context) (*sharedtypes.Params, error) {
 	logger := sq.logger.With("query_client", "shared", "method", "GetParams")
 
+	// TODO_IN_THIS_PR: Ensure that the latest cached version of the shared module
+	// parameters is indeed the latest one, by subscribing to params update events.
+
 	// Get the params from the cache if they exist.
-	if params, found := sq.paramsCache.Get(); found {
+	if params, found := sq.paramsCache.GetLatest(); found {
 		logger.Debug().Msg("cache hit for shared params")
 		return &params, nil
 	}
@@ -78,20 +83,38 @@ func (sq *sharedQuerier) GetParams(ctx context.Context) (*sharedtypes.Params, er
 	}
 
 	// Update the cache with the newly retrieved params.
-	sq.paramsCache.Set(res.Params)
+	sq.paramsCache.SetAtHeight(res.Params, int64(res.EffectiveBlockHeight))
+	return &res.Params, nil
+}
+
+// GetParamsAtHeight queries & returns the shared module onchain parameters
+// that were in effect at the given block height.
+func (sq *sharedQuerier) GetParamsAtHeight(ctx context.Context, height int64) (*sharedtypes.Params, error) {
+	logger := sq.logger.With("query_client", "shared", "method", "GetParamsAtHeight")
+
+	// Get the params from the cache if they exist.
+	if params, found := sq.paramsCache.GetAtHeight(height); found {
+		logger.Debug().Msgf("cache hit for shared params at height: %d", height)
+		return &params, nil
+	}
+
+	logger.Debug().Msgf("cache miss for shared params at height: %d", height)
+
+	req := &sharedtypes.QueryParamsAtHeightRequest{Height: uint64(height)}
+	res, err := sq.sharedQuerier.ParamsAtHeight(ctx, req)
+	if err != nil {
+		return nil, ErrQuerySessionParams.Wrapf("[%v]", err)
+	}
+
+	// Update the cache with the newly retrieved params.
+	sq.paramsCache.SetAtHeight(res.Params, int64(res.EffectiveBlockHeight))
 	return &res.Params, nil
 }
 
 // GetClaimWindowOpenHeight returns the block height at which the claim window of
 // the session that includes queryHeight opens.
-//
-// TODO_MAINNET(#543): We don't really want to have to query the params for every method call.
-// Once `ModuleParamsClient` is implemented, use its replay observable's `#Last()` method
-// to get the most recently (asynchronously) observed (and cached) value.
-// TODO_MAINNET(@bryanchriswhite,#543): We also don't really want to use the current value of the params. Instead,
-// we should be using the value that the params had for the session which includes queryHeight.
 func (sq *sharedQuerier) GetClaimWindowOpenHeight(ctx context.Context, queryHeight int64) (int64, error) {
-	sharedParams, err := sq.GetParams(ctx)
+	sharedParams, err := sq.GetParamsAtHeight(ctx, queryHeight)
 	if err != nil {
 		return 0, err
 	}
@@ -100,14 +123,8 @@ func (sq *sharedQuerier) GetClaimWindowOpenHeight(ctx context.Context, queryHeig
 
 // GetProofWindowOpenHeight returns the block height at which the proof window of
 // the session that includes queryHeight opens.
-//
-// TODO_MAINNET(#543): We don't really want to have to query the params for every method call.
-// Once `ModuleParamsClient` is implemented, use its replay observable's `#Last()` method
-// to get the most recently (asynchronously) observed (and cached) value.
-// TODO_MAINNET(@bryanchriswhite,#543): We also don't really want to use the current value of the params. Instead,
-// we should be using the value that the params had for the session which includes queryHeight.
 func (sq *sharedQuerier) GetProofWindowOpenHeight(ctx context.Context, queryHeight int64) (int64, error) {
-	sharedParams, err := sq.GetParams(ctx)
+	sharedParams, err := sq.GetParamsAtHeight(ctx, queryHeight)
 	if err != nil {
 		return 0, err
 	}
@@ -118,17 +135,11 @@ func (sq *sharedQuerier) GetProofWindowOpenHeight(ctx context.Context, queryHeig
 // for the session which includes queryHeight elapses.
 // The grace period is the number of blocks after the session ends during which relays
 // SHOULD be included in the session which most recently ended.
-//
-// TODO_MAINNET(#543): We don't really want to have to query the params for every method call.
-// Once `ModuleParamsClient` is implemented, use its replay observable's `#Last()` method
-// to get the most recently (asynchronously) observed (and cached) value.
-// TODO_MAINNET(@bryanchriswhite, #543): We also don't really want to use the current value of the params.
-// Instead, we should be using the value that the params had for the session which includes queryHeight.
 func (sq *sharedQuerier) GetSessionGracePeriodEndHeight(
 	ctx context.Context,
 	queryHeight int64,
 ) (int64, error) {
-	sharedParams, err := sq.GetParams(ctx)
+	sharedParams, err := sq.GetParamsAtHeight(ctx, queryHeight)
 	if err != nil {
 		return 0, err
 	}
@@ -137,16 +148,10 @@ func (sq *sharedQuerier) GetSessionGracePeriodEndHeight(
 
 // GetEarliestSupplierClaimCommitHeight returns the earliest block height at which a claim
 // for the session that includes queryHeight can be committed for a given supplier.
-//
-// TODO_MAINNET(#543): We don't really want to have to query the params for every method call.
-// Once `ModuleParamsClient` is implemented, use its replay observable's `#Last()` method
-// to get the most recently (asynchronously) observed (and cached) value.
-// TODO_MAINNET(@bryanchriswhite, #543): We also don't really want to use the current value of the params.
-// Instead, we should be using the value that the params had for the session which includes queryHeight.
 func (sq *sharedQuerier) GetEarliestSupplierClaimCommitHeight(ctx context.Context, queryHeight int64, supplierOperatorAddr string) (int64, error) {
 	logger := sq.logger.With("query_client", "shared", "method", "GetEarliestSupplierClaimCommitHeight")
 
-	sharedParams, err := sq.GetParams(ctx)
+	sharedParams, err := sq.GetParamsAtHeight(ctx, queryHeight)
 	if err != nil {
 		return 0, err
 	}
@@ -184,16 +189,10 @@ func (sq *sharedQuerier) GetEarliestSupplierClaimCommitHeight(ctx context.Contex
 
 // GetEarliestSupplierProofCommitHeight returns the earliest block height at which a proof
 // for the session that includes queryHeight can be committed for a given supplier.
-//
-// TODO_MAINNET(#543): We don't really want to have to query the params for every method call.
-// Once `ModuleParamsClient` is implemented, use its replay observable's `#Last()` method
-// to get the most recently (asynchronously) observed (and cached) value.
-// TODO_MAINNET(@bryanchriswhite, #543): We also don't really want to use the current value of the params.
-// Instead, we should be using the value that the params had for the session which includes queryHeight.
 func (sq *sharedQuerier) GetEarliestSupplierProofCommitHeight(ctx context.Context, queryHeight int64, supplierOperatorAddr string) (int64, error) {
 	logger := sq.logger.With("query_client", "shared", "method", "GetEarliestSupplierProofCommitHeight")
 
-	sharedParams, err := sq.GetParams(ctx)
+	sharedParams, err := sq.GetParamsAtHeight(ctx, queryHeight)
 	if err != nil {
 		return 0, err
 	}
@@ -229,14 +228,11 @@ func (sq *sharedQuerier) GetEarliestSupplierProofCommitHeight(ctx context.Contex
 }
 
 // GetComputeUnitsToTokensMultiplier returns the multiplier used to convert compute units to tokens.
-//
-// TODO_MAINNET(#543): We don't really want to have to query the params for every method call.
-// Once `ModuleParamsClient` is implemented, use its replay observable's `#Last()` method
-// to get the most recently (asynchronously) observed (and cached) value.
-// TODO_MAINNET(@bryanchriswhite, #543): We also don't really want to use the current value of the params.
-// Instead, we should be using the value that the params had for the session which includes queryHeight.
-func (sq *sharedQuerier) GetComputeUnitsToTokensMultiplier(ctx context.Context) (uint64, error) {
-	sharedParams, err := sq.GetParams(ctx)
+func (sq *sharedQuerier) GetComputeUnitsToTokensMultiplier(
+	ctx context.Context,
+	queryHeight int64,
+) (uint64, error) {
+	sharedParams, err := sq.GetParamsAtHeight(ctx, queryHeight)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/deps/config/suppliers.go
+++ b/pkg/deps/config/suppliers.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pokt-network/poktroll/app/volatile"
 	"github.com/pokt-network/poktroll/pkg/cache"
 	"github.com/pokt-network/poktroll/pkg/cache/memory"
-	"github.com/pokt-network/poktroll/pkg/client"
 	"github.com/pokt-network/poktroll/pkg/client/block"
 	"github.com/pokt-network/poktroll/pkg/client/events"
 	"github.com/pokt-network/poktroll/pkg/client/query"
@@ -532,7 +531,7 @@ func NewSupplyKeyValueCacheFn[T any](opts ...querycache.CacheOption[cache.KeyVal
 
 // NewSupplyParamsCacheFn returns a function which constructs a ParamsCache of type T.
 // It take a list of cache options that can be used to configure the cache.
-func NewSupplyParamsCacheFn[T any](opts ...querycache.CacheOption[client.ParamsCache[T]]) SupplierFn {
+func NewSupplyParamsCacheFn[T any]() SupplierFn {
 	return func(
 		ctx context.Context,
 		deps depinject.Config,
@@ -553,13 +552,6 @@ func NewSupplyParamsCacheFn[T any](opts ...querycache.CacheOption[client.ParamsC
 		paramsCache, err := querycache.NewParamsCache[T](memory.WithTTL(0))
 		if err != nil {
 			return nil, err
-		}
-
-		// Apply the query cache options
-		for _, opt := range opts {
-			if err := opt(ctx, deps, paramsCache); err != nil {
-				return nil, err
-			}
 		}
 
 		return depinject.Configs(deps, depinject.Supply(paramsCache)), nil

--- a/pkg/relayer/cmd/cmd.go
+++ b/pkg/relayer/cmd/cmd.go
@@ -229,10 +229,11 @@ func setupRelayerDependencies(
 		// Setup the params caches and configure them to clear on new blocks.
 		// Some of the params (tokenomics and gateway) are not used in the RelayMiner
 		// and don't need to have a corresponding cache.
-		config.NewSupplyParamsCacheFn[sharedtypes.Params](cache.WithNewBlockCacheClearing),  // leaf
-		config.NewSupplyParamsCacheFn[apptypes.Params](cache.WithNewBlockCacheClearing),     // leaf
-		config.NewSupplyParamsCacheFn[sessiontypes.Params](cache.WithNewBlockCacheClearing), // leaf
-		config.NewSupplyParamsCacheFn[prooftypes.Params](cache.WithNewBlockCacheClearing),   // leaf
+		// ParamsCache is a historical cache, so it is not cleared on new blocks.
+		config.NewSupplyParamsCacheFn[sharedtypes.Params](),  // leaf
+		config.NewSupplyParamsCacheFn[apptypes.Params](),     // leaf
+		config.NewSupplyParamsCacheFn[sessiontypes.Params](), // leaf
+		config.NewSupplyParamsCacheFn[prooftypes.Params](),   // leaf
 
 		// Setup the key-value caches for poktroll types and configure them to clear on new blocks.
 		config.NewSupplyKeyValueCacheFn[sharedtypes.Service](cache.WithNewBlockCacheClearing),                // leaf

--- a/proto/poktroll/shared/event.proto
+++ b/proto/poktroll/shared/event.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+package poktroll.shared;
+
+option go_package = "github.com/pokt-network/poktroll/x/shared/types";
+option (gogoproto.stable_marshaler_all) = true;
+
+import "gogoproto/gogo.proto";
+
+import "poktroll/shared/params.proto";
+
+// EventSharedParamsUpdate is emitted when a shared module params becomes effective.
+message EventSharedParamsUpdated {
+  poktroll.shared.Params params = 1 [(gogoproto.jsontag) = "params"];
+  // The start height of the session at which the param is activated.
+  uint64 effective_block_height = 2 [(gogoproto.jsontag) = "effective_block_height"];
+}

--- a/proto/poktroll/shared/params.proto
+++ b/proto/poktroll/shared/params.proto
@@ -57,3 +57,13 @@ message Params {
   // unstaking before their staked assets are moved to its account balance.
   uint64 gateway_unbonding_period_sessions = 10 [(gogoproto.jsontag) = "gateway_unbonding_period_sessions"];
 }
+
+// ParamsUpdate defines the parameters update along the block height at which the update is effective.
+message ParamsUpdate {
+  Params params = 1 [
+    (gogoproto.nullable) = false,
+    (amino.dont_omitempty) = true,
+    (gogoproto.customname) = "Params"
+  ];
+  uint64 effective_block_height = 2 [(gogoproto.customname) = "EffectiveBlockHeight"];
+}

--- a/proto/poktroll/shared/query.proto
+++ b/proto/poktroll/shared/query.proto
@@ -16,6 +16,10 @@ service Query {
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
     option (google.api.http).get = "/pokt-network/poktroll/shared/params";
   }
+
+  rpc ParamsAtHeight(QueryParamsAtHeightRequest) returns (QueryParamsAtHeightResponse) {
+    option (google.api.http).get = "/pokt-network/poktroll/shared/params/{height}";
+  }
 }
 
 // QueryParamsRequest is request type for the Query/Params RPC method.
@@ -28,4 +32,19 @@ message QueryParamsResponse {
     (gogoproto.nullable) = false,
     (amino.dont_omitempty) = true
   ];
+
+  uint64 effective_block_height = 2;
+}
+
+message QueryParamsAtHeightRequest {
+  uint64 height = 1;
+}
+
+message QueryParamsAtHeightResponse {
+  Params params = 1 [
+    (gogoproto.nullable) = false,
+    (amino.dont_omitempty) = true
+  ];
+
+  uint64 effective_block_height = 2;
 }

--- a/proto/poktroll/shared/tx.proto
+++ b/proto/poktroll/shared/tx.proto
@@ -36,7 +36,10 @@ message MsgUpdateParams {
 
 // MsgUpdateParamsResponse defines the response structure for executing a
 // MsgUpdateParams message.
-message MsgUpdateParamsResponse {}
+message MsgUpdateParamsResponse {
+  Params params = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  uint64 effective_block_height = 2;
+}
 
 // MsgUpdateParam is the Msg/UpdateParam request type to update a single param.
 message MsgUpdateParam {
@@ -56,6 +59,7 @@ message MsgUpdateParam {
 // MsgUpdateParamResponse defines the response structure for executing a
 // MsgUpdateParam message after a single param update.
 message MsgUpdateParamResponse {
-  Params params = 1;
+  Params params = 1 [(gogoproto.nullable) = false, (amino.dont_omitempty) = true];
+  uint64 effective_block_height = 2;
 }
 

--- a/x/proof/keeper/msg_server_create_claim.go
+++ b/x/proof/keeper/msg_server_create_claim.go
@@ -113,7 +113,8 @@ func (k msgServer) CreateClaim(
 
 	// Get the service ID relayMiningDifficulty to calculate the claimed uPOKT.
 	serviceId := session.GetHeader().GetServiceId()
-	sharedParams := k.sharedKeeper.GetParams(ctx)
+	sessionEndHeight := session.GetHeader().GetSessionEndBlockHeight()
+	sharedParams := k.sharedKeeper.GetParamsAtHeight(ctx, sessionEndHeight)
 	relayMiningDifficulty, _ := k.serviceKeeper.GetRelayMiningDifficulty(ctx, serviceId)
 	claimedUPOKT, err := claim.GetClaimeduPOKT(sharedParams, relayMiningDifficulty)
 

--- a/x/proof/keeper/msg_server_submit_proof.go
+++ b/x/proof/keeper/msg_server_submit_proof.go
@@ -124,7 +124,7 @@ func (k msgServer) SubmitProof(
 
 	// Get the service ID relayMiningDifficulty to calculate the claimed uPOKT.
 	serviceId := sessionHeader.GetServiceId()
-	sharedParams := k.sharedKeeper.GetParams(ctx)
+	sharedParams := k.sharedKeeper.GetParamsAtHeight(ctx, sessionHeader.SessionEndBlockHeight)
 	relayMiningDifficulty, _ := k.serviceKeeper.GetRelayMiningDifficulty(ctx, serviceId)
 
 	claimedUPOKT, err := claim.GetClaimeduPOKT(sharedParams, relayMiningDifficulty)
@@ -228,8 +228,9 @@ func (k Keeper) ProofRequirementForClaim(ctx context.Context, claim *types.Claim
 	// Defer telemetry calls so that they reference the final values the relevant variables.
 	defer k.finalizeProofRequirementTelemetry(requirementReason, claim, err)
 
+	sessionEndHeight := claim.GetSessionHeader().GetSessionEndBlockHeight()
+	sharedParams := k.sharedKeeper.GetParamsAtHeight(ctx, sessionEndHeight)
 	proofParams := k.GetParams(ctx)
-	sharedParams := k.sharedKeeper.GetParams(ctx)
 
 	serviceId := claim.GetSessionHeader().GetServiceId()
 	relayMiningDifficulty, _ := k.serviceKeeper.GetRelayMiningDifficulty(ctx, serviceId)
@@ -299,13 +300,13 @@ func (k Keeper) getProofRequirementSeedBlockHash(
 	ctx context.Context,
 	claim *types.Claim,
 ) (blockHash []byte, err error) {
-	sharedParams, err := k.sharedQuerier.GetParams(ctx)
+	sessionEndHeight := claim.GetSessionHeader().GetSessionEndBlockHeight()
+	supplierOperatorAddress := claim.GetSupplierOperatorAddress()
+
+	sharedParams, err := k.sharedQuerier.GetParamsAtHeight(ctx, sessionEndHeight)
 	if err != nil {
 		return nil, err
 	}
-
-	sessionEndHeight := claim.GetSessionHeader().GetSessionEndBlockHeight()
-	supplierOperatorAddress := claim.GetSupplierOperatorAddress()
 
 	proofWindowOpenHeight := sharedtypes.GetProofWindowOpenHeight(sharedParams, sessionEndHeight)
 	proofWindowOpenBlockHash := k.sessionKeeper.GetBlockHash(ctx, proofWindowOpenHeight)

--- a/x/proof/types/expected_keepers.go
+++ b/x/proof/types/expected_keepers.go
@@ -55,6 +55,7 @@ type ApplicationKeeper interface {
 // SharedKeeper defines the expected interface needed to retrieve shared information.
 type SharedKeeper interface {
 	GetParams(ctx context.Context) sharedtypes.Params
+	GetParamsAtHeight(ctx context.Context, queryHeight int64) sharedtypes.Params
 }
 
 // ServiceKeeper defines the expected interface for the Service module.

--- a/x/proof/types/shared_query_client.go
+++ b/x/proof/types/shared_query_client.go
@@ -37,6 +37,14 @@ func (sqc *SharedKeeperQueryClient) GetParams(
 	return &sharedParams, nil
 }
 
+func (sqc *SharedKeeperQueryClient) GetParamsAtHeight(
+	ctx context.Context,
+	height int64,
+) (params *sharedtypes.Params, err error) {
+	sharedParams := sqc.sharedKeeper.GetParamsAtHeight(ctx, height)
+	return &sharedParams, nil
+}
+
 // GetSessionGracePeriodEndHeight returns the block height at which the grace period
 // for the session which includes queryHeight elapses.
 // The grace period is the number of blocks after the session ends during which relays
@@ -48,7 +56,7 @@ func (sqc *SharedKeeperQueryClient) GetSessionGracePeriodEndHeight(
 	ctx context.Context,
 	queryHeight int64,
 ) (int64, error) {
-	sharedParams := sqc.sharedKeeper.GetParams(ctx)
+	sharedParams := sqc.sharedKeeper.GetParamsAtHeight(ctx, queryHeight)
 	return sharedtypes.GetSessionGracePeriodEndHeight(&sharedParams, queryHeight), nil
 }
 
@@ -61,7 +69,7 @@ func (sqc *SharedKeeperQueryClient) GetClaimWindowOpenHeight(
 	ctx context.Context,
 	queryHeight int64,
 ) (int64, error) {
-	sharedParams := sqc.sharedKeeper.GetParams(ctx)
+	sharedParams := sqc.sharedKeeper.GetParamsAtHeight(ctx, queryHeight)
 	return sharedtypes.GetClaimWindowOpenHeight(&sharedParams, queryHeight), nil
 }
 
@@ -74,7 +82,7 @@ func (sqc *SharedKeeperQueryClient) GetProofWindowOpenHeight(
 	ctx context.Context,
 	queryHeight int64,
 ) (int64, error) {
-	sharedParams := sqc.sharedKeeper.GetParams(ctx)
+	sharedParams := sqc.sharedKeeper.GetParamsAtHeight(ctx, queryHeight)
 	return sharedtypes.GetProofWindowOpenHeight(&sharedParams, queryHeight), nil
 }
 
@@ -85,7 +93,7 @@ func (sqc *SharedKeeperQueryClient) GetEarliestSupplierClaimCommitHeight(
 	queryHeight int64,
 	supplierOperatorAddr string,
 ) (int64, error) {
-	sharedParams := sqc.sharedKeeper.GetParams(ctx)
+	sharedParams := sqc.sharedKeeper.GetParamsAtHeight(ctx, queryHeight)
 	claimWindowOpenHeight := sharedtypes.GetClaimWindowOpenHeight(&sharedParams, queryHeight)
 
 	// Fetch the claim window open block hash so that it can be used as part of the
@@ -109,7 +117,7 @@ func (sqc *SharedKeeperQueryClient) GetEarliestSupplierProofCommitHeight(
 	queryHeight int64,
 	supplierOperatorAddr string,
 ) (int64, error) {
-	sharedParams := sqc.sharedKeeper.GetParams(ctx)
+	sharedParams := sqc.sharedKeeper.GetParamsAtHeight(ctx, queryHeight)
 	proofWindowOpenHeight := sharedtypes.GetProofWindowOpenHeight(&sharedParams, queryHeight)
 
 	// Fetch the proof window open block hash so that it can be used as part of the
@@ -127,12 +135,10 @@ func (sqc *SharedKeeperQueryClient) GetEarliestSupplierProofCommitHeight(
 }
 
 // GetComputeUnitsToTokensMultiplier returns the multiplier used to convert compute units to tokens.
-//
-// TODO_POST_MAINNNET: If this changes mid-session, the cost of the relays at the
-// end of the session may differ from what was anticipated at the beginning.
-// Since this will be a non-frequent occurrence, accounting for this edge case is
-// not an immediate blocker.
-func (sqc *SharedKeeperQueryClient) GetComputeUnitsToTokensMultiplier(ctx context.Context) (uint64, error) {
-	sharedParams := sqc.sharedKeeper.GetParams(ctx)
+func (sqc *SharedKeeperQueryClient) GetComputeUnitsToTokensMultiplier(
+	ctx context.Context,
+	queryHeight int64,
+) (uint64, error) {
+	sharedParams := sqc.sharedKeeper.GetParamsAtHeight(ctx, queryHeight)
 	return sharedParams.GetComputeUnitsToTokensMultiplier(), nil
 }

--- a/x/shared/keeper/activate_params.go
+++ b/x/shared/keeper/activate_params.go
@@ -1,0 +1,63 @@
+package keeper
+
+import (
+	"context"
+	"fmt"
+
+	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+)
+
+// BeginBlockerActivateSharedParams activates the shared params that are scheduled
+// to be effective at the start of the current session.
+// It returns the params update that was activated.
+func (k Keeper) BeginBlockerActivateSharedParams(
+	ctx context.Context,
+) (activatedSharedParamsUpdate *sharedtypes.ParamsUpdate, err error) {
+	logger := k.Logger().With("method", "ActivateSharedParams")
+
+	sdkCtx := cosmostypes.UnwrapSDKContext(ctx)
+	currentBlockHeight := sdkCtx.BlockHeight()
+	// Get the shared params prior to the activation to determine the session start height.
+	// If the NumBlocksPerSession will be updated, it will determine the session start height
+	// of the future sessions only.
+	previousSharedParams := k.sharedKeeper.GetParams(ctx)
+
+	// Only activate params at the start of a session.
+	if !sharedtypes.IsSessionStartHeight(&previousSharedParams, currentBlockHeight) {
+		return &sharedtypes.ParamsUpdate, nil
+	}
+
+	logger.Info(fmt.Sprintf(
+		"starting session %d, about to activate new shared params",
+		sharedtypes.GetSessionNumber(&previousSharedParams, currentBlockHeight),
+	))
+
+	for _, sharedParamsUpdate := range k.GetParamsUpdates(ctx) {
+		// Skip updates that are not scheduled to be effective at the current block height.
+		// EffectiveBlockHeight is set by UpdateParams and UpdateParam keeper methods
+		// to be a session start height.
+		if sharedParamsUpdate.EffectiveBlockHeight != currentBlockHeight {
+			continue
+		}
+
+		// Update the shared params.
+		k.SetParams(ctx, sharedParamsUpdate.Params)
+		activatedSharedParamsUpdate = &sharedParamsUpdate
+
+		// Emit service activation events.
+		eventSharedParamsUpdated := &sharedtypes.EventSharedParamsUpdated{
+			Params:               sharedParamsUpdate.Params,
+			EffectiveBlockHeight: sharedParamsUpdate.EffectiveBlockHeight,
+		}
+		if err := sdkCtx.EventManager().EmitTypedEvent(eventSharedParamsUpdated); err != nil {
+			logger.Error(fmt.Sprintf("could not emit event %v", eventSharedParamsUpdated))
+			return activatedSharedParamsUpdate, err
+		}
+
+		break
+	}
+
+	return activatedSharedParamsUpdate, nil
+}

--- a/x/shared/keeper/msg_server_update_param.go
+++ b/x/shared/keeper/msg_server_update_param.go
@@ -20,16 +20,6 @@ func (k msgServer) UpdateParam(ctx context.Context, msg *types.MsgUpdateParam) (
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	if k.GetAuthority() != msg.Authority {
-		return nil, status.Error(
-			codes.InvalidArgument,
-			types.ErrSharedInvalidSigner.Wrapf(
-				"invalid authority; expected %s, got %s",
-				k.GetAuthority(), msg.Authority,
-			).Error(),
-		)
-	}
-
 	params := k.GetParams(ctx)
 
 	switch msg.Name {
@@ -70,21 +60,19 @@ func (k msgServer) UpdateParam(ctx context.Context, msg *types.MsgUpdateParam) (
 		)
 	}
 
-	// Perform a global validation on all params, which includes the updated param.
-	// This is needed to ensure that the updated param is valid in the context of all other params.
-	if err := params.ValidateBasic(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	msgUpdateParams := &types.MsgUpdateParams{
+		Authority: k.GetAuthority(),
+		Params:    params,
 	}
-
-	if err := k.SetParams(ctx, params); err != nil {
+	response, err := k.UpdateParams(ctx, msgUpdateParams)
+	if err != nil {
 		err = fmt.Errorf("unable to set params: %w", err)
 		logger.Error(fmt.Sprintf("ERROR: %s", err))
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	updatedParams := k.GetParams(ctx)
-
 	return &types.MsgUpdateParamResponse{
-		Params: &updatedParams,
+		Params:               response.Params,
+		EffectiveBlockHeight: response.EffectiveBlockHeight,
 	}, nil
 }

--- a/x/shared/keeper/msg_update_params.go
+++ b/x/shared/keeper/msg_update_params.go
@@ -27,11 +27,24 @@ func (k msgServer) UpdateParams(goCtx context.Context, req *types.MsgUpdateParam
 		)
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	if err := k.SetParams(ctx, req.Params); err != nil {
+	committedHeight := ctx.BlockHeight()
+
+	currentParams := k.GetParams(ctx)
+	nextSessionStartHeight := types.GetNextSessionStartHeight(&currentParams, committedHeight)
+
+	paramsUpdate := types.ParamsUpdate{
+		Params:               req.Params,
+		EffectiveBlockHeight: uint64(nextSessionStartHeight),
+	}
+
+	if err := k.SetParamsUpdate(ctx, paramsUpdate); err != nil {
 		err = types.ErrSharedParamInvalid.Wrapf("unable to set params: %v", err)
 		logger.Error(err.Error())
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	return &types.MsgUpdateParamsResponse{}, nil
+	return &types.MsgUpdateParamsResponse{
+		Params:               paramsUpdate.Params,
+		EffectiveBlockHeight: paramsUpdate.EffectiveBlockHeight,
+	}, nil
 }

--- a/x/shared/keeper/params.go
+++ b/x/shared/keeper/params.go
@@ -3,6 +3,8 @@ package keeper
 import (
 	"context"
 
+	"cosmossdk.io/store/prefix"
+	storetypes "cosmossdk.io/store/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
 
 	"github.com/pokt-network/poktroll/x/shared/types"
@@ -28,6 +30,59 @@ func (k Keeper) SetParams(ctx context.Context, params types.Params) error {
 		return err
 	}
 	store.Set(types.ParamsKey, bz)
+
+	return nil
+}
+
+// GetParamsUpdates get all parameters updates history
+func (k Keeper) GetParamsUpdates(ctx context.Context) []types.ParamsUpdate {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.HistoricalParamsKeyPrefix))
+	iterator := storetypes.KVStorePrefixIterator(store, []byte{})
+
+	defer iterator.Close()
+
+	var paramsUpdates []types.ParamsUpdate
+	for ; iterator.Valid(); iterator.Next() {
+		var paramsUpdate types.ParamsUpdate
+		k.cdc.MustUnmarshal(iterator.Value(), &paramsUpdate)
+		paramsUpdates = append(paramsUpdates, paramsUpdate)
+	}
+
+	return paramsUpdates
+}
+
+// GetParamsAtHeight get parameters at a specific height
+func (k Keeper) GetParamsAtHeight(ctx context.Context, height int64) types.ParamsUpdate {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.HistoricalParamsKeyPrefix))
+	iterator := storetypes.KVStorePrefixIterator(store, []byte{})
+
+	defer iterator.Close()
+
+	var paramsAtHeight types.ParamsUpdate
+	for ; iterator.Valid(); iterator.Next() {
+		var paramsUpdate types.ParamsUpdate
+		k.cdc.MustUnmarshal(iterator.Value(), &paramsUpdate)
+
+		if paramsUpdate.EffectiveBlockHeight == uint64(height) {
+			paramsAtHeight = paramsUpdate
+			break
+		}
+	}
+
+	return paramsAtHeight
+}
+
+// SetParamsUpdate stores a params update that will be effective at a specific block height
+func (k Keeper) SetParamsUpdate(ctx context.Context, paramsUpdate types.ParamsUpdate) error {
+	storeAdapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(storeAdapter, types.KeyPrefix(types.HistoricalParamsKeyPrefix))
+	bz, err := k.cdc.Marshal(&paramsUpdate)
+	if err != nil {
+		return err
+	}
+	store.Set(types.ParamsUpdateKey(paramsUpdate.EffectiveBlockHeight), bz)
 
 	return nil
 }

--- a/x/shared/keeper/query_params.go
+++ b/x/shared/keeper/query_params.go
@@ -10,11 +10,32 @@ import (
 	"github.com/pokt-network/poktroll/x/shared/types"
 )
 
-func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
+// ParamsAtHeight queries the params at a specific height.
+func (k Keeper) ParamsAtHeight(goCtx context.Context, req *types.QueryParamsAtHeightRequest) (*types.QueryParamsAtHeightResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	return &types.QueryParamsResponse{Params: k.GetParams(ctx)}, nil
+	paramsAtHeight := k.GetParamsAtHeight(ctx, int64(req.Height))
+
+	return &types.QueryParamsAtHeightResponse{
+		Params:               paramsAtHeight.Params,
+		EffectiveBlockHeight: paramsAtHeight.EffectiveBlockHeight,
+	}, nil
+}
+
+func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid request")
+	}
+	ctx := sdk.UnwrapSDKContext(goCtx)
+	lastCommitHeight := ctx.BlockHeight()
+
+	paramsAtHeight := k.GetParamsAtHeight(ctx, lastCommitHeight)
+
+	return &types.QueryParamsResponse{
+		Params:               paramsAtHeight.Params,
+		EffectiveBlockHeight: paramsAtHeight.EffectiveBlockHeight,
+	}, nil
 }

--- a/x/shared/module/abci.go
+++ b/x/shared/module/abci.go
@@ -1,0 +1,32 @@
+package shared
+
+import (
+	"fmt"
+
+	cosmostelemetry "github.com/cosmos/cosmos-sdk/telemetry"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/pokt-network/poktroll/x/shared/keeper"
+	"github.com/pokt-network/poktroll/x/shared/types"
+)
+
+// BeginBlocker is called every block and handles shared params related updates that
+// need to be effective at the start of the block.
+func BeginBlocker(ctx sdk.Context, k keeper.Keeper) error {
+	// Telemetry: measure the begin-block execution time following standard cosmos-sdk practices.
+	defer cosmostelemetry.ModuleMeasureSince(types.ModuleName, cosmostelemetry.Now(), cosmostelemetry.MetricKeyBeginBlocker)
+
+	logger := k.Logger().With("method", "BeginBlocker")
+
+	effectiveParams, err := k.BeginBlockerActivateSharedParams(ctx)
+	if err != nil {
+		logger.Error(fmt.Sprintf("could not activate shared params due to error %v", err))
+		return err
+	}
+
+	if effectiveParams != nil {
+		logger.Info(fmt.Sprintf("activated new shared params %v", effectiveParams))
+	}
+
+	return nil
+}

--- a/x/shared/types/keys.go
+++ b/x/shared/types/keys.go
@@ -1,5 +1,7 @@
 package types
 
+import "strconv"
+
 const (
 	// ModuleName defines the module name
 	ModuleName = "shared"
@@ -9,6 +11,9 @@ const (
 
 	// MemStoreKey defines the in-memory store key
 	MemStoreKey = "mem_shared"
+
+	// HistoricalParamsKeyPrefix is the prefix for historical params
+	HistoricalParamsKeyPrefix = "historical_shared_params/effective_height/"
 )
 
 var (
@@ -17,4 +22,10 @@ var (
 
 func KeyPrefix(p string) []byte {
 	return []byte(p)
+}
+
+// ParamsUpdateKey returns the key for the params update at the given height
+func ParamsUpdateKey(height uint64) []byte {
+	heightStr := strconv.FormatUint(height, 10)
+	return []byte(HistoricalParamsKeyPrefix + heightStr)
 }

--- a/x/tokenomics/keeper/settle_pending_claims.go
+++ b/x/tokenomics/keeper/settle_pending_claims.go
@@ -65,6 +65,7 @@ func (k Keeper) SettlePendingClaims(ctx cosmostypes.Context) (
 			numEstimatedComputeUnits uint64
 		)
 
+		sessionEndHeight := claim.GetSessionHeader().SessionEndBlockHeight
 		sessionId := claim.GetSessionHeader().GetSessionId()
 
 		// NB: Not every (Req, Res) pair in the session is inserted into the tree due
@@ -103,7 +104,7 @@ func (k Keeper) SettlePendingClaims(ctx cosmostypes.Context) (
 			return settledResults, expiredResults, err
 		}
 
-		sharedParams := k.sharedKeeper.GetParams(ctx)
+		sharedParams := k.sharedKeeper.GetParamsAtHeight(ctx, sessionEndHeight)
 		// claimeduPOKT is the amount of uPOKT that the supplier would receive if the
 		// claim is settled. It is derived from the claimed number of relays, the current
 		// service mining difficulty and the global network parameters.
@@ -504,6 +505,11 @@ func (k Keeper) GetExpiringClaims(ctx cosmostypes.Context) (expiringClaims []pro
 	//   2. Ensure that claims are only settled or expired on a session end height.
 	//     2a. This likely also requires adding validation to the shared module params.
 	blockHeight := ctx.BlockHeight()
+
+	// TODO_IN_THIS_PR: Iterate over all claims and use the sharedParams as of the
+	// session end height to determine if the claim is expiring.
+	// This is necessary because the sharedParams can change between the session end
+	// height and the current block height.
 
 	// NB: This error can be safely ignored as onchain SharedQueryClient implementation cannot return an error.
 	sharedParams, _ := k.sharedQuerier.GetParams(ctx)

--- a/x/tokenomics/keeper/token_logic_modules.go
+++ b/x/tokenomics/keeper/token_logic_modules.go
@@ -160,7 +160,7 @@ func (k Keeper) ProcessTokenLogicModules(
 			targetNumRelays,
 		)
 	}
-	sharedParams := k.sharedKeeper.GetParams(ctx)
+	sharedParams := k.sharedKeeper.GetParamsAtHeight(ctx, sessionHeader.SessionEndBlockHeight)
 
 	// Determine the total number of tokens being claimed (i.e. for the work completed)
 	// by the supplier for the amount of work they did to service the application

--- a/x/tokenomics/types/expected_keepers.go
+++ b/x/tokenomics/types/expected_keepers.go
@@ -70,6 +70,7 @@ type ProofKeeper interface {
 
 type SharedKeeper interface {
 	GetParams(ctx context.Context) sharedtypes.Params
+	GetParamsAtHeight(ctx context.Context, queryHeight int64) sharedtypes.Params
 	SetParams(ctx context.Context, params sharedtypes.Params) error
 
 	GetSessionEndHeight(ctx context.Context, queryHeight int64) int64


### PR DESCRIPTION
## Summary

Enhance params system to track historical parameters and enable retrieval based on block height.
Delay params activation until next session to avoid disturbing the current session with new params.

### Primary Changes:
- Modify `ParamsCache` interface to support historical storage with `GetAtHeight` and `SetAtHeight` methods
- Add `GetParamsAtHeight` query functionality to retrieve params effective at a specific block height
- Update tokenomics and proof keepers methods to use params from the relevant session height instead of current params

### Secondary changes:
- Add `ParamsUpdate` storage with effective block heights
- Implement `BeginBlocker` to activate scheduled param updates at session boundaries
- Add events for shared params updates
- Update claim/proof processing to use historically correct parameter values

## Issue

- Issue: #543 

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
