### PR TITLE
[Bug] Fix supplier service config history pruning

### DIFF
--- a/x/supplier/keeper/prune_supplier_service_config_history.go
+++ b/x/supplier/keeper/prune_supplier_service_config_history.go
@@ -38,6 +38,14 @@ func (k Keeper) EndBlockerPruneSupplierServiceConfigHistory(
 		// Store the original number of historical service configs.
 		originalHistoryLength := len(supplier.ServiceConfigHistory)
 
+		// If there is only one service config update, it is the most recent one.
+		// In this case, we don't need to prune anything.
+		// Not skipping this case would lead to the supplier being systematically
+		// marshalled and saved to the store, even if no changes were made.
+		if originalHistoryLength == 1 {
+			continue
+		}
+
 		// Initialize a slice to retain service config updates that are still needed
 		// for pending claims settlement.
 		retainedServiceConfigs := make([]*sharedtypes.ServiceConfigUpdate, 0)


### PR DESCRIPTION
## Summary

Optimize the supplier service config history pruning process by skipping suppliers with only one config entry.

### Primary Changes:
- Add early `continue` when supplier has only one service config update
- Prevent unnecessary marshalling and store writes when no pruning would occur
- Reduce state bloat and improve performance during end block processing

## Issue

![image](https://github.com/user-attachments/assets/c3f6746d-365f-4fb2-aad2-3be6bcb7d1a5)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Consensus breaking; add the `consensus-breaking` label if so. See #791 for details
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [x] For code, I have run `make go_develop_and_test` and `make test_e2e`
- [ ] For code, I have added the `devnet-test-e2e` label to run E2E tests in CI
- [ ] For configurations, I have update the documentation
- [ ] For code covered by @oneshot E2E tests, `make test_e2e_oneshot` passes on localnet
- [ ] I added TODOs where applicable
