### PR TITLE
[LocalNet] Add Grove Helm charts dependency warning to localnet and test setup

### DIFF
--- a/makefiles/localnet.mk
+++ b/makefiles/localnet.mk
@@ -3,7 +3,7 @@
 ########################
 
 .PHONY: localnet_up
-localnet_up: check_docker_ps check_kind_context proto_regen localnet_regenesis ## Starts up a clean localnet
+localnet_up: warn_message_grove_helm_charts check_docker_ps check_kind_context proto_regen localnet_regenesis ## Starts up a clean localnet
 	tilt up
 
 .PHONY: localnet_up_quick
@@ -15,7 +15,7 @@ localnet_down: ## Delete resources created by localnet
 	tilt down
 
 .PHONY: localnet_regenesis
-localnet_regenesis: check_yq warn_message_acc_initialize_pubkeys warn_message_grove_helm_charts ## Regenerate the localnet genesis file
+localnet_regenesis: check_yq warn_message_acc_initialize_pubkeys ## Regenerate the localnet genesis file
 # NOTE: intentionally not using --home <dir> flag to avoid overwriting the test keyring
 	@echo "Initializing chain..."
 	@set -e

--- a/makefiles/localnet.mk
+++ b/makefiles/localnet.mk
@@ -15,7 +15,7 @@ localnet_down: ## Delete resources created by localnet
 	tilt down
 
 .PHONY: localnet_regenesis
-localnet_regenesis: check_yq warn_message_acc_initialize_pubkeys ## Regenerate the localnet genesis file
+localnet_regenesis: check_yq warn_message_acc_initialize_pubkeys warn_message_grove_helm_charts ## Regenerate the localnet genesis file
 # NOTE: intentionally not using --home <dir> flag to avoid overwriting the test keyring
 	@echo "Initializing chain..."
 	@set -e

--- a/makefiles/tests.mk
+++ b/makefiles/tests.mk
@@ -3,7 +3,7 @@
 #############
 
 .PHONY: test_e2e_env
-test_e2e_env: warn_message_acc_initialize_pubkeys warn_message_grove_helm_charts ## Setup the default env vars for E2E tests
+test_e2e_env: warn_message_acc_initialize_pubkeys ## Setup the default env vars for E2E tests
 	export POCKET_NODE=$(POCKET_NODE) && \
 	export PATH_URL=$(PATH_URL) && \
 	export POKTROLLD_HOME=../../$(POKTROLLD_HOME)

--- a/makefiles/tests.mk
+++ b/makefiles/tests.mk
@@ -3,7 +3,7 @@
 #############
 
 .PHONY: test_e2e_env
-test_e2e_env: warn_message_acc_initialize_pubkeys ## Setup the default env vars for E2E tests
+test_e2e_env: warn_message_acc_initialize_pubkeys warn_message_grove_helm_charts ## Setup the default env vars for E2E tests
 	export POCKET_NODE=$(POCKET_NODE) && \
 	export PATH_URL=$(PATH_URL) && \
 	export POKTROLLD_HOME=../../$(POKTROLLD_HOME)

--- a/makefiles/warnings.mk
+++ b/makefiles/warnings.mk
@@ -43,3 +43,19 @@ warn_flaky_tests: ## Print a warning message that some unit tests may be flaky
 .PHONY: warn_destructive
 warn_destructive: ## Print WARNING to the user
 	@echo "This is a destructive action that will affect docker resources outside the scope of this repo!"
+
+.PHONY: warn_message_grove_helm_charts
+warn_message_grove_helm_charts: ## Print a warning message about cloning Grove Helm charts - TODO_TECHDEBT: Fix this to avoid manual steps
+	@echo "+-----------------------------------------------------------------------------------+"
+	@echo "|                                                                                   |"
+	@echo "|     IMPORTANT: Please run the following commands to set up Grove Helm charts:     |"
+	@echo "|                                                                                   |"
+	@echo "|     git clone https://github.com/buildwithgrove/helm-charts grove-helm-charts     |"
+	@echo "|     cd grove-helm-charts && git checkout d8ac9df02af7a258dfaaa044580ff21f0412cc33 |"
+	@echo "|                                                                                   |"
+	@echo "|     Then update localnet_config_yaml with:                                        |"
+	@echo "|     grove_helm_chart_local_repo:                                                  |"
+	@echo "|       enabled: true                                                               |"
+	@echo "|       path: ../grove-helm-charts                                                  |"
+	@echo "|                                                                                   |"
+	@echo "+-----------------------------------------------------------------------------------+"

--- a/makefiles/warnings.mk
+++ b/makefiles/warnings.mk
@@ -45,17 +45,19 @@ warn_destructive: ## Print WARNING to the user
 	@echo "This is a destructive action that will affect docker resources outside the scope of this repo!"
 
 .PHONY: warn_message_grove_helm_charts
-warn_message_grove_helm_charts: ## Print a warning message about cloning Grove Helm charts - TODO_TECHDEBT: Fix this to avoid manual steps
+warn_message_grove_helm_charts: ## Print a temporary message about using local PATH helm charts while the codebase is in flux.
 	@echo "+-----------------------------------------------------------------------------------+"
+	@echo "|     TODO_MAINNET_MIGRATION(@olshansky): Remove this check after poktroll & path    |"
+	@echo "|     align                                                                         |"
 	@echo "|                                                                                   |"
-	@echo "|     IMPORTANT: Please run the following commands to set up Grove Helm charts:     |"
+	@echo "|     IMPORTANT: Please run the following commands to set up Grove Helm charts:      |"
 	@echo "|                                                                                   |"
-	@echo "|     git clone https://github.com/buildwithgrove/helm-charts grove-helm-charts     |"
-	@echo "|     cd grove-helm-charts && git checkout d8ac9df02af7a258dfaaa044580ff21f0412cc33 |"
+	@echo "|     git clone https://github.com/buildwithgrove/helm-charts grove-helm-charts       |"
+	@echo "|     cd grove-helm-charts && git checkout d8ac9df02af7a258dfaaa044580ff21f0412cc33   |"
 	@echo "|                                                                                   |"
-	@echo "|     Then update localnet_config_yaml with:                                        |"
-	@echo "|     grove_helm_chart_local_repo:                                                  |"
-	@echo "|       enabled: true                                                               |"
-	@echo "|       path: ../grove-helm-charts                                                  |"
+	@echo "|     Then update localnet_config_yaml with:                                         |"
+	@echo "|     grove_helm_chart_local_repo:                                                   |"
+	@echo "|       enabled: true                                                                |"
+	@echo "|       path: ../grove-helm-charts                                                   |"
 	@echo "|                                                                                   |"
 	@echo "+-----------------------------------------------------------------------------------+"


### PR DESCRIPTION
## Summary
Add warning messages about Grove Helm charts setup requirement to relevant makefiles

### Primary Changes:
- Add `warn_message_grove_helm_charts` target with instructions for cloning Grove Helm charts
- Update `localnet_regenesis` target to include the Grove Helm charts warning
- Update `test_e2e_env` target to include the Grove Helm charts warning

## Issue

![image](https://github.com/user-attachments/assets/0eabbd10-d89a-4e3b-bb68-32dcdceced80)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [x] I added TODOs where applicable
