### PR TITLE
[Localnet] add host-proxy localnet chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,3 +409,4 @@ include ./makefiles/migrate.mk
 include ./makefiles/claudesync.mk
 include ./makefiles/docs.mk
 include ./makefiles/release.mk
+include ./makefiles/ibc.mk

--- a/Tiltfile
+++ b/Tiltfile
@@ -89,6 +89,13 @@ localnet_config_defaults = {
         "enabled": False,
         "clone_if_not_present": False,
     },
+
+    "ibc": {
+        "enabled": False,
+        "relay_pairs_enabled": {
+            "pocket-agoric": False,
+        }
+    }
 }
 
 # Initial empty config
@@ -510,3 +517,7 @@ load("./tiltfiles/pocketdex.tilt", "check_and_load_pocketdex")
 #   -- OR --
 #   2. Prints a message if true or false
 check_and_load_pocketdex(localnet_config["indexer"])
+
+### IBC relayer(s) & alt-chain node(s)
+load("./tiltfiles/ibc.tilt", "check_and_load_ibc")
+check_and_load_ibc(localnet_config["ibc"])

--- a/app/upgrades/v0.1.9.go
+++ b/app/upgrades/v0.1.9.go
@@ -1,0 +1,129 @@
+package upgrades
+
+import (
+	"context"
+	"time"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	icacontrollertypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/types"
+	icahosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
+	ibcclienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+	connectiontypes "github.com/cosmos/ibc-go/v8/modules/core/03-connection/types"
+	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
+
+	"github.com/pokt-network/poktroll/app/keepers"
+)
+
+const (
+	Upgrade_0_1_9_PlanName = "v0.1.9"
+)
+
+var (
+	// TODO_IN_THIS_COMMIT: this is a funciton of block time, which is per network!
+	IbcConnectionParamMasExpectedTimePerBlock   = uint64((15 * time.Minute).Nanoseconds())
+	IbcChannelParamUpgradeTimeoutRevisionNumber = uint64(0)
+	IbcChannelParamUpgradeTimeoutRevisionHeight = uint64(0)
+	IbcChannelParamUpgradeTimeoutTimestamp      = uint64(0)
+	IbcClientParamAllowedClients                = []string{"07-tendermint"}
+
+	IbcTransferParamSendEnabled    = true
+	IbcTransferParamReceiveEnabled = true
+
+	// Enable both ICA host and controller.
+	IbcIcaHostParamHostEnabled             = true
+	IbcIcaControllerParamControllerEnabled = true
+
+	// Allow all messages to be executed via interchain accounts.
+	IbcIcaHostParamAllowMessages = []string{"*"}
+)
+
+// Upgrade_0_1_9 handles the upgrade to release `v0.1.9`.
+// This is planned to be issued on both Pocket Network's Shannon Alpha, Beta TestNets as well as MainNet.
+// It is an upgrade intended to reduce the memory footprint when iterating over Suppliers and Applications.
+// https://github.com/pokt-network/poktroll/compare/v0.1.6..99c393
+var Upgrade_0_1_9 = Upgrade{
+	PlanName: Upgrade_0_1_9_PlanName,
+	// No migrations in this upgrade.
+	StoreUpgrades: storetypes.StoreUpgrades{},
+
+	// Upgrade Handler
+	CreateUpgradeHandler: func(
+		mm *module.Manager,
+		keepers *keepers.Keepers,
+		configurator module.Configurator,
+	) upgradetypes.UpgradeHandler {
+		ibcConnectionParams := connectiontypes.Params{
+			MaxExpectedTimePerBlock: IbcConnectionParamMasExpectedTimePerBlock,
+		}
+
+		ibcChannelParams := channeltypes.Params{
+			UpgradeTimeout: channeltypes.Timeout{
+				Height: ibcclienttypes.Height{
+					RevisionNumber: IbcChannelParamUpgradeTimeoutRevisionNumber,
+					RevisionHeight: IbcChannelParamUpgradeTimeoutRevisionHeight,
+				},
+				Timestamp: IbcChannelParamUpgradeTimeoutTimestamp,
+			},
+		}
+
+		ibcClientParams := ibcclienttypes.Params{
+			AllowedClients: IbcClientParamAllowedClients,
+		}
+
+		ibcTransferParams := ibctransfertypes.Params{
+			SendEnabled:    IbcTransferParamSendEnabled,
+			ReceiveEnabled: IbcTransferParamReceiveEnabled,
+		}
+
+		ibcIcaHostParams := icahosttypes.Params{
+			HostEnabled:   IbcIcaHostParamHostEnabled,
+			AllowMessages: IbcIcaHostParamAllowMessages,
+		}
+
+		ibcIcaControllerParams := icacontrollertypes.Params{
+			ControllerEnabled: IbcIcaControllerParamControllerEnabled,
+		}
+
+		populateIBCParams := func(ctx context.Context) (err error) {
+			sdkCtx := cosmostypes.UnwrapSDKContext(ctx)
+
+			// IBC core
+			keepers.IBCKeeper.ConnectionKeeper.SetParams(sdkCtx, ibcConnectionParams)
+			keepers.IBCKeeper.ChannelKeeper.SetParams(sdkCtx, ibcChannelParams)
+			keepers.IBCKeeper.ClientKeeper.SetParams(sdkCtx, ibcClientParams)
+
+			// IBC transfer
+			keepers.TransferKeeper.SetParams(sdkCtx, ibcTransferParams)
+
+			// IBC interchain accounts host & controller
+			keepers.ICAHostKeeper.SetParams(sdkCtx, ibcIcaHostParams)
+			keepers.ICAControllerKeeper.SetParams(sdkCtx, ibcIcaControllerParams)
+
+			return nil
+		}
+
+		bindIcaHostPort := func(ctx context.Context) (err error) {
+			sdkCtx := cosmostypes.UnwrapSDKContext(ctx)
+			if !keepers.IBCKeeper.PortKeeper.IsBound(sdkCtx, icahosttypes.SubModuleName) {
+				_ = keepers.IBCKeeper.PortKeeper.BindPort(sdkCtx, icahosttypes.SubModuleName)
+			}
+			return nil
+		}
+
+		return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+			if err := populateIBCParams(ctx); err != nil {
+				return vm, err
+			}
+
+			if err := bindIcaHostPort(ctx); err != nil {
+				return vm, err
+			}
+
+			return vm, nil
+		}
+	},
+}

