### PR TITLE
[Morse -> Shannon Migration] docs: supplier claim CLI example & non-custodial note

### DIFF
--- a/docusaurus/docs/operate/morse_migration/claiming.md
+++ b/docusaurus/docs/operate/morse_migration/claiming.md
@@ -345,7 +345,7 @@ pocketd migrate claim-application \
 Should prompt for a passphrase and produce output similar to the following:
 
 ```shell
-Enter Decrypt Passphrase: 
+Enter Decrypt Passphrase:
 MsgClaimMorseApplication {
   "shannon_dest_address": "pokt1mrqt5f7qh8uxs27cjm9t7v9e74a9vvdnq5jva4",
   "morse_src_address": "1A0BB8623F40D2A9BEAC099A0BAFDCAE3C5D8288",
@@ -354,7 +354,7 @@ MsgClaimMorseApplication {
     "service_id": "anvil"
   }
 }
-Confirm MsgClaimMorseApplication: y/[n]: 
+Confirm MsgClaimMorseApplication: y/[n]:
 ```
 
 :::tip
@@ -381,9 +381,10 @@ Omit the `stake_amount` field in a supplier config; providing it in when claimin
 
 :::important (optional) Non-custodial staking
 
-If you would like to claim a Morse supplier with distinct "owner" and "operator" addresses, you MAY do so by specifying both in the [supplier staking config](../configs/supplier_staking_config.md#staking-types).
+If you would like to claim a Morse supplier with distinct `owner` and `operator` addresses,
+you MAY do so by specifying both in the [supplier staking config](../configs/supplier_staking_config.md).
 
-This delegates the permission of signing claims and proofs to the "operator" address, while the "owner" address retains sole ownership over the supplier stake and rewards.
+This delegates signing claims and proofs to the `operator` address, while the `owner` address retains sole ownership over the supplier stake and rewards.
 
 See the ["Supplier staking config" > "Staking types"](../configs/supplier_staking_config.md#staking-types).
 
@@ -402,7 +403,7 @@ For example, running the following command:
 
 ```bash
 pocketd tx migration claim-supplier \
-Enter Decrypt Passphrase: 
+Enter Decrypt Passphrase:
 MsgClaimMorseSupplier {
   "shannon_owner_address": "pokt1chn2mglfxqcp52znqk8jq2rww73qffxczz3jph",
   "shannon_operator_address": "pokt1chn2mglfxqcp52znqk8jq2rww73qffxczz3jph",


### PR DESCRIPTION
## Summary

Updates the Morse supplier claiming docs.

Changes:
- Fixes the example CLI usage
- Adds a call-out regarding non-custodial staking

## Issue

- Issue: #1126

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [x] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] For code covered by @oneshot E2E tests, `make test_e2e_oneshot` passes on localnet
- [ ] I added TODOs where applicable
