### PR TITLE
[Localnet] Modify Tilt & localnet config to allow running PATH alongside localnet from published Helm Charts

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -72,9 +72,8 @@ localnet_config_defaults = {
 
     # By default, we use the `helm_repo` function below to point to the remote repository
     # but can update it to the locally cloned repo for testing & development
-    # TODO_MAINNET_MIGRATION(@olshansky): Revert this to `False` when `PATH` helm charts are finalized.
     "grove_helm_chart_local_repo": {
-        "enabled": True,
+        "enabled": False,
         "path": os.path.join("..", "grove-helm-charts")
     },
 
@@ -370,13 +369,19 @@ for x in range(localnet_config["path_gateways"]["count"]):
     actor_number += 1
 
     resource_flags = [
-        "--values=./localnet/kubernetes/values-common.yaml",
-        "--set=metrics.serviceMonitor.enabled=" + str(localnet_config["observability"]["enabled"]),
-        "--set=path.mountConfigMaps[0].name=path-config-" + str(actor_number),
-        "--set=path.mountConfigMaps[0].mountPath=/app/config/",
+        # PATH global values
         "--set=fullnameOverride=path" + str(actor_number),
         "--set=nameOverride=path" + str(actor_number),
         "--set=global.serviceAccount.name=path" + str(actor_number),
+        "--set=metrics.serviceMonitor.enabled=" + str(localnet_config["observability"]["enabled"]),
+        # PATH config values
+        "--set=config.fromConfigMap.enabled=true",
+        "--set=config.fromConfigMap.name=path-config-" + str(actor_number),
+        "--set=config.fromConfigMap.key=.config.yaml",
+        # GUARD values
+        "--set=guard.global.namespace=default", # Ensure GUARD runs in the default namespace
+        "--set=guard.global.serviceName=path" + str(actor_number) + "-http", # Override the default service name
+        "--set=guard.services[0].serviceId=anvil", # Ensure HTTPRoute resources are created for Anvil
     ]
 
     if localnet_config["path_local_repo"]["enabled"]:

--- a/Tiltfile
+++ b/Tiltfile
@@ -399,6 +399,14 @@ for x in range(localnet_config["path_gateways"]["count"]):
         from_file=".config.yaml=./localnet/kubernetes/config-path-" + str(actor_number) + ".yaml"
     )
 