--- a/config.yml
+++ b/config.yml
@@ -217,6 +217,19 @@ genesis:
       params:
         send_enabled: true
         receive_enabled: true
+    # For ref, see https://github.com/cosmos/ibc-go/blob/v8.7.0/proto/ibc/applications/interchain_accounts/genesis/v1/genesis.proto#L12
+    interchainaccounts:
+      controller_genesis_state:
+        # For ref, see https://github.com/cosmos/ibc-go/blob/v8.7.0/proto/ibc/applications/interchain_accounts/controller/v1/controller.proto#L9
+        params:
+          controller_enabled: true
+      host_genesis_state:
+        port: icahost
+        # For ref, https://github.com/cosmos/ibc-go/blob/v8.7.0/proto/ibc/applications/interchain_accounts/host/v1/host.proto#L9
+        params:
+          host_enabled: true
+          allow_messages:
+            - "*"
     # For ref, see proto/poktroll/application/params.proto
     application:
       params:

--- a/config.yml
+++ b/config.yml
@@ -188,6 +188,35 @@ genesis:
           coins:
             - amount: "1000000000" # MUST BE equal to one add_service_fee below
               denom: upokt
+    # For ref, see https://github.com/cosmos/ibc-go/blob/v8.7.0/proto/ibc/core/types/v1/genesis.proto#L13
+    ibc:
+      # - https://github.com/cosmos/ibc-go/blob/bd79edf6749398e36fb367730b7e20da5c563806/proto/ibc/core/client/v1/client.proto#L61
+      client_genesis:
+        params:
+          allowed_clients:
+            - 07-tendermint
+      # - https://github.com/cosmos/ibc-go/blob/v8.7.0/proto/ibc/core/connection/v1/connection.proto#L109
+      connection_genesis:
+        params:
+          # TODO_IN_THIS_COMMIT: revisit this!
+          max_expected_time_per_block: 10000000000
+      # - https://github.com/cosmos/ibc-go/blob/v8.7.0/proto/ibc/core/channel/v1/channel.proto#L184
+      channel_genesis:
+        params:
+          upgrade_timeout:
+            # TODO_IN_THIS_COMMIT: revisit this!
+            height:
+              revision_number: 0
+              revision_height: 0
+            timestamp: 10000000000
+    # For ref, see https://github.com/cosmos/ibc-go/blob/v8.7.0/proto/ibc/applications/transfer/v1/genesis.proto#L12
+    # and https://github.com/cosmos/ibc-go/blob/v8.7.0/proto/ibc/applications/transfer/v1/transfer.proto#L21
+    transfer:
+      port_id: transfer
+      denom_traces: [ ]
+      params:
+        send_enabled: true
+        receive_enabled: true
     # For ref, see proto/poktroll/application/params.proto
     application:
       params:

--- a/localnet/agoric/.helmignore
+++ b/localnet/agoric/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/localnet/agoric/Chart.yaml
+++ b/localnet/agoric/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: agoric-chain
+description: Agoric chain node
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/localnet/agoric/templates/agoric-configmap.yaml
+++ b/localnet/agoric/templates/agoric-configmap.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-scripts
+  namespace: {{ .Release.Namespace }}
+data:
+  foreigner.mnemonic: |
+    {{ .Values.mnemonic }}
+
+  entrypoint.sh: |
+    #!/bin/bash
+    set -e
+
+    # Import the "foreigner" key from the mnemonic
+    cat /usr/src/upgrade-test-scripts/foreigner.mnemonic | agd keys add foreigner --keyring-backend=test --hd-path="m/44'/118'/0'/0/0" --recover
+
+    . /usr/src/upgrade-test-scripts/env_setup.sh
+
+    if [ -n "$DELVE_PORT" ]; then
+      # TODO_IMPROVE: figure out how to get delve/gdb to not lose the source hook.
+      #echo "Starting delve debug agd in foreground"
+      #/usr/src/upgrade-test-scripts/start_agd_delve.sh
+      echo "🚨 Remote debugging not yet supported 🚨\n🚧Use: 'make agd_shell', then './start_agd_debug.sh' to debug locally!🚧"
+      sleep infinity
+    else
+      echo "Starting agd in foreground"
+      /usr/src/upgrade-test-scripts/start_agd.sh
+    fi
+
+  # DEV_NOTE: This is not currently used, as it does not yet work. 😅
+  # TODO_IMPROVE: figure out how to get delve/gdb to not lose the source hook.
+  # See:
+  # - https://discord.com/channels/585576150827532298/1366728719141441598/1366789646230622289
+  # - https://github.com/Agoric/agoric-sdk/pull/8002
+  start_agd_debug.sh: |
+    #!/bin/bash
+    set -e
+
+    # Import the "foreigner" key from the mnemonic
+    cat /usr/src/upgrade-test-scripts/foreigner.mnemonic | agd keys add foreigner --keyring-backend=test --hd-path="m/44'/118'/0'/0/0" --recover
+
+    #. /usr/src/upgrade-test-scripts/env_setup.sh
+    . /root/.bashrc
+
+    # start_agd never builds an image so it's safe to include this multigigabyte logfile
+    export SLOGFILE=slog.slog
+
+    echo "Starting agd debugger in foreground"
+
+    # Remote delve
+    #dlv exec --headless --accept-multiclient --api-version=2 --listen=:$DELVE_PORT $(which agd) -- start --log_level warn "$@"
+
+    # Local delve (use make `agd_shell`, then `./entrypoint.sh`)
+    #dlv exec $(which agd) -- start --log_level warn "$@"
+
+    # Remote gdb
+    #gdbserver agd start --log_level warn "$@"
+
+    # Local gdb
+    #gdb --args agd start --log_level warn "$@"

--- a/localnet/agoric/templates/agoric-deployment.yaml
+++ b/localnet/agoric/templates/agoric-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: agd
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            {{- range $_, $port := .Values.service.ports }}
+            - containerPort: {{ $port }}
+            {{- end }}
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+          command: {{- toYaml .Values.command | nindent 12 }}
+          volumeMounts:
+            - name: agoric-scripts-volume
+              mountPath: /usr/src/upgrade-test-scripts/entrypoint.sh
+              subPath: entrypoint.sh
+              readOnly: true
+            - name: agoric-scripts-volume
+              mountPath: /usr/src/upgrade-test-scripts/start_agd_delve.sh
+              subPath: start_agd_delve.sh
+              readOnly: true
+            - name: agoric-scripts-volume
+              mountPath: /usr/src/upgrade-test-scripts/foreigner.mnemonic
+              subPath: foreigner.mnemonic
+              readOnly: true
+      volumes:
+        - name: agoric-scripts-volume
+          configMap:
+            name: {{ .Release.Name }}-scripts
+            defaultMode: 0755
+

