### PR TITLE
[Cache] Prevent cache race conditions through double-check locking pattern

### DIFF
--- a/pkg/client/query/proofquerier.go
+++ b/pkg/client/query/proofquerier.go
@@ -3,6 +3,7 @@ package query
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"cosmossdk.io/depinject"
 	"github.com/cosmos/gogoproto/grpc"
@@ -27,6 +28,10 @@ type proofQuerier struct {
 	// claimsCache caches proofQuerier.Claim requests
 	// It keys the Claims by sessionId and supplierOperatorAddress
 	claimsCache cache.KeyValueCache[prooftypes.Claim]
+
+	// Mutexes to protect cache access patterns
+	paramsMutex sync.Mutex
+	claimsMutex sync.Mutex
 }
 
 // NewProofQuerier returns a new instance of a client.ProofQueryClient by
@@ -67,7 +72,17 @@ func (pq *proofQuerier) GetParams(
 		return &params, nil
 	}
 
-	logger.Debug().Msg("cache miss proof params")
+	// Use mutex to prevent multiple concurrent cache updates
+	pq.paramsMutex.Lock()
+	defer pq.paramsMutex.Unlock()
+
+	// Double-check cache after acquiring lock
+	if params, found := pq.paramsCache.Get(); found {
+		logger.Debug().Msg("cache hit for proof params after lock")
+		return &params, nil
+	}
+
+	logger.Debug().Msg("cache miss for proof params")
 
 	req := &prooftypes.QueryParamsRequest{}
 	res, err := retry.Call(ctx, func() (*prooftypes.QueryParamsResponse, error) {
@@ -95,6 +110,16 @@ func (pq *proofQuerier) GetClaim(
 	claimCacheKey := getClaimCacheKey(supplierOperatorAddress, sessionId)
 	if claim, found := pq.claimsCache.Get(claimCacheKey); found {
 		logger.Debug().Msgf("claim cache HIT for claim with sessionId %q", sessionId)
+		return &claim, nil
+	}
+
+	// Use mutex to prevent multiple concurrent cache updates
+	pq.claimsMutex.Lock()
+	defer pq.claimsMutex.Unlock()
+
+	// Double-check cache after acquiring lock
+	if claim, found := pq.claimsCache.Get(claimCacheKey); found {
+		logger.Debug().Msgf("claim cache HIT for claim with sessionId %q after lock", sessionId)
 		return &claim, nil
 	}
 

--- a/pkg/client/query/querycache_test.go
+++ b/pkg/client/query/querycache_test.go
@@ -29,6 +29,7 @@ import (
 	servicetypes "github.com/pokt-network/poktroll/x/service/types"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+	suppliertypes "github.com/pokt-network/poktroll/x/supplier/types"
 )
 
 const numCalls = 4
@@ -505,6 +506,12 @@ func supplyCacheDeps(t *testing.T) depinject.Config {
 	claimsCache, err := memory.NewKeyValueCache[prooftypes.Claim](opts)
 	require.NoError(t, err)
 
+	supplierParamsCache, err := querycache.NewParamsCache[suppliertypes.Params](opts)
+	require.NoError(t, err)
+
+	serviceParamsCache, err := querycache.NewParamsCache[servicetypes.Params](opts)
+	require.NoError(t, err)
+
 	sharedParamsCache, err := querycache.NewParamsCache[sharedtypes.Params](opts)
 	require.NoError(t, err)
 
@@ -530,6 +537,8 @@ func supplyCacheDeps(t *testing.T) depinject.Config {
 		blockHashCache,
 		claimsCache,
 
+		serviceParamsCache,
+		supplierParamsCache,
 		sharedParamsCache,
 		appParamsCache,
 		sessionParamsCache,

--- a/pkg/relayer/cmd/cmd.go
+++ b/pkg/relayer/cmd/cmd.go
@@ -35,6 +35,7 @@ import (
 	servicetypes "github.com/pokt-network/poktroll/x/service/types"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+	suppliertypes "github.com/pokt-network/poktroll/x/supplier/types"
 )
 
 // TODO_CONSIDERATION: Consider moving all flags defined in `/pkg` to the cmd/flags package.
@@ -228,10 +229,12 @@ func setupRelayerDependencies(
 		// Setup the params caches and configure them to clear on new blocks.
 		// Some of the params (tokenomics and gateway) are not used in the RelayMiner
 		// and don't need to have a corresponding cache.
-		config.NewSupplyParamsCacheFn[sharedtypes.Params](cache.WithNewBlockCacheClearing),  // leaf
-		config.NewSupplyParamsCacheFn[apptypes.Params](cache.WithNewBlockCacheClearing),     // leaf
-		config.NewSupplyParamsCacheFn[sessiontypes.Params](cache.WithNewBlockCacheClearing), // leaf
-		config.NewSupplyParamsCacheFn[prooftypes.Params](cache.WithNewBlockCacheClearing),   // leaf
+		config.NewSupplyParamsCacheFn[sharedtypes.Params](cache.WithNewBlockCacheClearing),   // leaf
+		config.NewSupplyParamsCacheFn[apptypes.Params](cache.WithNewBlockCacheClearing),      // leaf
+		config.NewSupplyParamsCacheFn[sessiontypes.Params](cache.WithNewBlockCacheClearing),  // leaf
+		config.NewSupplyParamsCacheFn[prooftypes.Params](cache.WithNewBlockCacheClearing),    // leaf
+		config.NewSupplyParamsCacheFn[servicetypes.Params](cache.WithNewBlockCacheClearing),  // leaf
+		config.NewSupplyParamsCacheFn[suppliertypes.Params](cache.WithNewBlockCacheClearing), // leaf
 
 		// Setup the key-value caches for pocket types and configure them to clear on new blocks.
 		config.NewSupplyKeyValueCacheFn[sharedtypes.Service](cache.WithNewBlockCacheClearing),                // leaf

--- a/testutil/integration/suites/service.go
+++ b/testutil/integration/suites/service.go
@@ -52,6 +52,7 @@ func (s *ServiceModuleSuite) GetServiceQueryClient(t *testing.T) client.ServiceQ
 		polyzero.NewLogger(),
 		testcache.NewNoopKeyValueCache[sharedtypes.Service](),
 		testcache.NewNoopKeyValueCache[servicetypes.RelayMiningDifficulty](),
+		testcache.NewNoopParamsCache[servicetypes.Params](),
 	)
 	serviceClient, err := query.NewServiceQuerier(deps)
 	require.NoError(t, err)

--- a/testutil/integration/suites/supplier.go
+++ b/testutil/integration/suites/supplier.go
@@ -31,6 +31,7 @@ func (s *SupplierModuleSuite) GetSupplierQueryClient(t *testing.T) client.Suppli
 		s.GetApp().QueryHelper(),
 		polyzero.NewLogger(),
 		testcache.NewNoopKeyValueCache[sharedtypes.Supplier](),
+		testcache.NewNoopParamsCache[suppliertypes.Params](),
 	)
 	supplierQueryClient, err := query.NewSupplierQuerier(deps)
 	require.NoError(t, err)

--- a/testutil/testcache/mocks.go
+++ b/testutil/testcache/mocks.go
@@ -8,6 +8,12 @@ type MockKeyValueCache[T any] struct {
 	mock.Mock
 }
 
+// MockParamsCache is a mock implementation of the ParamsCache interface.
+// DEV_NOTE: Since gomock does not support generics, we're using testify/mock instead here.
+type MockParamsCache[T any] struct {
+	mock.Mock
+}
+
 func NewNoopKeyValueCache[T any]() *MockKeyValueCache[T] {
 	var zeroT T
 	cache := &MockKeyValueCache[T]{}
@@ -34,5 +40,30 @@ func (m *MockKeyValueCache[T]) Delete(key string) {
 }
 
 func (m *MockKeyValueCache[T]) Clear() {
+	m.Called()
+}
+
+func NewNoopParamsCache[T any]() *MockParamsCache[T] {
+	var zeroT T
+	cache := &MockParamsCache[T]{}
+	// Always simulate a cache miss.
+	cache.On("Get", mock.Anything).Return(zeroT, false)
+	cache.On("Set", mock.Anything, mock.Anything)
+	cache.On("Delete", mock.Anything)
+	cache.On("Clear")
+
+	return cache
+}
+
+func (m *MockParamsCache[T]) Get() (T, bool) {
+	args := m.Called()
+	return args.Get(0).(T), args.Bool(1)
+}
+
+func (m *MockParamsCache[T]) Set(value T) {
+	m.Called(value)
+}
+
+func (m *MockParamsCache[T]) Clear() {
 	m.Called()
 }


### PR DESCRIPTION
## Summary

Eliminate "thundering herd" problem in query caches by implementing double-check locking pattern

### Primary Changes:
- Add mutex protection to all querier caches to prevent race conditions
- Implement double-check locking pattern for cache access in all queriers
- Fix scenario where multiple goroutines simultaneously encounter cache misses

### Secondary changes:
- Add consistent debug logging for cache hits and misses
- Improve code comments to explain the double-check locking pattern

## Issue

- Description: The multiple cache misses are likely occurring because of a race condition in the different `QueryClient`s methods.

![image](https://github.com/user-attachments/assets/1e252066-323b-492f-b4d4-443a983dc9ff)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [x] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] For code covered by @oneshot E2E tests, `make test_e2e_oneshot` passes on localnet
- [ ] I added TODOs where applicable
