### PR TITLE
[Code Health] refactor: exports & interface registration

### DIFF
--- a/x/migration/module/cmd/claim_morse_account.go
+++ b/x/migration/module/cmd/claim_morse_account.go
@@ -67,7 +67,7 @@ For more information, see: https://dev.poktroll.com/operate/morse_migration/clai
 func runClaimAccount(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	morseKeyExportPath := args[0]
-	morsePrivKey, err := loadMorsePrivateKey(morseKeyExportPath, morseKeyfileDecryptPassphrase)
+	morsePrivKey, err := LoadMorsePrivateKey(morseKeyExportPath, morseKeyfileDecryptPassphrase, noPassphrase)
 	if err != nil {
 		return err
 	}

--- a/x/migration/module/cmd/claim_morse_application.go
+++ b/x/migration/module/cmd/claim_morse_application.go
@@ -68,7 +68,7 @@ func runClaimApplication(cmd *cobra.Command, args []string) error {
 
 	// Retrieve and validate the morse key based on the first argument provided.
 	morseKeyExportPath := args[0]
-	morsePrivKey, err := loadMorsePrivateKey(morseKeyExportPath, morseKeyfileDecryptPassphrase)
+	morsePrivKey, err := LoadMorsePrivateKey(morseKeyExportPath, morseKeyfileDecryptPassphrase, noPassphrase)
 	if err != nil {
 		return err
 	}

--- a/x/migration/module/cmd/claim_morse_supplier.go
+++ b/x/migration/module/cmd/claim_morse_supplier.go
@@ -67,7 +67,7 @@ func runClaimSupplier(cmd *cobra.Command, args []string) error {
 
 	// Retrieve and validate the morse key based on the first argument provided.
 	morseKeyExportPath := args[0]
-	morsePrivKey, err := loadMorsePrivateKey(morseKeyExportPath, morseKeyfileDecryptPassphrase)
+	morsePrivKey, err := LoadMorsePrivateKey(morseKeyExportPath, morseKeyfileDecryptPassphrase, noPassphrase)
 	if err != nil {
 		return err
 	}

--- a/x/migration/module/cmd/morse_keys.go
+++ b/x/migration/module/cmd/morse_keys.go
@@ -34,14 +34,15 @@ const (
 	klen = 32
 )
 
-// loadMorsePrivateKey reads, deserializes, decrypts and returns an exported Morse private key from morseKeyExportPath.
-func loadMorsePrivateKey(morseKeyExportPath, passphrase string) (ed25519.PrivKey, error) {
+// LoadMorsePrivateKey reads, deserializes, decrypts and returns an exported Morse private key from morseKeyExportPath.
+func LoadMorsePrivateKey(morseKeyExportPath, passphrase string, noPrompt bool) (ed25519.PrivKey, error) {
 	morseArmoredKeyfileBz, err := os.ReadFile(morseKeyExportPath)
 	if err != nil {
 		return nil, err
 	}
 
-	passphrase, err = ensurePassphrase(passphrase, noPassphrase)
+	// Support overriding via the noPassphrase flag.
+	passphrase, err = ensurePassphrase(passphrase, noPrompt)
 	if err != nil {
 		return nil, err
 	}

--- a/x/shared/types/codec.go
+++ b/x/shared/types/codec.go
@@ -10,11 +10,13 @@ import (
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgUpdateParam{},
+		&SupplierServiceConfig{},
 	)
 	// this line is used by starport scaffolding # 3
 
 	registry.RegisterImplementations((*sdk.Msg)(nil),
 		&MsgUpdateParams{},
+		&SupplierServiceConfig{},
 	)
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }


### PR DESCRIPTION
## Summary

Some tweaks to support migration module operations in the C and python client bindings.

Changes:
- Register `SupplierServiceConfig` with interface registry
- Export `LoadMorsePrivateKey`

## Issue

N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] For code covered by @oneshot E2E tests, `make test_e2e_oneshot` passes on localnet
- [ ] I added TODOs where applicable