--- a/localnet/agoric/templates/agoric-service.yaml
+++ b/localnet/agoric/templates/agoric-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ .Release.Name }}
+  ports:
+    {{- range $name, $port := .Values.service.ports }}
+    - name: {{ $name }}
+      port: {{ $port }}
+      targetPort: {{ $port }}
+    {{- end }}

--- a/localnet/host-proxy/.helmignore
+++ b/localnet/host-proxy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/localnet/host-proxy/Chart.yaml
+++ b/localnet/host-proxy/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: host-proxy
+description: A Helm chart for a proxy service to allow kubernetes resources to connect host-bound services
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/localnet/host-proxy/templates/_helpers.tpl
+++ b/localnet/host-proxy/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "host-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "host-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "host-proxy.labels" -}}
+helm.sh/chart: {{ include "host-proxy.chart" . }}
+{{ include "host-proxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "host-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "host-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/localnet/host-proxy/templates/configmap.yaml
+++ b/localnet/host-proxy/templates/configmap.yaml
@@ -1,0 +1,95 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-proxy-script
+  labels:
+    app: host-proxy
+data:
+  proxy.sh: |
+    #!/bin/sh
+    set -e
+
+    echo "Starting socat tunnels to host for reverse proxy..."
+
+    HOST_IP=""
+    echo "Trying to determine host IP..."
+
+    # Method 0: Host IP from environment
+    if [ ! -z "$HOST_IP" ]; then
+      echo "Using host IP from environment: $HOST_IP"
+    fi
+
+    # Method 1: host.docker.internal
+    if [ -z "$HOST_IP" ]; then
+      echo "Method 1: Trying host.docker.internal..."
+      HOST_IP=$(getent hosts host.docker.internal | awk '{ print $1 }')
+      if [ ! -z "$HOST_IP" ]; then
+        echo "Found host.docker.internal: $HOST_IP"
+      fi
+    fi
+
+    # Method 2: Default gateway
+    if [ -z "$HOST_IP" ]; then
+      echo "Method 2: Trying default gateway..."
+      GATEWAY_IP=$(ip route | grep default | awk '{print $3}')
+      if [ ! -z "$GATEWAY_IP" ]; then
+        echo "Found default gateway: $GATEWAY_IP"
+        HOST_IP=$GATEWAY_IP
+      fi
+    fi
+
+    # Method 3: Scanning network interfaces
+    if [ -z "$HOST_IP" ]; then
+      echo "Method 3: Scanning network interfaces..."
+      for subnet in "192.168." "10." "172."; do
+        for ip in $(ip -4 addr | grep -oP "$subnet\d+\.\d+" | uniq); do
+          if [ "$ip" != "127.0.0.1" ] && [ "$ip" != "10.244.0.1" ]; then
+            first_octet=$(echo $ip | cut -d. -f1)
+            if [ "$first_octet" = "10" ] || [ "$first_octet" = "172" ] || [ "$first_octet" = "192" ]; then
+              {{- range .Values.proxy.ports }}
+              echo "Testing connection to $ip:{{ .proxy }}..."
+              if nc -z -w2 $ip {{ .proxy }}; then
+                echo "Found working connection to $ip:{{ .proxy }}"
+                HOST_IP=$ip
+                break 3
+              fi
+              {{- end }}
+            fi
+          fi
+        done
+      done
+    fi
+
+    # Fallback
+    if [ -z "$HOST_IP" ]; then
+      echo "ERROR: Could not determine host IP. Falling back to pod IP."
+      HOST_IP=$(hostname -i)
+    fi
+
+    echo "Using host IP: $HOST_IP"
+
+    # Final network debug
+    echo "Testing connections to proxied services..."
+    SUCCESS=0
+    {{- range .Values.proxy.ports }}
+    if nc -z -w5 $HOST_IP {{ .proxy }}; then
+      echo "Successfully connected to $HOST_IP:{{ .proxy }}"
+      SUCCESS=1
+    else
+      echo "WARNING: Cannot connect to $HOST_IP:{{ .proxy }}"
+    fi
+    {{- end }}
+
+    if [ "$SUCCESS" -ne 1 ]; then
+      echo "No ports responded successfully. Continuing anyway, but things may not work."
+    fi
+
+    # Start socat tunnels
+    echo "Starting socat tunnels..."
+    {{- range .Values.proxy.ports }}
+    echo "Starting socat tunnel: TCP-LISTEN:{{ .target }},fork TCP:$HOST_IP:{{ .proxy }}"
+    socat -d -d TCP-LISTEN:{{ .target }},fork TCP:$HOST_IP:{{ .proxy }} &
+    {{- end }}
+
+    # Wait for all socat processes
+    wait

--- a/localnet/host-proxy/templates/deployment.yaml
+++ b/localnet/host-proxy/templates/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: host-proxy
+spec:
+  selector:
+    matchLabels:
+      app: host-proxy
+  template:
+    metadata:
+      labels:
+        app: host-proxy
+    spec:
+      containers:
+        - name: proxy
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh", "/scripts/proxy.sh"]
+          env:
+            - name: HOST_IP
+              value: {{ .Values.proxy.hostIP | quote }}
+        {{- if .Values.extraEnv }}
+        {{- toYaml .Values.extraEnv | nindent 8 }}
+        {{- end }}
+          ports:
+            {{- range .Values.service.ports }}
+            - containerPort: {{ .targetPort }}
+            {{- end }}
+          volumeMounts:
+            - name: proxy-script
+              mountPath: /scripts
+      volumes:
+        - name: proxy-script
+          configMap:
+            name: {{ .Release.Name }}-proxy-script
+            defaultMode: 0777

--- a/localnet/host-proxy/templates/service.yaml
+++ b/localnet/host-proxy/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: host-proxy
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    {{- range .Values.service.ports }}
+    - port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: {{ .protocol }}
+      name: {{ .name }}
+  {{- end }}
+  selector:
+    app: host-proxy

--- a/localnet/ibc-relayer/.helmignore
+++ b/localnet/ibc-relayer/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/localnet/ibc-relayer/Chart.yaml
+++ b/localnet/ibc-relayer/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: ibc-relayer
+description: Hermes IBC Relayer
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/localnet/ibc-relayer/templates/configmap.yaml
+++ b/localnet/ibc-relayer/templates/configmap.yaml
@@ -1,0 +1,190 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.prefix }}-ibc-relayer-configs
+  namespace: {{ .Release.Namespace }}
+data:
+  pocket.mnemonic: |
+    {{ .Values.chainA.mnemonic }}
+
+  foreigner.mnemonic: |
+    {{ .Values.chainB.mnemonic }}
+
+  entrypoint.sh: |
+    #!/usr/bin/env bash
+    set -e
+
+    export PATH=$PATH:/root/.hermes/bin
+
+    /root/.hermes/bin/hermes keys add --chain pocket --mnemonic-file /root/.hermes/pocket.mnemonic
+    /root/.hermes/bin/hermes keys add --chain agoriclocal --mnemonic-file /root/.hermes/foreigner.mnemonic
+
+    hermes --config /root/.hermes/config.toml $@
+
+  config.toml: |
+    [global]
+    log_level = "info"
+
+    [mode.clients]
+    enabled = true
+    refresh = true
+    misbehaviour = true
+
+    [mode.connections]
+    enabled = false
+
+    [mode.channels]
+    enabled = false
+
+    [mode.packets]
+    enabled = true
+    clear_interval = 100
+    clear_on_start = true
+    tx_confirmation = false
+    auto_register_counterparty_payee = false
+    clear_limit = 50
+
+    [mode.packets.ics20_max_memo_size]
+    enabled = true
+    size = 32768
+
+    [mode.packets.ics20_max_receiver_size]
+    enabled = true
+    size = 2048
+
+    [rest]
+    enabled = false
+    host = "127.0.0.1"
+    port = 3000
+
+    [telemetry]
+    enabled = false
+    host = "127.0.0.1"
+    port = 3001
+
+    [telemetry.buckets.latency_submitted]
+    start = 500
+    end = 20000
+    buckets = 10
+
+    [telemetry.buckets.latency_confirmed]
+    start = 1000
+    end = 30000
+    buckets = 10
+
+    [[chains]]
+    type = "CosmosSdk"
+    id = "{{ .Values.chainA.id }}"
+    rpc_addr = "{{ .Values.chainA.rpc_addr }}"
+    grpc_addr = "{{ .Values.chainA.grpc_addr }}"
+    rpc_timeout = "10s"
+    trusted_node = false
+    account_prefix = "{{ .Values.chainA.account_prefix }}"
+    key_name = "{{ .Values.chainA.key_name }}"
+    key_store_type = "Test"
+    store_prefix = "ibc"
+    default_gas = 100000
+    max_gas = 400000
+    gas_multiplier = 1.1
+    max_msg_num = 30
+    max_tx_size = 180000
+    max_grpc_decoding_size = 33554432
+    query_packets_chunk_size = 50
+    clock_drift = "5s"
+    max_block_time = "30s"
+    client_refresh_rate = "1/3"
+    ccv_consumer_chain = false
+    memo_prefix = ""
+    sequential_batch_tx = false
+    allow_ccq = true
+
+    [chains.event_source]
+    mode = "pull"
+    interval = "500ms"
+    max_retries = 4
+
+    [chains.trust_threshold]
+    numerator = 2
+    denominator = 3
+
+    [chains.gas_price]
+    price = 0.00
+    denom = "{{ .Values.chainA.gas_denom }}"
+
+    [chains.packet_filter]
+    policy = "allow"
+    list = [["transfer", "{{ .Values.chainA.packet_channel }}"]]
+
+    [chains.packet_filter.min_fees]
+
+    [chains.dynamic_gas_price]
+    enabled = false
+    multiplier = 1.1
+    max = 0.6
+
+    [chains.address_type]
+    derivation = "cosmos"
+
+    [chains.excluded_sequences]
+
+    ## -------------------- Chain B ----------------------
+
+    [[chains]]
+    type = "CosmosSdk"
+    id = "{{ .Values.chainB.id }}"
+    rpc_addr = "{{ .Values.chainB.rpc_addr }}"
+    grpc_addr = "{{ .Values.chainB.grpc_addr }}"
+    rpc_timeout = "10s"
+    trusted_node = false
+    account_prefix = "{{ .Values.chainB.account_prefix }}"
+    key_name = "{{ .Values.chainB.key_name }}"
+    key_store_type = "Test"
+    store_prefix = "ibc"
+    default_gas = 100000
+    max_gas = 400000
+    gas_multiplier = 1.1
+    max_msg_num = 30
+    max_tx_size = 180000
+    max_grpc_decoding_size = 33554432
+    query_packets_chunk_size = 50
+    clock_drift = "5s"
+    max_block_time = "30s"
+    client_refresh_rate = "1/3"
+    ccv_consumer_chain = false
+    memo_prefix = ""
+    sequential_batch_tx = false
+    allow_ccq = true
+
+    [chains.event_source]
+    mode = "pull"
+    interval = "500ms"
+    max_retries = 4
+
+    [chains.trust_threshold]
+    numerator = 2
+    denominator = 3
+
+    [chains.gas_price]
+    price = 0.02
+    denom = "{{ .Values.chainB.gas_denom }}"
+
+    [chains.packet_filter]
+    policy = "allow"
+    list = [["transfer", "{{ .Values.chainB.packet_channel }}"]]
+
+    [chains.packet_filter.min_fees]
+
+    [chains.dynamic_gas_price]
+    enabled = false
+    multiplier = 1.1
+    max = 0.6
+
+    [chains.address_type]
+    derivation = "cosmos"
+
+    [chains.excluded_sequences]
+
+    [tracing_server]
+    enabled = false
+    port = 5555
+

