### PR TITLE
[Quick PR] change beta rpc url in the docs

### DIFF
--- a/docusaurus/docs/develop/developer_guide/debug_tips.md
+++ b/docusaurus/docs/develop/developer_guide/debug_tips.md
@@ -73,7 +73,7 @@ To investigate this issue, the following command is used to get the details of t
 ```bash
 pocketd query tx \
 --type=hash 9E4CA2B72FCD6F74C771A5B2289CEACED30C2717ABEA4330E12543D3714D322B \
---node https://shannon-testnet-grove-seed-rpc.poktroll.com
+--node https://shannon-testnet-grove-rpc.beta.poktroll.com
 ```
 
 Which shows the following log entry:
@@ -103,7 +103,7 @@ TestNet at this point. Please consider updating with a new one!
 ```bash
 pocketd query tx \
 --type=hash 9E4CA2B72FCD6F74C771A5B2289CEACED30C2717ABEA4330E12543D3714D322B \
---node https://shannon-testnet-grove-seed-rpc.poktroll.com \
+--node https://shannon-testnet-grove-rpc.beta.poktroll.com \
  --output json | jq .raw_log
 ```
 

--- a/docusaurus/docs/operate/configs/relayminer_config.md
+++ b/docusaurus/docs/operate/configs/relayminer_config.md
@@ -507,7 +507,7 @@ result in `Supplier` slashing if the `Proof` is required.
 The following command can be used to check the balance of a `Supplier` operator:
 
 ```bash
-pocketd query bank balance <supplier_operator_address> upokt --node https://shannon-testnet-grove-seed-rpc.poktroll.com
+pocketd query bank balance <supplier_operator_address> upokt --node https://shannon-testnet-grove-rpc.beta.poktroll.com
 ```
 
 Which output would look like:
@@ -530,7 +530,7 @@ balance:
 The following command can be used to check the current `proof_submission_fee`:
 
 ```bash
-pocketd query proof params --node https://shannon-testnet-grove-seed-rpc.poktroll.com
+pocketd query proof params --node https://shannon-testnet-grove-rpc.beta.poktroll.com
 ```
 
 Which output would look like:

--- a/docusaurus/docs/tools/tools/shannon_beta.md
+++ b/docusaurus/docs/tools/tools/shannon_beta.md
@@ -23,13 +23,13 @@ We provide `gRPC`, `JSON-RPC` and `REST` endpoints, which are available here:
 Using `curl`:
 
 ```bash
-curl -X POST https://shannon-testnet-grove-seed-rpc.poktroll.com/block
+curl -X POST https://shannon-testnet-grove-rpc.beta.poktroll.com/block
 ```
 
 Using the `pocketd` binary:
 
 ```bash
-pocketd query block --type=height 0 --node https://shannon-testnet-grove-seed-rpc.poktroll.com
+pocketd query block --type=height 0 --node https://shannon-testnet-grove-rpc.beta.poktroll.com
 ```
 
 ## Alpha Genesis


### PR DESCRIPTION
Changing the URL to the correct one.

Reported here: https://discord.com/channels/553741558869131266/1234943674903953529/1358927454621925448