+    # Start a Tilt resource to patch the Envoy Gateway LoadBalancer resource
+    # to ensure it is reachable from outside the cluster at "localhost:3070".
+    local_resource(
+        "patch-envoy-gateway",
+        "./localnet/scripts/patch_envoy_gateway.sh",
+        resource_deps=["path-stack"],
+    )
+
     helm_resource(
         "path" + str(actor_number),
         grove_chart_prefix + "path",

--- a/docusaurus/docs/develop/developer_guide/walkthrough.md
+++ b/docusaurus/docs/develop/developer_guide/walkthrough.md
@@ -23,10 +23,9 @@ Create a new [GitHub issue here](https://github.com/pokt-network/poktroll/issues
   - [1.1 Clone the `poktroll` repository](#11-clone-the-poktroll-repository)
   - [1.2 See all the available helper commands in `Makefile`](#12-see-all-the-available-helper-commands-in-makefile)
   - [1.3 Prepare your development environment](#13-prepare-your-development-environment)
-  - [1.4 Create a `k8s` cluster](#14-create-a-k8s-cluster)
-  - [1.5 Start up LocalNet](#15-start-up-localnet)
-  - [1.6 View Grafana Logs](#16-view-grafana-logs)
-  - [1.7 Check the status of the blockchain](#17-check-the-status-of-the-blockchain)
+  - [1.4 Start up LocalNet](#14-start-up-localnet)
+  - [1.5 View Grafana Logs](#15-view-grafana-logs)
+  - [1.6 Check the status of the blockchain](#16-check-the-status-of-the-blockchain)
 - [2. Fund New Accounts](#2-fund-new-accounts)
   - [2.1 Create a Shannon `Supplier` Account](#21-create-a-shannon-supplier-account)
   - [2.2 Create a Shannon `Application` Account](#22-create-a-shannon-application-account)
@@ -156,21 +155,7 @@ needing to regenerate the mocks and types:
 make test_all
 ```
 
-### 1.4 Create a `k8s` cluster
-
-Create a new `k8s` cluster for your LocalNet:
-
-```bash
-kind create cluster
-```
-
-If you use `k8s` for other things, you may need to switch your context as well:
-
-```bash
-kubectl config use-context kind-kind
-```
-
-### 1.5 Start up LocalNet
+### 1.4 Start up LocalNet
 
 Bring up your LocalNet and wait a few minutes:
 
@@ -178,11 +163,28 @@ Bring up your LocalNet and wait a few minutes:
 make localnet_up
 ```
 
+:::info
+
+The `make localnet_up` command will run the `make dev_up` target, which:
+
+- Creates a new `kind` cluster
+- Creates all namespaces required by the PATH Helm Charts
+
+:::tip 
+
+To fully stop your LocalNet:
+
+- Exit the Tilt shell by pressing `Ctrl+C`
+- Run `make localnet_down` to stop Tilt
+- Run `kind delete cluster` to delete the `kind` cluster
+
+:::
+
 Visit [localhost:10350](<http://localhost:10350/r/(all)/overview>) and wait until all the containers are 🟢
 
 If everything worked as expected, your screen should look similar to the following:
 
-### 1.6 View Grafana Logs
+### 1.5 View Grafana Logs
 
 Every actor has a local grafana dashboard associated with it.
 
@@ -193,7 +195,7 @@ you can click in the top left corner to view its [grafana dashboard](http://loca
 
 ![Grafana RelayMiner](./img/quickstart_relayminer_grafana.png)
 
-### 1.7 Check the status of the blockchain
+### 1.6 Check the status of the blockchain
 
 You can query the status of the blockchain using `pocketd` by running:
 
@@ -551,9 +553,11 @@ information on how public keys are stored and accessible onchain.
 You can use `curl`
 
 ```bash
-curl -X POST -H "Content-Type: application/json" \
-  --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
-  http://anvil.localhost:3000/v1
+curl http://localhost:3070/v1 \
+    -H "Authorization: test_api_key" \
+    -H "Target-Service-Id: anvil" \
+    -H "App-Address: pokt1mrqt5f7qh8uxs27cjm9t7v9e74a9vvdnq5jva4" \
+    -d '{"jsonrpc":"2.0","method":"eth_blockNumber","id":1}
 ```
 
 If everything worked as expected, you should see output similar to the following:

--- a/localnet/kubernetes/config-path-1.yaml
+++ b/localnet/kubernetes/config-path-1.yaml
@@ -9,7 +9,3 @@ shannon_config:
     gateway_mode: delegated
     gateway_address: pokt15vzxjqklzjtlz7lahe8z2dfe9nm5vxwwmscne4 # gateway1
     gateway_private_key_hex: cf09805c952fa999e9a63a9f434147b0a5abfd10f268879694c6b5a70e1ae177
-
-services:
-  anvil:
-    alias: anvil

--- a/localnet/kubernetes/config-path-2.yaml
+++ b/localnet/kubernetes/config-path-2.yaml
@@ -9,7 +9,3 @@ shannon_config:
     gateway_mode: delegated
     gateway_address: pokt15w3fhfyc0lttv7r585e2ncpf6t2kl9uh8rsnyz # gateway2
     gateway_private_key_hex: 177ba43cec962ea407f71da9c3994ba685708e82d5d7a6d7da3268e74119bf88
-
-services:
-  anvil:
-    alias: anvil

--- a/localnet/kubernetes/config-path-3.yaml
+++ b/localnet/kubernetes/config-path-3.yaml
@@ -9,7 +9,3 @@ shannon_config:
     gateway_mode: delegated
     gateway_address: pokt1zhmkkd0rh788mc9prfq0m2h88t9ge0j83gnxya # gateway3
     gateway_private_key_hex: f73b6f7f0b9c99603c7eeddbf1c419c6f6bbc241f3798e3e4c8da9769ca81c26
-
-services:
-  anvil:
-    alias: anvil

--- a/localnet/kubernetes/kind-config.yaml
+++ b/localnet/kubernetes/kind-config.yaml
@@ -1,0 +1,16 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane 
+    extraPortMappings:
+    # GUARD (Envoy Gateway)
+    # Port will be patched to 30070 after install
+    - containerPort: 30070 
+      hostPort: 3070
+      protocol: TCP
+containerdConfigPatches:
+  # Ensure kind can pull images from GitHub Container Registry
+  - |
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors."ghcr.io"]
+        endpoint = ["https://ghcr.io"]

--- a/localnet/scripts/patch_envoy_gateway.sh
+++ b/localnet/scripts/patch_envoy_gateway.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+# Envoy Gateway Port Configuration
+#
+# This script patches the Envoy Gateway LoadBalancer service to expose a static port (30070),
+# making it reachable from the local machine on port 3070 as defined in the `kind-config.yaml` file.
+#
+# Implementation context:
+#   - Envoy Gateway service is created as a LoadBalancer 
+#   - When running in kind, LoadBalancer services automatically use NodePort underneath
+#   - In cloud environments, a LoadBalancer provisioner would map a public IP to this NodePort
+#   - In kind environments (without external load balancers), Kubernetes auto-assigns a dynamic 
+#     NodePort (30000-32767 range) unless explicitly specified
+
+PATCH_PAYLOAD='[{"op": "replace", "path": "/spec/ports/0/nodePort", "value":30070}]'
+
+# Gets the name of the Envoy Gateway service in the local cluster.
+# eg. "envoy-default-guard-envoy-gateway-f82f158a"
+get_envoy_gateway_service_name() {
+  local envoy_gateway_service_name
+  envoy_gateway_service_name=$(kubectl get svc -o json | jq -r '.items[] | select(.metadata.name | startswith("envoy-") and contains("guard-envoy-gateway")) | .metadata.name')
+  echo "$envoy_gateway_service_name"
+}
+
+# Patches the Envoy Gateway service to enforce a consistent port number of 30070 inside the container.
+# eg.  NAME                                     TYPE          CLUSTER-IP    EXTERNAL-IP  PORT(S)         AGE
+#      envoy-path-guard-envoy-gateway-55375d27  LoadBalancer  10.96.50.102  <pending>    3070:30070/TCP  3m19s
+patch_guard_port() {
+    kubectl patch svc "$(get_envoy_gateway_service_name)" --type='json' -p="$PATCH_PAYLOAD"
+}
+
+echo "Waiting for Envoy Gateway service..."
+while true; do
+  svc=$(get_envoy_gateway_service_name)
+  if [ -n "$svc" ]; then
+    echo "Found Envoy Gateway service: $svc"
+    echo "Patching service $svc..."
+    patch_guard_port
+    exit 0
+  fi
+  echo "Envoy Gateway service not found, retrying..."
+  sleep 2
+done

--- a/makefiles/localnet.mk
+++ b/makefiles/localnet.mk
@@ -4,17 +4,25 @@
 
 # TODO_TECHDEBT(@olshansk): Look at `make dev_up` in the `path` repo and port it here.
 .PHONY: localnet_up
-localnet_up: check_pocketd warn_message_grove_helm_charts check_docker_ps check_kind_context proto_regen localnet_regenesis ## Starts up a clean localnet
+localnet_up: check_pocketd check_docker_ps proto_regen localnet_regenesis dev_up check_kind_context ## Starts up a clean localnet
 	tilt up
 
 .PHONY: localnet_up_quick
-localnet_up_quick: check_docker_ps check_kind_context ## Starts up a localnet without regenerating fixtures
+localnet_up_quick: check_docker_ps dev_up check_kind_context ## Starts up a localnet without regenerating fixtures
 	tilt up
 
 .PHONY: localnet_down
 localnet_down: ## Delete resources created by localnet
 	tilt down
 
+.PHONY: dev_up
+dev_up: check_kind # Internal helper: Spins up Kind cluster if it doesn't already exist
+	echo "[INFO] Creating kind cluster..."; \
+	kind create cluster --config ./localnet/kubernetes/kind-config.yaml; \
+	kubectl config use-context kind-kind; \
+	kubectl create namespace path; \
+	kubectl create namespace monitoring; \
+	kubectl create namespace middleware; \
 
 # Optional context for 'move_poktroll_to_pocket' to answer this question:
 # https://github.com/pokt-network/poktroll/pull/1151#discussion_r2013801486 

--- a/makefiles/localnet.mk
+++ b/makefiles/localnet.mk
@@ -17,7 +17,7 @@ localnet_down: ## Delete resources created by localnet
 
 
 # Optional context for 'move_poktroll_to_pocket' to answer this question:
-# https://github.com/pokt-network/poktroll/pull/1151#discussion_r2013801486
+# https://github.com/pokt-network/poktroll/pull/1151#discussion_r2013801486 
 #
 # When running 'ignite chain --help', it states:
 # > By default the validator node will be initialized in your $HOME directory in a hidden directory that matches the name of your project.

--- a/makefiles/warnings.mk
+++ b/makefiles/warnings.mk
@@ -43,21 +43,3 @@ warn_flaky_tests: ## Print a warning message that some unit tests may be flaky
 .PHONY: warn_destructive
 warn_destructive: ## Print WARNING to the user
 	@echo "This is a destructive action that will affect docker resources outside the scope of this repo!"
-
-.PHONY: warn_message_grove_helm_charts
-warn_message_grove_helm_charts: ## Print a temporary message about using local PATH helm charts while the codebase is in flux.
-	@echo "+-----------------------------------------------------------------------------------+"
-	@echo "|     TODO_MAINNET_MIGRATION(@olshansky): Remove this check after poktroll & path   |"
-	@echo "|     align                                                                         |"
-	@echo "|                                                                                   |"
-	@echo "|     IMPORTANT: Please run the following commands to set up Grove Helm charts:     |"
-	@echo "|                                                                                   |"
-	@echo "|     git clone https://github.com/buildwithgrove/helm-charts grove-helm-charts     |"
-	@echo "|     cd grove-helm-charts && git checkout d8ac9df02af7a258dfaaa044580ff21f0412cc33 |"
-	@echo "|                                                                                   |"
-	@echo "|     Then update localnet_config_yaml with:                                        |"
-	@echo "|     grove_helm_chart_local_repo:                                                  |"
-	@echo "|       enabled: true                                                               |"
-	@echo "|       path: ../grove-helm-charts                                                  |"
-	@echo "|                                                                                   |"
-	@echo "+-----------------------------------------------------------------------------------+"


### PR DESCRIPTION
## 🌿 Summary

Modify Tilt & localnet configuration to enable running PATH alongside localnet using published Helm Charts.

### 🌱 Primary Changes:
- Updated `Tiltfile` to configure PATH Helm Chart values and add Envoy Gateway patching
- Added `kind-config.yaml` and `patch_envoy_gateway.sh` to manage Envoy Gateway port forwarding
- Simplified localnet startup process by consolidating `make localnet_up` with `dev_up` target

### 🍃 Secondary changes:
- Updated developer documentation to reflect new localnet startup process
- Removed temporary warning message about Grove Helm charts
- Cleaned up PATH config files by removing redundant service aliases

## 🛠️ Type of change

Select one or more from the following:

- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation

## 🤯 Sanity Checklist

- [ ] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For configurations, I have update the documentation