--- a/localnet/ibc-relayer/templates/deployment.yaml
+++ b/localnet/ibc-relayer/templates/deployment.yaml
@@ -1,0 +1,58 @@
+kind: {{ .Values.kind | default "Deployment" }}
+apiVersion: {{ if eq (.Values.kind | default "Deployment") "Job" }}batch/v1{{ else }}apps/v1{{ end }}
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: 1
+  {{- if eq .Values.kind "Deployment" }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      restartPolicy: {{ if eq .Values.kind "Job" }}Never{{ else }}Always{{ end }}
+      containers:
+        - name: ibc-relayer
+          image: ibc-relayer
+          command: {{- toYaml (
+            ternary
+              (concat
+                .Values.command
+                (list
+                  (printf "--a-chain=%s" .Values.chain_a_id)
+                  (printf "--b-chain=%s" .Values.chain_b_id)
+                )
+                (default list .Values.extraArgs)
+              )
+              .Values.command
+              (eq .Values.kind "Job")
+          ) | nindent 12 }}
+          volumeMounts:
+            - name: {{ .Values.prefix }}-ibc-relayer-configs
+              mountPath: /root/.hermes/entrypoint.sh
+              subPath: entrypoint.sh
+              readOnly: true
+            - name: {{ .Values.prefix }}-ibc-relayer-configs
+              mountPath: /root/.hermes/config.toml
+              subPath: config.toml
+              readOnly: true
+            - name: {{ .Values.prefix }}-ibc-relayer-configs
+              mountPath: /root/.hermes/pocket.mnemonic
+              subPath: pocket.mnemonic
+              readOnly: true
+            - name: {{ .Values.prefix }}-ibc-relayer-configs
+              mountPath: /root/.hermes/foreigner.mnemonic
+              subPath: foreigner.mnemonic
+              readOnly: true
+
+      volumes:
+        - name: {{ .Values.prefix }}-ibc-relayer-configs
+          configMap:
+            name: {{ .Values.prefix }}-ibc-relayer-configs
+            defaultMode: 0755

--- a/localnet/kubernetes/values-agoric.yaml
+++ b/localnet/kubernetes/values-agoric.yaml
@@ -1,0 +1,24 @@
+image:
+  repository: agoric
+  tag: latest
+  pullPolicy: Never
+
+mnemonic: "beach prize number regular tiger aware ring shiver path dizzy please bacon steel car crash youth rural history furnace possible property chicken entire system"
+
+service:
+  type: ClusterIP
+  ports:
+    p2p: 26656
+    rpc: 26657
+    rest: 1317
+    grpc: 9090
+
+env:
+  DEST: "1"
+  DEBUG: "SwingSet:ls,SwingSet:vat"
+
+  # Uncomment to enable delve debugging
+  # DELVE_PORT: "40009"
+
+command:
+  - /usr/src/upgrade-test-scripts/entrypoint.sh

--- a/localnet/kubernetes/values-host-proxy.yaml
+++ b/localnet/kubernetes/values-host-proxy.yaml
@@ -1,0 +1,32 @@
+image:
+  repository: alpine/socat
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+# Reverse proxy configuration
+proxy:
+  # NOTE: Provide your LAN IP here for best results.
+  hostIP: ""  # Empty by default, will try to auto-detect
+  ports:
+    - target: 36657
+      proxy: 36657
+    - target: 10090
+      proxy: 10090
+
+# Service configuration
+service:
+  type: ClusterIP
+  ports:
+    - port: 36657
+      targetPort: 36657
+      protocol: TCP
+      name: rpc
+    - port: 10090
+      targetPort: 10090
+      protocol: TCP
+      name: grpc
+
+# Additional environment variables if needed
+extraEnv: []
+  # - name: EXAMPLE_ENV
+  #   value: "example-value"

--- a/localnet/kubernetes/values-ibc-relayer-cli.yaml
+++ b/localnet/kubernetes/values-ibc-relayer-cli.yaml
@@ -1,0 +1,13 @@
+prefix: "cli"
+kind: "Job"
+command:
+  - /root/.hermes/entrypoint.sh
+  - create
+  - channel
+  - --a-port=transfer
+  - --b-port=transfer
+  - --new-client-connection
+  - --yes
+  # Intentionally omitted, expected to be added by Tilt with helm(set=[chain_a="xxx",chain_b="yyy"])
+  # - --a-chain=xxx
+  # - --b-chain=yyy

--- a/localnet/kubernetes/values-ibc-relayer-config-pocket-agoriclocal.yaml
+++ b/localnet/kubernetes/values-ibc-relayer-config-pocket-agoriclocal.yaml
@@ -1,0 +1,20 @@
+chainA:
+  id: pocket
+  # LocalNet app1 mnemonic; SHOULD match config.yml.
+  mnemonic: "mention spy involve verb exercise fiction catalog order agent envelope mystery text defy sing royal fringe return face alpha knife wonder vocal virus drum"
+  rpc_addr: "http://validator-pocket-validator.default.svc.cluster.local:26657/"
+  grpc_addr: "http://validator-pocket-validator.default.svc.cluster.local:9090/"
+  account_prefix: pokt
+  key_name: pocket
+  gas_denom: pokt
+  packet_channel: channel-0
+
+chainB:
+  id: agoriclocal
+  mnemonic: "beach prize number regular tiger aware ring shiver path dizzy please bacon steel car crash youth rural history furnace possible property chicken entire system"
+  rpc_addr: http://agoric.default.svc.cluster.local:26657/
+  grpc_addr: http://agoric.default.svc.cluster.local:9090/
+  account_prefix: agoric
+  key_name: agoriclocal
+  gas_denom: ubld
+  packet_channel: channel-0

--- a/localnet/kubernetes/values-ibc-relayer-daemon.yaml
+++ b/localnet/kubernetes/values-ibc-relayer-daemon.yaml
@@ -1,0 +1,6 @@
+# TODO_IN_THIS_COMMIT: rename
+prefix: "daemon"
+kind: "Deployment"
+command:
+  - /root/.hermes/entrypoint.sh
+  - start

--- a/makefiles/ibc.mk
+++ b/makefiles/ibc.mk
@@ -1,0 +1,29 @@
+.PHONY: ibc_list_channels
+ibc_list_channels:
+	pocketd --home=$(POCKETD_HOME) q ibc channel channels --node $(POCKET_NODE)
+
+.PHONY: ibc_list_connections
+ibc_list_connections:
+	pocketd --home=$(POCKETD_HOME) q ibc connection connections --node $(POCKET_NODE)
+
+.PHONY: fund-agoric_account
+fund_agoric_account:
+	# TODO_IN_THIS_COMMIT: log about localnet running and localnet_config ibc...
+	kubectl exec $$(kubectl get pods|grep agoric|cut -f 1 -d " ") -- agd tx bank send validator agoric1sz7nw80886tuenrhvg2tttlemgfxy734xcw70w 1000000000ubld --keyring-backend=test --chain-id=agoriclocal --from=validator --yes
+
+.PHONY: agd_shell
+agd_shell:
+	# TODO_IN_THIS_COMMIT: log about localnet running and localnet_config ibc...
+	kubectl exec -it $$(kubectl get pods|grep agoric|cut -f 1 -d " ") -- bash
+
+.PHONY: ibc_test_transfer
+ibc_test_transfer:
+	kubectl exec -it $$(kubectl get pods|grep agoric|cut -f 1 -d " ") -- agd tx ibc-transfer transfer transfer channel-0 pokt1mrqt5f7qh8uxs27cjm9t7v9e74a9vvdnq5jva4 1000ubld --keyring-backend=test --chain-id=agoriclocal --from=validator --yes
+
+.PHONY: agd_query_tx
+agd_query_tx:
+	kubectl exec -it $$(kubectl get pods|grep agoric|cut -f 1 -d " ") -- agd query tx $(TX_HASH) --chain-id=agoriclocal
+
+.PHONY: agd_query_tx_json
+agd_query_tx_json:
+	kubectl exec -it $$(kubectl get pods|grep agoric|cut -f 1 -d " ") -- agd query tx $(TX_HASH) --chain-id=agoriclocal -o json

--- a/tiltfiles/ibc.tilt
+++ b/tiltfiles/ibc.tilt
@@ -1,0 +1,124 @@
+# pocketdex_disabled_resource creates a tilt resource that prints a message indicating
+# that the indexer is disabled and how to enable it.
+def ibc_disabled_resource(reason):
+    local_resource("⚠️ IBC Disabled",
+                   "echo '{}'".format(reason),
+                   labels=["IBC"])
+
+def check_and_load_ibc(ibc_config):
+    print("IBC config:")
+    print(ibc_config)
+    if ibc_config["enabled"]:
+        print("TRUE")
+        load_ibc_resources()
+    else:
+        print("FALSE")
+        ibc_disabled_resource("Localnet IBC resources disabled. Set `ibc.enabled` to `true` in `localnet_config.yaml` to enable them.")
+
+def load_ibc_resources():
+    docker_build(
+        "agoric",
+        context=os.path.join(".", "localnet", "agoric"),  # needs any folder, doesn't matter
+        dockerfile_contents="""
+        FROM ghcr.io/agoric/agoric-3-proposals:latest
+        
+        # Update .bashrc
+        RUN grep -qF 'env_setup.sh' /root/.bashrc || echo "source /usr/src/upgrade-test-scripts/env_setup.sh" >> /root/.bashrc
+        RUN grep -qF 'printKeys' /root/.bashrc || echo "printKeys" >> /root/.bashrc
+        
+        ## Install Go v1.23.0
+        #RUN wget https://go.dev/dl/go1.23.0.linux-amd64.tar.gz
+        #RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go*.tar.gz
+        #RUN echo 'export PATH=$PATH:/usr/local/go/bin' >> /root/.bashrc
+        #RUN echo 'export GOPATH=/usr/local/go' >> /root/.bashrc
+        #
+        ## Install Debugging Tools
+        #RUN source /root/.bashrc && go install github.com/go-delve/delve/cmd/dlv@v1.23.0
+        #RUN apt update && apt install -y gdbserver gdb
+        #
+        ## Clone and build Agoric SDK for local debugging source
+        #RUN git clone https://github.com/agoric/agoric-sdk.git --branch=v0.35.0-u19.2 /usr/src/agoric-sdk2
+        #WORKDIR /usr/src/agoric-sdk2/golang/cosmos
+        #RUN yarn add node-addon-api
+        #RUN . /root/.bashrc && go mod tidy
+        #RUN . /root/.bashrc && make all
+        #RUN cp ./build/agd /usr/local/bin/agd
+        #
+        ## Reset the working directory
+        #WORKDIR /usr/src/upgrade-test-scripts
+        """,
+    )
+
+    k8s_yaml(helm(
+        os.path.join("localnet", "agoric"),
+        name="agoric",
+        values=os.path.join("localnet", "kubernetes", "values-agoric.yaml"),  # Only files go here
+    ))
+
+    k8s_resource(
+        'agoric',
+        new_name="Agoric Local Node",
+        labels=["IBC"],
+        port_forwards=[
+            "46657:26657",
+            "11090:9090",
+            "40009:40009"
+        ],
+    )
+
+    # Deploy IBC relayer CLI (Job) and daemon (Deployment)
+    k8s_yaml(helm(
+        os.path.join("localnet", "ibc-relayer"),
+        values=[
+            os.path.join("localnet", "kubernetes", "values-ibc-relayer-cli.yaml"),
+            os.path.join("localnet", "kubernetes", "values-ibc-relayer-common.yaml"),
+        ]
+    ))
+
+    k8s_yaml(helm(
+        os.path.join("localnet", "ibc-relayer"),
+        values=[
+            os.path.join("localnet", "kubernetes", "values-ibc-relayer-daemon.yaml"),
+            os.path.join("localnet", "kubernetes", "values-ibc-relayer-common.yaml"),
+        ]
+    ))
+
+    docker_build(
+        "ibc-relayer",
+        context=os.path.join(".", "localnet", "ibc-relayer"),  # needs any folder, doesn't matter
+        dockerfile_contents="""
+        FROM golang:1.23.0
+
+        RUN apt-get update && apt-get install -y wget
+
+        # Install hermes IBC relayer CLI.
+        RUN mkdir -p /root/.hermes/bin
+        WORKDIR /usr/local
+        RUN wget https://github.com/informalsystems/hermes/releases/download/v1.10.3/hermes-v1.10.3-x86_64-unknown-linux-gnu.tar.gz
+        RUN tar -C /root/.hermes/bin/ -vxf /usr/local/hermes-v1.10.3-x86_64-unknown-linux-gnu.tar.gz
+
+        ENTRYPOINT ["/root/.hermes/bin/hermes"]
+        CMD ["start"]
+    """)
+
+    k8s_resource(
+        workload="cli-ibc-relayer",
+        new_name="IBC Setup",
+        labels=["IBC"],
+        trigger_mode=TRIGGER_MODE_MANUAL,
+        resource_deps=[
+            "validator",
+            "Agoric Local Node",
+        ]
+    )
+
+    k8s_resource(
+        workload="daemon-ibc-relayer",
+        new_name="Agoric IBC Relayer",
+        labels=["IBC"],
+        resource_deps=[
+            "validator",
+            "Agoric Local Node",
+            "IBC Setup",
+        ]
+    )

--- a/tiltfiles/ibc.tilt
+++ b/tiltfiles/ibc.tilt
@@ -1,3 +1,48 @@
+ibc_relayer_dockerfile = """
+FROM golang:1.23.0
+
+RUN apt-get update && apt-get install -y wget
+
+# Install hermes IBC relayer CLI.
+RUN mkdir -p /root/.hermes/bin
+WORKDIR /usr/local
+RUN wget https://github.com/informalsystems/hermes/releases/download/v1.10.3/hermes-v1.10.3-x86_64-unknown-linux-gnu.tar.gz
+RUN tar -C /root/.hermes/bin/ -vxf /usr/local/hermes-v1.10.3-x86_64-unknown-linux-gnu.tar.gz
+
+ENTRYPOINT ["/root/.hermes/bin/hermes"]
+CMD ["start"]
+"""
+
+agoric_dockerfile = """
+FROM ghcr.io/agoric/agoric-3-proposals:latest
+
+# Update .bashrc
+RUN grep -qF 'env_setup.sh' /root/.bashrc || echo "source /usr/src/upgrade-test-scripts/env_setup.sh" >> /root/.bashrc
+RUN grep -qF 'printKeys' /root/.bashrc || echo "printKeys" >> /root/.bashrc
+
+## Install Go v1.23.0
+#RUN wget https://go.dev/dl/go1.23.0.linux-amd64.tar.gz
+#RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go*.tar.gz
+#RUN echo 'export PATH=$PATH:/usr/local/go/bin' >> /root/.bashrc
+#RUN echo 'export GOPATH=/usr/local/go' >> /root/.bashrc
+#
+## Install Debugging Tools
+#RUN source /root/.bashrc && go install github.com/go-delve/delve/cmd/dlv@v1.23.0
+#RUN apt update && apt install -y gdbserver gdb
+#
+## Clone and build Agoric SDK for local debugging source
+#RUN git clone https://github.com/agoric/agoric-sdk.git --branch=v0.35.0-u19.2 /usr/src/agoric-sdk2
+#WORKDIR /usr/src/agoric-sdk2/golang/cosmos
+#RUN yarn add node-addon-api
+#RUN . /root/.bashrc && go mod tidy
+#RUN . /root/.bashrc && make all
+#RUN cp ./build/agd /usr/local/bin/agd
+#
+## Reset the working directory
+#WORKDIR /usr/src/upgrade-test-scripts
+"""
+
+
 # pocketdex_disabled_resource creates a tilt resource that prints a message indicating
 # that the indexer is disabled and how to enable it.
 def ibc_disabled_resource(reason):
@@ -5,120 +50,146 @@ def ibc_disabled_resource(reason):
                    "echo '{}'".format(reason),
                    labels=["IBC"])
 
