### PR TITLE
[Upgrade] Update `v0.1.2` transactions

### DIFF
--- a/tools/scripts/upgrades/upgrade_tx_v0.1.2_beta.json
+++ b/tools/scripts/upgrades/upgrade_tx_v0.1.2_beta.json
@@ -3,10 +3,10 @@
     "messages": [
       {
         "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
-        "authority": "pokt1f0c9y7mahf2ya8tymy8g4rr75ezh3pkklu4c3e",
+        "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
         "plan": {
           "name": "v0.1.2",
-          "height": "UPDATE_ME",
+          "height": "4013",
           "info": "{\"binaries\":{\"linux/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.2/pocket_linux_amd64.tar.gz?checksum=sha256:cf6c0dcdbb48d4d146e6d95c06fe75a4bc9e2ada976f0185bd679ae11b5b6f37\",\"linux/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.2/pocket_linux_arm64.tar.gz?checksum=sha256:f1d3df287cfd7ff562ee9d833c5902b5f497584056b95ce8b200c7d8a817e85f\",\"darwin/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.2/pocket_darwin_amd64.tar.gz?checksum=sha256:8a265c8abfeeda333579ec531c04f90ee1ff2c6da931db2cc11b9527e8077f52\",\"darwin/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.2/pocket_darwin_arm64.tar.gz?checksum=sha256:8cd8fd7e5c468fd152b450a646d16455f1594412766dd767bb0dc4bbfb44eb0a\"}}"
         }
       }

--- a/tools/scripts/upgrades/upgrade_tx_v0.1.2_local.json
+++ b/tools/scripts/upgrades/upgrade_tx_v0.1.2_local.json
@@ -3,7 +3,7 @@
     "messages": [
       {
         "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
-        "authority": "pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw",
+        "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
         "plan": {
           "name": "v0.1.2",
           "height": "UPDATE_ME",

--- a/tools/scripts/upgrades/upgrade_tx_v0.1.2_main.json
+++ b/tools/scripts/upgrades/upgrade_tx_v0.1.2_main.json
@@ -3,7 +3,7 @@
     "messages": [
       {
         "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
-        "authority": "pokt18808wvw0h4t450t06uvauny8lvscsxjfyua7vh",
+        "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
         "plan": {
           "name": "v0.1.2",
           "height": "UPDATE_ME",


### PR DESCRIPTION
- Update `v0.1.2` authority transactions
- Update beta upgrade height

```
export TX_HASH=E94F714B017D372FC73EF8477DBE104A3083772AD9912D7A53E198C5C1B78ADF
export RPC_ENDPOINT=https://shannon-testnet-grove-rpc.beta.poktroll.com
pocketd query tx --type=hash ${TX_HASH} --node ${RPC_ENDPOINT}
```