### PR TITLE
[Loclanet] Remove cluster name checks - Add notes on network realy readiness

### DIFF
--- a/docusaurus/docs/develop/developer_guide/walkthrough.md
+++ b/docusaurus/docs/develop/developer_guide/walkthrough.md
@@ -164,7 +164,7 @@ Create a new `k8s` cluster for your LocalNet:
 kind create cluster
 ```
 
-If you use `k8s` for other things, you may need to switch your context as well:
+If you use `k8s` for other things, you may (optionally) need to switch your context as well:
 
 ```bash
 kubectl config use-context kind-kind
@@ -179,6 +179,11 @@ make localnet_up
 ```
 
 Visit [localhost:10350](<http://localhost:10350/r/(all)/overview>) and wait until all the containers are 🟢
+
+:::note
+You wont be able to send a relay yet! Keep on reading the guide!
+If you are in a hurry, specifically look for the `acc_initialize_pubkeys` step.
+:::
 
 If everything worked as expected, your screen should look similar to the following:
 
@@ -540,6 +545,7 @@ a `Supplier`, and are running a `RelayMiner`, we can send a relay!
 
 You must run `make acc_initialize_pubkeys` before sending a relay in order for
 the public keys to be initialized correctly.
+This is requiered for the Shannon SDK to be able to query account information, part of the relay signing process.
 
 See the [x/auth](https://docs.cosmos.network/main/build/modules/auth) for more
 information on how public keys are stored and accessible onchain.

--- a/makefiles/checks.mk
+++ b/makefiles/checks.mk
@@ -85,12 +85,12 @@ check_docker_ps: check_docker
 ## Internal helper target - checks if the kind-kind context exists and is set
 check_kind_context: check_kind
 	@if ! kubectl config get-contexts | grep -q 'kind-kind'; then \
-		echo "kind-kind context does not exist. Please create it or switch to it."; \
-		exit 1; \
+		echo "WARNING: kind-kind context does not exist. Please consider creating it or switch to it."; \
+		echo "WARNING: Using default cluster to deploy Localnet."; \
 	fi
 	@if ! kubectl config current-context | grep -q 'kind-kind'; then \
-		echo "kind-kind context is not currently set. Use 'kubectl config use-context kind-kind' to set it."; \
-		exit 1; \
+		echo "WARNING: kind-kind context is not currently set. Please consider to use 'kubectl config use-context kind-kind' to set it."; \
+		echo "WARNING: Using default cluster to deploy Localnet."; \
 	fi
 
 .PHONY: check_godoc


### PR DESCRIPTION
## Summary

PR solving 
https://github.com/pokt-network/poktroll/issues/1206
(copied below)

## Objective

During make localnet_up the local cluster is expected to be named kind-kind, if this is not true, the process fails.

The documentation is not clear that after doing make localnet_up the network will be ready to send relays.


## Origin Document

Cluster Name: Cluster naming should not be mandatory for all devs. Localnet should be deployed in any cluster name.

Localnet readiness: Despite the general health of the localnet and that it is producing blocks, there is mandatory step: make acc_initialize_pubkeys. This is required regardless you are following the full guide or just need parts of it running.

## Goals
- Remove kind-kind cluster name requirement
- Add note stating that make acc_initialize_pubkeys is mandatory for relaying near the make localnet_up command.