+
 def check_and_load_ibc(ibc_config):
-    print("IBC config:")
-    print(ibc_config)
     if ibc_config["enabled"]:
-        print("TRUE")
-        load_ibc_resources()
+        load_ibc_resources(ibc_config)
     else:
-        print("FALSE")
-        ibc_disabled_resource("Localnet IBC resources disabled. Set `ibc.enabled` to `true` in `localnet_config.yaml` to enable them.")
+        ibc_disabled_resource(
+            "Localnet IBC resources disabled. Set `ibc.enabled` to `true` in `localnet_config.yaml` to enable them.")
 
-def load_ibc_resources():
-    docker_build(
-        "agoric",
-        context=os.path.join(".", "localnet", "agoric"),  # needs any folder, doesn't matter
-        dockerfile_contents="""
-        FROM ghcr.io/agoric/agoric-3-proposals:latest
-        
-        # Update .bashrc
-        RUN grep -qF 'env_setup.sh' /root/.bashrc || echo "source /usr/src/upgrade-test-scripts/env_setup.sh" >> /root/.bashrc
-        RUN grep -qF 'printKeys' /root/.bashrc || echo "printKeys" >> /root/.bashrc
-        
-        ## Install Go v1.23.0
-        #RUN wget https://go.dev/dl/go1.23.0.linux-amd64.tar.gz
-        #RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go*.tar.gz
-        #RUN echo 'export PATH=$PATH:/usr/local/go/bin' >> /root/.bashrc
-        #RUN echo 'export GOPATH=/usr/local/go' >> /root/.bashrc
-        #
-        ## Install Debugging Tools
-        #RUN source /root/.bashrc && go install github.com/go-delve/delve/cmd/dlv@v1.23.0
-        #RUN apt update && apt install -y gdbserver gdb
-        #
-        ## Clone and build Agoric SDK for local debugging source
-        #RUN git clone https://github.com/agoric/agoric-sdk.git --branch=v0.35.0-u19.2 /usr/src/agoric-sdk2
-        #WORKDIR /usr/src/agoric-sdk2/golang/cosmos
-        #RUN yarn add node-addon-api
-        #RUN . /root/.bashrc && go mod tidy
-        #RUN . /root/.bashrc && make all
-        #RUN cp ./build/agd /usr/local/bin/agd
-        #
-        ## Reset the working directory
-        #WORKDIR /usr/src/upgrade-test-scripts
-        """,
-    )
 
