### PR TITLE
[Docs] Update StakeNodes' Shannon Explorer URLs

### DIFF
--- a/docusaurus/docs/tools/tools/shannon_alpha.md
+++ b/docusaurus/docs/tools/tools/shannon_alpha.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 ## Explorers
 
 - 🪙 [StakeNodes' Faucet](https://faucet.alpha.testnet.pokt.network/)
-- 🗺️ [StakeNodes' Explorer](https://explorer.pocket.network)
+- 🗺️ [StakeNodes' Explorer](https://explorer.pocket.network/pocket-alpha)
 - 🗺️ [Soothe's Explorer](https://shannon-alpha.trustsoothe.io/)
 - 👨‍💻 [Soothe's GraphQL Playground](https://shannon-alpha-api.trustsoothe.io/)
 

--- a/docusaurus/docs/tools/tools/shannon_alpha.md
+++ b/docusaurus/docs/tools/tools/shannon_alpha.md
@@ -5,8 +5,8 @@ sidebar_position: 3
 
 ## Explorers
 
-- 🪙 [StakeNode's Faucet](https://faucet.alpha.testnet.pokt.network/)
-- 🗺️ [StakeNode's Explorer](https://shannon.alpha.testnet.pokt.network)
+- 🪙 [StakeNodes' Faucet](https://faucet.alpha.testnet.pokt.network/)
+- 🗺️ [StakeNodes' Explorer](https://explorer.pocket.network)
 - 🗺️ [Soothe's Explorer](https://shannon-alpha.trustsoothe.io/)
 - 👨‍💻 [Soothe's GraphQL Playground](https://shannon-alpha-api.trustsoothe.io/)
 

--- a/docusaurus/docs/tools/tools/shannon_beta.md
+++ b/docusaurus/docs/tools/tools/shannon_beta.md
@@ -5,8 +5,8 @@ sidebar_position: 2
 
 ## Explorers
 
-- 🪙 [StakeNode's Faucet](https://faucet.beta.testnet.pokt.network/)
-- 🗺️ [StakeNode's Explorer](https://shannon.beta.testnet.pokt.network)
+- 🪙 [StakeNodes' Faucet](https://faucet.beta.testnet.pokt.network/)
+- 🗺️ [StakeNodes' Explorer](https://explorer.pocket.network/pocket-beta)
 - 🗺️ [Soothe's Explorer](https://shannon-beta.trustsoothe.io)
 - 👨‍💻 [Soothe's GraphQL Playground](https://shannon-beta-api.trustsoothe.io/)
 

--- a/docusaurus/docs/tools/tools/shannon_mainnet.md
+++ b/docusaurus/docs/tools/tools/shannon_mainnet.md
@@ -3,7 +3,7 @@ title: MainNet
 sidebar_position: 1
 ---
 
-- 🗺️ [TODO: StakeNode's Explorer](http://todo.com)
+- 🗺️ [TODO: StakeNodes' Explorer](https://explorer.pocket.network)
 - 🗺️ [Soothe's Explorer](https://shannon-mainnet.trustsoothe.io)
 - 👨‍💻 [Soothe's GraphQL Playground](https://shannon-mainnet-api.trustsoothe.io)
 


### PR DESCRIPTION
## Summary

Request from @Olshansk to update the Shannon documentation to reflect the new StakeNodes' [explorer](https://explorer.pocket.network) URL(s)


Changes:
- Replace StakeNodes' explorer url in `docusaurus/docs/tools/tools/shannon_alpha.md`
- Replace StakeNodes' explorer url in `docusaurus/docs/tools/tools/shannon_beta.md`
- Replace StakeNodes' explorer url in `docusaurus/docs/tools/tools/shannon_mainnet.md`

## Issue

- Description: N/A
- Issue: # N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [ ] Code health or cleanup
- [X] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] For code covered by @oneshot E2E tests, `make test_e2e_oneshot` passes on localnet
- [ ] I added TODOs where applicable
