### PR TITLE
Fixed naming of Pocket in Docs

### DIFF
--- a/docusaurus/docs/README.md
+++ b/docusaurus/docs/README.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-title: PoktrolPocketl
+title: Pocket
 id: home-doc
 slug: /
 ---


### PR DESCRIPTION
## Summary

Pocket was misnamed on the docusaurus homepage after the poktroll -> pocket change.

Changes:
- Fixed the name of the docusaurus homepage title.
![Screenshot 2025-03-28 at 12 56 47 PM](https://github.com/user-attachments/assets/f5bce52e-7378-4bce-9a50-a5287f6fec93)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [X] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [X] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [X] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