-    k8s_yaml(helm(
-        os.path.join("localnet", "agoric"),
-        name="agoric",
-        values=os.path.join("localnet", "kubernetes", "values-agoric.yaml"),  # Only files go here
-    ))
+def check_and_load_agoric(ibc_config):
+    if ibc_config["relay_pairs_enabled"]["pocket-agoriclocal"]:
+        docker_build(
+            "agoric",
+            context=os.path.join(".", "localnet", "agoric"),  # needs any folder, doesn't matter
+            dockerfile_contents=agoric_dockerfile
+        )
 
-    k8s_resource(
-        'agoric',
-        new_name="Agoric Local Node",
-        labels=["IBC"],
-        port_forwards=[
-            "46657:26657",
-            "11090:9090",
-            "40009:40009"
-        ],
-    )
+        k8s_yaml(helm(
+            os.path.join("localnet", "agoric"),
+            name="agoric",
+            values=os.path.join("localnet", "kubernetes", "values-agoric.yaml"),  # Only files go here
+        ))
 
-    # Deploy IBC relayer CLI (Job) and daemon (Deployment)
-    k8s_yaml(helm(
-        os.path.join("localnet", "ibc-relayer"),
-        values=[
-            os.path.join("localnet", "kubernetes", "values-ibc-relayer-cli.yaml"),
-            os.path.join("localnet", "kubernetes", "values-ibc-relayer-common.yaml"),
+        k8s_resource(
+            'agoric',
+            new_name="Agoric Local Node",
+            labels=["IBC"],
+            port_forwards=[
+                "46657:26657",
+                "11090:9090",
+                "40009:40009"
+            ],
+        )
+
+
+def pair_pretty(pair):
+    chain_a_id, chain_b_id = pair.split("-")
+    return chain_a_id.title() + "->" + chain_b_id.title()
+
+
+def load_ibc_relayer_server_resources(pair):
+    chain_a_id, chain_b_id = pair.split("-")
+    release_name = pair + "-daemon-ibc-relayer"
+    pair_ibc_setup_dep = pair_pretty(pair) + " IBC Setup"
+
+    if chain_a_id == "pocket":
+        resource_deps = [
+            "validator",
+            chain_b_id.title() + " Local Node",
+            pair_ibc_setup_dep,
         ]
-    ))
+    elif chain_b_id == "pocket":
+        resource_deps = [
+            "validator",
+            chain_a_id.title() + " Local Node",
+            pair_ibc_setup_dep,
+        ]
+    else:
+        resource_deps = [
+            chain_a_id.title() + " Local Node",
+            chain_b_id.title() + " Local Node",
+            pair_ibc_setup_dep,
+        ]
 
     k8s_yaml(helm(
         os.path.join("localnet", "ibc-relayer"),
+        name=release_name,
         values=[
             os.path.join("localnet", "kubernetes", "values-ibc-relayer-daemon.yaml"),
-            os.path.join("localnet", "kubernetes", "values-ibc-relayer-common.yaml"),
-        ]
+            os.path.join("localnet", "kubernetes", "values-ibc-relayer-config-" + pair + ".yaml"),
+        ],
+        set=[
+            "chain_a_id=" + chain_a_id,
+            "chain_b_id=" + chain_b_id
+        ],
     ))
 
