### PR TITLE
fix: update gateway cheatsheet to stake anvil not F00C

### DIFF
--- a/docusaurus/docs/operate/cheat_sheets/gateway_cheatsheet.md
+++ b/docusaurus/docs/operate/cheat_sheets/gateway_cheatsheet.md
@@ -149,7 +149,7 @@ Create an Application stake configuration file:
 cat <<🚀 > /tmp/stake_app_config.yaml
 stake_amount: 100000000upokt
 service_ids:
-  - "F00C"
+  - "anvil"
 🚀
 ```
 


### PR DESCRIPTION
## Summary

Changes the Gateway cheatsheet docs to stake for `anvil` (shannon) and not `F00C` (morse).

## Issue

Noted from support discussion on Discord:
https://discord.com/channels/824324475256438814/1349394368758284330/1354376338605215877

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
