### PR TITLE
[IBC] localnet: add Agoric chart

### DIFF
--- a/localnet/agoric/.helmignore
+++ b/localnet/agoric/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/localnet/agoric/Chart.yaml
+++ b/localnet/agoric/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: agoric-chain
+description: Agoric chain node
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/localnet/agoric/templates/agoric-configmap.yaml
+++ b/localnet/agoric/templates/agoric-configmap.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-scripts
+  namespace: {{ .Release.Namespace }}
+data:
+  foreigner.mnemonic: |
+    {{ .Values.mnemonic }}
+
+  entrypoint.sh: |
+    #!/bin/bash
+    set -e
+
+    # Import the "foreigner" key from the mnemonic
+    cat /usr/src/upgrade-test-scripts/foreigner.mnemonic | agd keys add foreigner --keyring-backend=test --hd-path="m/44'/118'/0'/0/0" --recover
+
+    . /usr/src/upgrade-test-scripts/env_setup.sh
+
+    if [ -n "$DELVE_PORT" ]; then
+      # TODO_IMPROVE: figure out how to get delve/gdb to not lose the source hook.
+      #echo "Starting delve debug agd in foreground"
+      #/usr/src/upgrade-test-scripts/start_agd_delve.sh
+      echo "🚨 Remote debugging not yet supported 🚨\n🚧Use: 'make agd_shell', then './start_agd_debug.sh' to debug locally!🚧"
+      sleep infinity
+    else
+      echo "Starting agd in foreground"
+      /usr/src/upgrade-test-scripts/start_agd.sh
+    fi
+
+  # DEV_NOTE: This is not currently used, as it does not yet work. 😅
+  # TODO_IMPROVE: figure out how to get delve/gdb to not lose the source hook.
+  # See:
+  # - https://discord.com/channels/585576150827532298/1366728719141441598/1366789646230622289
+  # - https://github.com/Agoric/agoric-sdk/pull/8002
+  start_agd_debug.sh: |
+    #!/bin/bash
+    set -e
+
+    # Import the "foreigner" key from the mnemonic
+    cat /usr/src/upgrade-test-scripts/foreigner.mnemonic | agd keys add foreigner --keyring-backend=test --hd-path="m/44'/118'/0'/0/0" --recover
+
+    #. /usr/src/upgrade-test-scripts/env_setup.sh
+    . /root/.bashrc
+
+    # start_agd never builds an image so it's safe to include this multigigabyte logfile
+    export SLOGFILE=slog.slog
+
+    echo "Starting agd debugger in foreground"
+
+    # Remote delve
+    #dlv exec --headless --accept-multiclient --api-version=2 --listen=:$DELVE_PORT $(which agd) -- start --log_level warn "$@"
+
+    # Local delve (use make `agd_shell`, then `./entrypoint.sh`)
+    #dlv exec $(which agd) -- start --log_level warn "$@"
+
+    # Remote gdb
+    #gdbserver agd start --log_level warn "$@"
+
+    # Local gdb
+    #gdb --args agd start --log_level warn "$@"

--- a/localnet/agoric/templates/agoric-deployment.yaml
+++ b/localnet/agoric/templates/agoric-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: agd
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            {{- range $_, $port := .Values.service.ports }}
+            - containerPort: {{ $port }}
+            {{- end }}
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+          command: {{- toYaml .Values.command | nindent 12 }}
+          volumeMounts:
+            - name: agoric-scripts-volume
+              mountPath: /usr/src/upgrade-test-scripts/entrypoint.sh
+              subPath: entrypoint.sh
+              readOnly: true
+            - name: agoric-scripts-volume
+              mountPath: /usr/src/upgrade-test-scripts/start_agd_delve.sh
+              subPath: start_agd_delve.sh
+              readOnly: true
+            - name: agoric-scripts-volume
+              mountPath: /usr/src/upgrade-test-scripts/foreigner.mnemonic
+              subPath: foreigner.mnemonic
+              readOnly: true
+      volumes:
+        - name: agoric-scripts-volume
+          configMap:
+            name: {{ .Release.Name }}-scripts
+            defaultMode: 0755
+

--- a/localnet/agoric/templates/agoric-service.yaml
+++ b/localnet/agoric/templates/agoric-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ .Release.Name }}
+  ports:
+    {{- range $name, $port := .Values.service.ports }}
+    - name: {{ $name }}
+      port: {{ $port }}
+      targetPort: {{ $port }}
+    {{- end }}

--- a/localnet/kubernetes/values-agoric.yaml
+++ b/localnet/kubernetes/values-agoric.yaml
@@ -1,0 +1,24 @@
+image:
+  repository: agoric
+  tag: latest
+  pullPolicy: Never
+
+mnemonic: "beach prize number regular tiger aware ring shiver path dizzy please bacon steel car crash youth rural history furnace possible property chicken entire system"
+
+service:
+  type: ClusterIP
+  ports:
+    p2p: 26656
+    rpc: 26657
+    rest: 1317
+    grpc: 9090
+
+env:
+  DEST: "1"
+  DEBUG: "SwingSet:ls,SwingSet:vat"
+
+  # Uncomment to enable delve debugging
+  # DELVE_PORT: "40009"
+
+command:
+  - /usr/src/upgrade-test-scripts/entrypoint.sh


### PR DESCRIPTION
## Summary

Adds a chart for a localnet [Agoric chain node](https://docs.agoric.com/) for exercising IBC connectivity

```
Pocket cosmos-sdk: v0.50.x
Pocket ibc-go: v8.7.0
Agoric cosmos-sdk: v0.46.x (fork)
Agoric ibc-go: v0.6.x (fork)
```


## Issue

- #1201 

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