-    docker_build(
-        "ibc-relayer",
-        context=os.path.join(".", "localnet", "ibc-relayer"),  # needs any folder, doesn't matter
-        dockerfile_contents="""
-        FROM golang:1.23.0
+    k8s_resource(
+        release_name,
+        new_name=pair_pretty(pair) + " IBC Relayer",
+        labels=["IBC"],
+        resource_deps=resource_deps,
+    )
 
-        RUN apt-get update && apt-get install -y wget
 
-        # Install hermes IBC relayer CLI.
-        RUN mkdir -p /root/.hermes/bin
-        WORKDIR /usr/local
-        RUN wget https://github.com/informalsystems/hermes/releases/download/v1.10.3/hermes-v1.10.3-x86_64-unknown-linux-gnu.tar.gz
-        RUN tar -C /root/.hermes/bin/ -vxf /usr/local/hermes-v1.10.3-x86_64-unknown-linux-gnu.tar.gz
+def load_ibc_relayer_setup_resource(pair):
+    chain_a_id, chain_b_id = pair.split("-")
+    release_name = pair + "-cli-ibc-relayer"
+    if chain_a_id == "pocket":
+        resource_deps = [
+            "validator",
+            chain_b_id.title() + " Local Node",
+        ]
+    elif chain_b_id == "pocket":
+        resource_deps = [
+            "validator",
+            chain_a_id.title() + " Local Node",
+        ]
+    else:
+        resource_deps = [
+            chain_a_id.title() + " Local Node",
+            chain_b_id.title() + " Local Node",
+        ]
 
-        ENTRYPOINT ["/root/.hermes/bin/hermes"]
-        CMD ["start"]
-    """)
+    k8s_yaml(helm(
+        os.path.join("localnet", "ibc-relayer"),
+        name=release_name,
+        values=[
+            os.path.join("localnet", "kubernetes", "values-ibc-relayer-cli.yaml"),
+            os.path.join("localnet", "kubernetes", "values-ibc-relayer-config-" + pair + ".yaml"),
+        ],
+        set=[
+            "chain_a_id=" + chain_a_id,
+            "chain_b_id=" + chain_b_id
+        ],
+    ))
 
     k8s_resource(
-        workload="cli-ibc-relayer",
-        new_name="IBC Setup",
+        workload=release_name,
+        new_name=pair_pretty(pair) + " IBC Setup",
         labels=["IBC"],
         trigger_mode=TRIGGER_MODE_MANUAL,
-        resource_deps=[
-            "validator",
-            "Agoric Local Node",
-        ]
+        resource_deps=resource_deps,
     )
 
