### PR TITLE
[Code Health] chore: cleanup TODOs

### DIFF
--- a/x/migration/keeper/msg_server_claim_morse_account.go
+++ b/x/migration/keeper/msg_server_claim_morse_account.go
@@ -13,13 +13,12 @@ import (
 
 func (k msgServer) ClaimMorseAccount(ctx context.Context, msg *migrationtypes.MsgClaimMorseAccount) (*migrationtypes.MsgClaimMorseAccountResponse, error) {
 	sdkCtx := cosmostypes.UnwrapSDKContext(ctx)
+	waiveMorseClaimGasFees := k.GetParams(sdkCtx).WaiveMorseClaimGasFees
 
 	// Ensure that gas fees are NOT waived if one of the following is true:
 	// - The claim is invalid
 	// - Morse account has already been claimed
 	// Claiming gas fees in the cases above ensures that we prevent spamming.
-	//
-	// TODO_MAINNET_MIGRATION(@bryanchriswhite): Make this conditional once the WaiveMorseClaimGasFees param is available.
 	//
 	// Rationale:
 	// 1. Morse claim txs MAY be signed by Shannon accounts which have 0upokt balances.
@@ -38,7 +37,7 @@ func (k msgServer) ClaimMorseAccount(ctx context.Context, msg *migrationtypes.Ms
 		isFound, isValid, isAlreadyClaimed bool
 	)
 	defer func() {
-		if !isFound || !isValid || isAlreadyClaimed {
+		if waiveMorseClaimGasFees && (!isFound || !isValid || isAlreadyClaimed) {
 			// Attempt to charge the waived gas fee for invalid claims.
 			sdkCtx.GasMeter()
 			// DEV_NOTE: Assuming that the tx containing this message was signed

--- a/x/migration/keeper/msg_server_claim_morse_application.go
+++ b/x/migration/keeper/msg_server_claim_morse_application.go
@@ -24,13 +24,12 @@ import (
 func (k msgServer) ClaimMorseApplication(ctx context.Context, msg *migrationtypes.MsgClaimMorseApplication) (*migrationtypes.MsgClaimMorseApplicationResponse, error) {
 	sdkCtx := cosmostypes.UnwrapSDKContext(ctx)
 	logger := k.Logger().With("method", "ClaimMorseApplication")
+	waiveMorseClaimGasFees := k.GetParams(sdkCtx).WaiveMorseClaimGasFees
 
 	// Ensure that gas fees are NOT waived if one of the following is true:
 	// - The claim is invalid
 	// - Morse account has already been claimed
 	// Claiming gas fees in the cases above ensures that we prevent spamming.
-	//
-	// TODO_MAINNET_MIGRATION(@bryanchriswhite): Make this conditional once the WaiveMorseClaimGasFees param is available.
 	//
 	// Rationale:
 	// 1. Morse claim txs MAY be signed by Shannon accounts which have 0upokt balances.
@@ -49,7 +48,7 @@ func (k msgServer) ClaimMorseApplication(ctx context.Context, msg *migrationtype
 		isFound, isValid, isAlreadyClaimed bool
 	)
 	defer func() {
-		if !isFound || !isValid || isAlreadyClaimed {
+		if waiveMorseClaimGasFees && (!isFound || !isValid || isAlreadyClaimed) {
 			// Attempt to charge the waived gas fee for invalid claims.
 			sdkCtx.GasMeter()
 			// DEV_NOTE: Assuming that the tx containing this message was signed

--- a/x/migration/keeper/msg_server_claim_morse_supplier.go
+++ b/x/migration/keeper/msg_server_claim_morse_supplier.go
@@ -28,13 +28,12 @@ func (k msgServer) ClaimMorseSupplier(
 ) (*migrationtypes.MsgClaimMorseSupplierResponse, error) {
 	sdkCtx := cosmostypes.UnwrapSDKContext(ctx)
 	logger := k.Logger().With("method", "ClaimMorseSupplier")
+	waiveMorseClaimGasFees := k.GetParams(sdkCtx).WaiveMorseClaimGasFees
 
 	// Ensure that gas fees are NOT waived if one of the following is true:
 	// - The claim is invalid
 	// - Morse account has already been claimed
 	// Claiming gas fees in the cases above ensures that we prevent spamming.
-	//
-	// TODO_MAINNET_MIGRATION(@bryanchriswhite): Make this conditional once the WaiveMorseClaimGasFees param is available.
 	//
 	// Rationale:
 	// 1. Morse claim txs MAY be signed by Shannon accounts which have 0upokt balances.
@@ -53,7 +52,7 @@ func (k msgServer) ClaimMorseSupplier(
 		isFound, isValid, isAlreadyClaimed bool
 	)
 	defer func() {
-		if !isFound || !isValid || isAlreadyClaimed {
+		if waiveMorseClaimGasFees && (!isFound || !isValid || isAlreadyClaimed) {
 			// Attempt to charge the waived gas fee for invalid claims.
 			sdkCtx.GasMeter()
 			// DEV_NOTE: Assuming that the tx containing this message was signed

--- a/x/migration/module/autocli.go
+++ b/x/migration/module/autocli.go
@@ -6,9 +6,6 @@ import (
 	modulev1 "github.com/pokt-network/poktroll/api/pocket/migration"
 )
 
-// TODO_MAINNET(@bryanchriswhite, #1047): Make sure to document why the autocli is
-// not used for transactions requiring auth signatures.
-
 // AutoCLIOptions implements the autocli.HasAutoCLIConfig interface.
 func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 	return &autocliv1.ModuleOptions{
@@ -47,8 +44,7 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:            "import-morse-claimable-accounts [morse-account-state]",
 					Short:          "Send a import_morse_claimable_accounts tx",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "morseAccountState"}},
-					// TODO_MAINNET_CRITICAL(@bryanchriswhite, #1034): Implement CLI logic.
-					Skip: true, // skipped because authority gated
+					Skip:           true, // skipped because authority gated
 				},
 				{
 					RpcMethod:      "ClaimMorseAccount",
@@ -64,15 +60,13 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:          "Send a claim_morse_application tx",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "morseSrcAddress"}, {ProtoField: "morseSignature"}, {ProtoField: "stake"}, {ProtoField: "serviceConfig"}},
 					Skip:           true, // skipped because autoCLI cannot handle loading & signing using the Morse key.
-					// TODO_MAINNET_CRITICAL(@bryanchriswhite, #1034): Add morse application claiming CLI, incl. examples (see x/supplier/module/autocli.go).
 				},
 				{
 					RpcMethod:      "ClaimMorseSupplier",
 					Use:            "claim-morse-supplier [morse-src-address] [morse-signature] [stake] [service-config]",
 					Short:          "Send a claim_morse_supplier tx",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "morseSrcAddress"}, {ProtoField: "morseSignature"}, {ProtoField: "stake"}, {ProtoField: "serviceConfig"}},
-					Skip:           true, // skipped because autoCLI cannot handle signing
-					// TODO_MAINNET_CRITICAL(@bryanchriswhite, #1034): Add morse supplier claiming CLI, incl. examples (see x/supplier/module/autocli.go).
+					Skip:           true, // skipped because autoCLI cannot handle loading & signing using the Morse key.
 				},
 				// this line is used by ignite scaffolding # autocli/tx
 			},


### PR DESCRIPTION
## Summary

Cleaning up done and/or simple TODOs.

Changes:
- Remove done TODOs.
- Update the Morse claim message handlers' conditional re-application of the waived Morse claim tx fee to consider whether fee waiving is enabled.

## Issue

N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] For code covered by @oneshot E2E tests, `make test_e2e_oneshot` passes on localnet
- [ ] I added TODOs where applicable
