### PR TITLE
Bump shannon-sdk dependency: SHA efd370a75d51

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	// This is creating a circular dependency whereby exporting the protobufs into a separate
 	// repo is the first obvious idea, but has to be carefully considered, automated, and is not
 	// a hard blocker.
-	github.com/pokt-network/shannon-sdk v0.0.0-20250328031800-20e08e50fe82
+	github.com/pokt-network/shannon-sdk v0.0.0-20250417224837-efd370a75d51
 	github.com/pokt-network/smt v0.13.0
 	github.com/pokt-network/smt/kvstore/pebble v0.0.0-20240822175047-21ea8639c188
 	github.com/prometheus/client_golang v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -1021,8 +1021,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pokt-network/ring-go v0.1.0 h1:hF7mDR4VVCIqqDAsrloP8azM9y1mprc99YgnTjKSSwk=
 github.com/pokt-network/ring-go v0.1.0/go.mod h1:8NHPH7H3EwrPX3XHfpyRI6bz4gApkE3+fd0XZRbMWP0=
-github.com/pokt-network/shannon-sdk v0.0.0-20250328031800-20e08e50fe82 h1:U1G0OQBBNm/pjyrcfO2dGT79GbGc1VwEFDm2C0AEb1E=
-github.com/pokt-network/shannon-sdk v0.0.0-20250328031800-20e08e50fe82/go.mod h1:hLRmAUnO/iZ8x3oHoQz1oohVMvjx8K31HFAGLoe2mck=
+github.com/pokt-network/shannon-sdk v0.0.0-20250417224837-efd370a75d51 h1:f5jEnHptz+I1JZ4rj3+prxZd8iIbIh2c6Q9MWsah/Nw=
+github.com/pokt-network/shannon-sdk v0.0.0-20250417224837-efd370a75d51/go.mod h1:hLRmAUnO/iZ8x3oHoQz1oohVMvjx8K31HFAGLoe2mck=
 github.com/pokt-network/smt v0.13.0 h1:C2F8FlJh34aU+DVeRU/Bt8BOkFXn4QjWMK+nbT9PUj4=
 github.com/pokt-network/smt v0.13.0/go.mod h1:S4Ho4OPkK2v2vUCHNtA49XDjqUC/OFYpBbynRVYmxvA=
 github.com/pokt-network/smt/kvstore/pebble v0.0.0-20240822175047-21ea8639c188 h1:QK1WmFKQ/OzNVob/br55Brh+EFbWhcdq41WGC8UMihM=


### PR DESCRIPTION
## Summary

Bump Shannon-SDK dependency to the latest commit as of the time of opening this PR: https://github.com/pokt-network/shannon-sdk/commit/efd370a75d51df047aab5bf8aeb717cd0598e34a

Changes:
- Update go.mod and go.sum with the new shannon-sdk SHA.

## Issue

- Description: Stay up to date with the Shannon-sdk repo.
- Issue: #{ISSUE_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] For code covered by @oneshot E2E tests, `make test_e2e_oneshot` passes on localnet
- [ ] I added TODOs where applicable