-    k8s_resource(
-        workload="daemon-ibc-relayer",
-        new_name="Agoric IBC Relayer",
-        labels=["IBC"],
-        resource_deps=[
-            "validator",
-            "Agoric Local Node",
-            "IBC Setup",
-        ]
-    )
+
+def load_ibc_relayer(pair):
+    load_ibc_relayer_server_resources(pair)
+    load_ibc_relayer_setup_resource(pair)
+
+
+def load_ibc_resources(ibc_config):
+    check_and_load_agoric(ibc_config)
+
+    if len(ibc_config["relay_pairs_enabled"]) > 0:
+        docker_build(
+            "ibc-relayer",
+            context=os.path.join(".", "localnet", "ibc-relayer"),  # needs any folder, doesn't matter
+            dockerfile_contents=ibc_relayer_dockerfile)
+
+    for pair, enabled in ibc_config["relay_pairs_enabled"].items():
+        if enabled:
+            load_ibc_relayer(pair)


### PR DESCRIPTION
## Summary

Adds a chart which is useful for integrating new resources in to localnet, step-by-step.
Projects often have their own tooling (e.g. docker-compose files, scripts, etc.) which they recommend and reference in their documentation. Using the host-proxy to connect to a new service which is running on the host, using the project's own tooling, minimizes early devops integration hurdles.

## Issue

- #1201 

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
