### PR TITLE
[Morse -> Shannon Migration] chore: restore default timeout height offset support in `TxClient`

### DIFF
--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -90,9 +90,14 @@ type SupplierClient interface {
 // TxClient provides a synchronous interface initiating and waiting for transactions
 // derived from cosmos-sdk messages, in a cosmos-sdk based blockchain network.
 type TxClient interface {
-	SignAndBroadcast(
+	SignAndBroadcastWithTimeoutHeight(
 		ctx context.Context,
 		timeoutHeight int64,
+		msgs ...cosmostypes.Msg,
+	) either.AsyncError
+
+	SignAndBroadcast(
+		ctx context.Context,
 		msgs ...cosmostypes.Msg,
 	) either.AsyncError
 }

--- a/pkg/client/supplier/client.go
+++ b/pkg/client/supplier/client.go
@@ -83,7 +83,7 @@ func (sClient *supplierClient) SubmitProofs(
 
 	// TODO(@bryanchriswhite): reconcile splitting of supplier & proof modules
 	//  with offchain pkgs/nomenclature.
-	eitherErr := sClient.txClient.SignAndBroadcast(ctx, timeoutHeight, msgs...)
+	eitherErr := sClient.txClient.SignAndBroadcastWithTimeoutHeight(ctx, timeoutHeight, msgs...)
 	err, errCh := eitherErr.SyncOrAsyncError()
 	if err != nil {
 		return err
@@ -130,7 +130,7 @@ func (sClient *supplierClient) CreateClaims(
 
 	// TODO(@bryanchriswhite): reconcile splitting of supplier & proof modules
 	//  with offchain pkgs/nomenclature.
-	eitherErr := sClient.txClient.SignAndBroadcast(ctx, timeoutHeight, msgs...)
+	eitherErr := sClient.txClient.SignAndBroadcastWithTimeoutHeight(ctx, timeoutHeight, msgs...)
 	err, errCh := eitherErr.SyncOrAsyncError()
 	if err != nil {
 		return err

--- a/pkg/client/tx/client_integration_test.go
+++ b/pkg/client/tx/client_integration_test.go
@@ -62,7 +62,7 @@ func TestTxClient_SignAndBroadcast_Integration(t *testing.T) {
 	}
 
 	// Sign and broadcast the message.
-	eitherErr := txClient.SignAndBroadcast(ctx, 0, appStakeMsg)
+	eitherErr := txClient.SignAndBroadcast(ctx, appStakeMsg)
 	err, _ = eitherErr.SyncOrAsyncError()
 	require.NoError(t, err)
 }

--- a/pkg/client/tx/client_test.go
+++ b/pkg/client/tx/client_test.go
@@ -114,7 +114,7 @@ func TestTxClient_SignAndBroadcast_Succeeds(t *testing.T) {
 	}
 
 	// Sign and broadcast the message.
-	eitherErr := txClient.SignAndBroadcast(ctx, 0, appStakeMsg)
+	eitherErr := txClient.SignAndBroadcast(ctx, appStakeMsg)
 	err, errCh := eitherErr.SyncOrAsyncError()
 	require.NoError(t, err)
 
@@ -270,7 +270,7 @@ func TestTxClient_SignAndBroadcast_SyncError(t *testing.T) {
 		// NB: explicitly omitting required fields
 	}
 
-	eitherErr := txClient.SignAndBroadcast(ctx, 0, appStakeMsg)
+	eitherErr := txClient.SignAndBroadcast(ctx, appStakeMsg)
 	err, _ = eitherErr.SyncOrAsyncError()
 	require.ErrorIs(t, err, tx.ErrInvalidMsg)
 
@@ -348,7 +348,7 @@ $ go test -v -count=1 -run TestTxClient_SignAndBroadcast_CheckTxError ./pkg/clie
 	}
 
 	// Sign and broadcast the message.
-	eitherErr := txClient.SignAndBroadcast(ctx, 0, appStakeMsg)
+	eitherErr := txClient.SignAndBroadcast(ctx, appStakeMsg)
 	err, _ = eitherErr.SyncOrAsyncError()
 	require.ErrorIs(t, err, tx.ErrCheckTx)
 	require.ErrorContains(t, err, expectedErrMsg)
@@ -421,7 +421,7 @@ func TestTxClient_SignAndBroadcast_Timeout(t *testing.T) {
 	}
 
 	// Sign and broadcast the message in a transaction.
-	eitherErr := txClient.SignAndBroadcast(ctx, timeoutHeight, appStakeMsg)
+	eitherErr := txClient.SignAndBroadcast(ctx, appStakeMsg)
 	err, errCh := eitherErr.SyncOrAsyncError()
 	require.NoError(t, err)
 
@@ -529,7 +529,7 @@ func TestTxClient_SignAndBroadcast_Retry(t *testing.T) {
 	}
 
 	// Sign and broadcast the message.
-	go txClient.SignAndBroadcast(ctx, 0, appStakeMsg)
+	go txClient.SignAndBroadcast(ctx, appStakeMsg)
 
 	// Wait for 5 seconds to allow the retry strategy to perform 4 failing retries.
 	time.Sleep(5 * time.Second)
@@ -554,7 +554,7 @@ func TestTxClient_SignAndBroadcast_Retry(t *testing.T) {
 	callStatus.errorToReturn = sdkerrors.ErrTxTimeoutHeight.Wrap(fmt.Errorf("test error").Error())
 
 	// Sign and broadcast the message.
-	go txClient.SignAndBroadcast(ctx, 0, appStakeMsg)
+	go txClient.SignAndBroadcast(ctx, appStakeMsg)
 
 	// Wait the same amount of time and assert that only one failing attempt was made.
 	time.Sleep(5 * time.Second)

--- a/testutil/testclient/testtx/client.go
+++ b/testutil/testclient/testtx/client.go
@@ -70,7 +70,7 @@ func NewOneTimeSignAndBroadcastTxClient(
 	ctrl := gomock.NewController(t)
 
 	txClient := mockclient.NewMockTxClient(ctrl)
-	txClient.EXPECT().SignAndBroadcast(
+	txClient.EXPECT().SignAndBroadcastWithTimeoutHeight(
 		gomock.Eq(ctx),
 		gomock.Any(),
 		gomock.Any(),


### PR DESCRIPTION
## Summary

Restores support for using `TxClient#SignAndBroadcast()` to consumers who don't know/have a specific timeout height in mind; e.g. Morse claim CLI.

## Issue
 
- Issue: #1034

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [x] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
