### PR TITLE
[Upgrade] v0.1.6 upgrade handler to reduce memory footprint for Supplier config pruning

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -39,7 +39,10 @@ var allUpgrades = []upgrades.Upgrade{
 	// upgrades.Upgrade_0_1_4,
 
 	// v0.1.5 - upgrade to reduce memory footprint when iterating over Suppliers and Applications.
-	upgrades.Upgrade_0_1_5,
+	// upgrades.Upgrade_0_1_5,
+
+	// v0.1.6 - upgrade to reduce the memory by avoiding unnecessary marshaling of the supplier object when iterating over the suppliers.
+	upgrades.Upgrade_0_1_6,
 }
 
 // setUpgrades sets upgrade handlers for all upgrades and executes KVStore migration if an upgrade plan file exists.

--- a/app/upgrades/v0.1.6.go
+++ b/app/upgrades/v0.1.6.go
@@ -1,0 +1,20 @@
+package upgrades
+
+import (
+	storetypes "cosmossdk.io/store/types"
+)
+
+const Upgrade_0_1_6_PlanName = "v0.1.6"
+
+// Upgrade_0_1_6 handles the upgrade to release `v0.1.6`.
+// This is planned to be issued on both Pocket Network's Shannon Alpha, Beta TestNets as well as MainNet.
+// It is an upgrade intended to reduce the memory by avoiding unnecessary marshaling of the supplier object
+// when iterating over the suppliers.
+// https://github.com/pokt-network/poktroll/compare/v0.1.5..c7ab386
+var Upgrade_0_1_6 = Upgrade{
+	PlanName: Upgrade_0_1_6_PlanName,
+	// No state or consensus-breaking changes in this upgrade.
+	CreateUpgradeHandler: defaultUpgradeHandler,
+	// No migrations in this upgrade.
+	StoreUpgrades: storetypes.StoreUpgrades{},
+}


### PR DESCRIPTION
## Summary

This PR adds the v0.1.6 upgrade, which aims to reduce the memory footprint of the Supplier config history pruning which always marshals and saves all Suppliers.

### Primary changes
* Added a new upgrade handler for v0.1.6
* Added the v0.1.6 upgrade to the allUpgrades list
