### PR TITLE
[Session] Performance optimization for supplier service data in session hydration

### DIFF
--- a/x/session/keeper/session_hydrator.go
+++ b/x/session/keeper/session_hydrator.go
@@ -211,7 +211,8 @@ func (k Keeper) hydrateSessionSuppliers(ctx context.Context, sh *sessionHydrator
 			//   - OperatorAddress
 			//   - Stake
 			//   - SessionServiceConfig
-			supplier.Services = supplier.Services[:sessionServiceConfigIdx+1]
+			serviceConfig := supplier.Services[sessionServiceConfigIdx]
+			supplier.Services = []*sharedtypes.SupplierServiceConfig{serviceConfig}
 			supplier.ServiceConfigHistory = nil
 
 			candidateSuppliers = append(candidateSuppliers, &supplier)

--- a/x/session/keeper/session_hydrator.go
+++ b/x/session/keeper/session_hydrator.go
@@ -204,6 +204,13 @@ func (k Keeper) hydrateSessionSuppliers(ctx context.Context, sh *sessionHydrator
 			// Do not check if sessionServiceConfigIdx is -1 since IsActive is already doing that.
 			sessionServiceConfigIdx := getSupplierSessionServiceConfigIdx(&supplier, sh.sessionHeader.ServiceId)
 
+			// TODO_POST_MAINNET: Have dedicated proto type for session suppliers hydration.
+			// * Create a distinct supplier proto type specific for session hydration
+			// * Avoid confusion between full supplier records and session supplier records
+			// * Include only data relevant to the session:
+			//   - OperatorAddress
+			//   - Stake
+			//   - SessionServiceConfig
 			supplier.Services = supplier.Services[:sessionServiceConfigIdx+1]
 			supplier.ServiceConfigHistory = nil
 

--- a/x/session/keeper/session_hydrator_test.go
+++ b/x/session/keeper/session_hydrator_test.go
@@ -64,7 +64,11 @@ func TestSession_HydrateSession_Success_BaseCase(t *testing.T) {
 
 	supplier := suppliers[0]
 	require.Equal(t, keepertest.TestSupplierOperatorAddress, supplier.OperatorAddress)
-	require.Len(t, supplier.Services, 3)
+
+	// supplier.Services should only contain the service corresponding to the
+	// session's serviceId
+	require.Len(t, supplier.Services, 1)
+	require.Equal(t, keepertest.TestServiceId1, supplier.Services[0].ServiceId)
 }
 
 func TestSession_HydrateSession_Metadata(t *testing.T) {


### PR DESCRIPTION
## Sumarry

Reduces the amount of data transferred over the network when sending sessions by omitting service configs that are non-relevant to the requested session.


### Primary Changes
* Optimize session data size by keeping only relevant `ServiceConfig` for the session's service ID
* Add `getSupplierSessionServiceConfigIdx` helper function to locate the specific service config
* Set `ServiceConfigHistory` to nil to further reduce data size

### Secondary Changes
* Update tests to verify that suppliers now only contain the specific service config

## Issue

![image](https://github.com/user-attachments/assets/b3dada96-cdda-485f-8040-16d614b9e21a)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [x] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] For code covered by @oneshot E2E tests, `make test_e2e_oneshot` passes on localnet
- [x] I added TODOs where applicable
