### PR TITLE
[Upgrade] Transactions for v0.1.5

### DIFF
--- a/docusaurus/docs/operate/upgrades/2_release_procedure.md
+++ b/docusaurus/docs/operate/upgrades/2_release_procedure.md
@@ -373,7 +373,7 @@ See [pocketd CLI docs](../../tools/user_guide/pocketd_cli.md) for more info.
 Repeat [Step 7: Submit the Upgrade Onchain](#7-submit-the-upgrade-on-alpha-testnet) with the appropriate parameters for Beta and MainNet:
 
 - Use the correct `<RPC_ENDPOINT>` for Beta or MainNet
-- Use the correct `NETWORK`, (`pocket-beta` for Beta or `pocket` for MainNet)
+- Use the correct `<NETWORK>`, (`pocket-beta` for Beta or `pocket` for MainNet)
 - Use the correct `<UPGRADE_TX_JSON>` (e.g., `upgrade_tx_v0.1.2_beta.json` or `upgrade_tx_v0.1.2_main.json`)
 - Use the correct sender account for each network
 

--- a/docusaurus/docs/operate/upgrades/2_release_procedure.md
+++ b/docusaurus/docs/operate/upgrades/2_release_procedure.md
@@ -264,6 +264,17 @@ This step is parameterized so you can use it for any network (Alpha, Beta, or Ma
 1. Get the RPC endpoint for `NETWORK`. Example for Alpha [here](https://dev.poktroll.com/tools/tools/shannon_alpha).
 2. Update the `height` in your upgrade transaction JSON ():
 
+   :::tip Export `UPGRADE_TX_JSON`, `RPC_ENDPOINT`, `NETWORK`, and `FROM_ACCOUNT`
+
+   ```bash
+   export RPC_ENDPOINT=https://shannon-testnet-grove-rpc.alpha.poktroll.com
+   export UPGRADE_TX_JSON="tools/scripts/upgrades/upgrade_tx_v0.1.2_alpha.json"
+   export NETWORK=pocket-alpha
+   export FROM_ACCOUNT=pnf_alpha
+   ```
+
+   :::
+
    ```bash
    # Get the current height
    CURRENT_HEIGHT=$(pocketd status --node ${RPC_ENDPOINT} | jq '.sync_info.latest_block_height' | tr -d '"')
@@ -274,15 +285,6 @@ This step is parameterized so you can use it for any network (Alpha, Beta, or Ma
    # Cat the output file
    cat ${UPGRADE_TX_JSON}
    ```
-
-   :::tip Export `UPGRADE_TX_JSON` and `RPC_ENDPOINT` first
-
-   ```bash
-   export RPC_ENDPOINT=https://shannon-testnet-grove-rpc.alpha.poktroll.com
-   export UPGRADE_TX_JSON="tools/scripts/upgrades/upgrade_tx_v0.1.4_alpha.json"
-   ```
-
-   :::
 
 3. Submit the transaction:
 
@@ -331,7 +333,7 @@ This step is parameterized so you can use it for any network (Alpha, Beta, or Ma
 
 :::
 
-**⚠️ DO NOT PROCEED until the changes from step (2) are merged assuming the upgrade suceeded⚠️**
+**⚠️ DO NOT PROCEED until the changes from step (2) are merged assuming the upgrade succeeded ⚠️**
 
 ---
 
@@ -371,12 +373,13 @@ See [pocketd CLI docs](../../tools/user_guide/pocketd_cli.md) for more info.
 Repeat [Step 7: Submit the Upgrade Onchain](#7-submit-the-upgrade-on-alpha-testnet) with the appropriate parameters for Beta and MainNet:
 
 - Use the correct `<RPC_ENDPOINT>` for Beta or MainNet
+- Use the correct `NETWORK`, (`pocket-beta` for Beta or `pocket` for MainNet)
 - Use the correct `<UPGRADE_TX_JSON>` (e.g., `upgrade_tx_v0.1.2_beta.json` or `upgrade_tx_v0.1.2_main.json`)
 - Use the correct sender account for each network
 
 This ensures a single, copy-pasta-friendly process for all networks.
 
-**⚠️ DO NOT PROCEED until the changes from step (2) are merged assuming the upgrade succeeded⚠️**
+**⚠️ DO NOT PROCEED until the changes from step (2) are merged assuming the upgrade succeeded ⚠️**
 
 :::tip Grove Employees 🌿
 

--- a/tools/scripts/upgrades/upgrade_tx_v0.1.5_alpha.json
+++ b/tools/scripts/upgrades/upgrade_tx_v0.1.5_alpha.json
@@ -1,0 +1,15 @@
+{
+  "body": {
+    "messages": [
+      {
+        "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+        "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+        "plan": {
+          "name": "v0.1.5",
+          "height": "31597",
+          "info": "{\"binaries\":{\"linux/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_linux_amd64.tar.gz\",\"linux/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_linux_arm64.tar.gz\",\"darwin/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_darwin_amd64.tar.gz\",\"darwin/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_darwin_arm64.tar.gz\"}}"
+        }
+      }
+    ]
+  }
+}

--- a/tools/scripts/upgrades/upgrade_tx_v0.1.5_beta.json
+++ b/tools/scripts/upgrades/upgrade_tx_v0.1.5_beta.json
@@ -1,0 +1,15 @@
+{
+  "body": {
+    "messages": [
+      {
+        "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+        "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+        "plan": {
+          "name": "v0.1.5",
+          "height": "5831",
+          "info": "{\"binaries\":{\"linux/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_linux_amd64.tar.gz?checksum=sha256:8f7126f429565931cf2d3cf32489bdd0fd9f4141bd7f3fedd330e4edabef1b9f\",\"linux/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_linux_arm64.tar.gz?checksum=sha256:69060fa8b5c8e80fc7ce11a9180691da56764a50e1b132f3b59ec13cc5520b9d\",\"darwin/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_darwin_amd64.tar.gz?checksum=sha256:fdd7aecc86e41dcfcbe82bfb0c0234a092b239d5a68b08edb215a2af961cf2f4\",\"darwin/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_darwin_arm64.tar.gz?checksum=sha256:333912c080dce8824c3eeb301320a2860f1ec7fb149977bc4472de3d7b08a272\"}}"
+        }
+      }
+    ]
+  }
+}

--- a/tools/scripts/upgrades/upgrade_tx_v0.1.5_local.json
+++ b/tools/scripts/upgrades/upgrade_tx_v0.1.5_local.json
@@ -1,0 +1,15 @@
+{
+  "body": {
+    "messages": [
+      {
+        "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+        "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+        "plan": {
+          "name": "v0.1.5",
+          "height": "UPDATE_ME",
+          "info": "{\"binaries\":{\"linux/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_linux_amd64.tar.gz\",\"linux/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_linux_arm64.tar.gz\",\"darwin/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_darwin_amd64.tar.gz\",\"darwin/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_darwin_arm64.tar.gz\"}}"
+        }
+      }
+    ]
+  }
+}

--- a/tools/scripts/upgrades/upgrade_tx_v0.1.5_main.json
+++ b/tools/scripts/upgrades/upgrade_tx_v0.1.5_main.json
@@ -1,0 +1,15 @@
+{
+  "body": {
+    "messages": [
+      {
+        "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+        "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+        "plan": {
+          "name": "v0.1.5",
+          "height": "UPDATE_ME",
+          "info": "{\"binaries\":{\"linux/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_linux_amd64.tar.gz?checksum=sha256:8f7126f429565931cf2d3cf32489bdd0fd9f4141bd7f3fedd330e4edabef1b9f\",\"linux/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_linux_arm64.tar.gz?checksum=sha256:69060fa8b5c8e80fc7ce11a9180691da56764a50e1b132f3b59ec13cc5520b9d\",\"darwin/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_darwin_amd64.tar.gz?checksum=sha256:fdd7aecc86e41dcfcbe82bfb0c0234a092b239d5a68b08edb215a2af961cf2f4\",\"darwin/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.5/pocket_darwin_arm64.tar.gz?checksum=sha256:333912c080dce8824c3eeb301320a2860f1ec7fb149977bc4472de3d7b08a272\"}}"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Create upgrade transactions for the `v0.1.5` upgrade using the following:
"./tools/scripts/upgrades/prepare_upgrade_tx.sh v0.1.5"

Minor documentation improvements