### PR TITLE
[Bug] Fix supplier service configuration caching in claim settlement process

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -53,7 +53,10 @@ var allUpgrades = []upgrades.Upgrade{
 	// upgrades.Upgrade_0_1_8,
 
 	// v0.1.9 - upgrade to cache claim settlement context
-	upgrades.Upgrade_0_1_9,
+	// upgrades.Upgrade_0_1_9,
+
+	// v0.1.10 - upgrade to fix chain halts caused by the previous upgrade.
+	upgrades.Upgrade_0_1_10,
 }
 
 // setUpgrades sets upgrade handlers for all upgrades and executes KVStore migration if an upgrade plan file exists.

--- a/app/upgrades/v0.1.10.go
+++ b/app/upgrades/v0.1.10.go
@@ -1,0 +1,19 @@
+package upgrades
+
+import (
+	storetypes "cosmossdk.io/store/types"
+)
+
+const Upgrade_0_1_10_PlanName = "v0.1.10"
+
+// Upgrade_0_1_9 handles the upgrade to release `v0.1.9`.
+// This is fix upgrade to be issued on both Pocket Network's Shannon Alpha, Beta TestNets.
+// It is an upgrade intended to fix chain halts caused by the previous upgrade.
+// https://github.com/pokt-network/poktroll/compare/v0.1.9..v0.1.10
+var Upgrade_0_1_10 = Upgrade{
+	PlanName: Upgrade_0_1_10_PlanName,
+	// No state or consensus-breaking changes in this upgrade.
+	CreateUpgradeHandler: defaultUpgradeHandler,
+	// No migrations in this upgrade.
+	StoreUpgrades: storetypes.StoreUpgrades{},
+}

--- a/x/tokenomics/keeper/settle_pending_claims_context.go
+++ b/x/tokenomics/keeper/settle_pending_claims_context.go
@@ -261,7 +261,7 @@ func (sctx *settlementContext) cacheSupplierServiceConfig(
 		return s.ServiceId == serviceId
 	})
 
-	if serviceConfigIdx < 0 {
+	if serviceConfigIdx >= 0 {
 		// Service configuration already cached, no need to update
 		return
 	}

--- a/x/tokenomics/keeper/settle_pending_claims_context.go
+++ b/x/tokenomics/keeper/settle_pending_claims_context.go
@@ -261,8 +261,8 @@ func (sctx *settlementContext) cacheSupplierServiceConfig(
 		return s.ServiceId == serviceId
 	})
 
+	// Service configuration already cached, no need to update
 	if serviceConfigIdx >= 0 {
-		// Service configuration already cached, no need to update
 		return
 	}
 

--- a/x/tokenomics/keeper/settle_pending_claims_test.go
+++ b/x/tokenomics/keeper/settle_pending_claims_test.go
@@ -901,7 +901,14 @@ func (s *TestSuite) TestSettlePendingClaims_ClaimExpired_SupplierUnstaked() {
 	require.Equal(t, 1, len(unbondingBeginEvents))
 
 	// Validate the EventSupplierUnbondingBegin event.
-	for i := range slashedSupplier.ServiceConfigHistory {
+	for i := len(slashedSupplier.ServiceConfigHistory) - 1; i >= 0; i-- {
+		if slashedSupplier.ServiceConfigHistory[i].Service.ServiceId != serviceId {
+			slashedSupplier.ServiceConfigHistory = append(
+				slashedSupplier.ServiceConfigHistory[:i],
+				slashedSupplier.ServiceConfigHistory[i+1:]...,
+			)
+			continue
+		}
 		slashedSupplier.ServiceConfigHistory[i].DeactivationHeight = upcomingSessionEndHeight
 		if slashedSupplier.ServiceConfigHistory[i].Service.Endpoints == nil {
 			slashedSupplier.ServiceConfigHistory[i].Service.Endpoints = []*sharedtypes.SupplierEndpoint{}

--- a/x/tokenomics/keeper/settle_pending_claims_test.go
+++ b/x/tokenomics/keeper/settle_pending_claims_test.go
@@ -113,6 +113,11 @@ func (s *TestSuite) SetupTest() {
 	require.NoError(t, err)
 
 	appStake := types.NewCoin("upokt", math.NewInt(1000000))
+
+	// Setup the test for each service:
+	// - Create and store the service in the service keeper.
+	// - Create and store an application staked to the service.
+	// - Create a supplier service config for the service.
 	supplierServiceConfigs := make([]*sharedtypes.SupplierServiceConfig, 0, len(testServiceIds))
 	appAddresses := make([]string, 0, len(testServiceIds))
 	for i, serviceId := range testServiceIds {
@@ -151,6 +156,7 @@ func (s *TestSuite) SetupTest() {
 		s.keepers.SetApplication(s.ctx, app)
 	}
 
+	// Make the supplier staked for each tested service.
 	supplierStake := types.NewCoin("upokt", math.NewInt(supplierStakeAmt))
 	supplierServiceConfigHistory := sharedtest.CreateServiceConfigUpdateHistoryFromServiceConfigs(supplierOwnerAddr, supplierServiceConfigs, 1, 0)
 	supplier := sharedtypes.Supplier{
@@ -162,6 +168,7 @@ func (s *TestSuite) SetupTest() {
 	}
 	s.keepers.SetAndIndexDehydratedSupplier(s.ctx, supplier)
 
+	// Create a claim and proof for each service.
 	s.relayMiningDifficulties = make([]servicetypes.RelayMiningDifficulty, 0, len(testServiceIds))
 	for i, serviceId := range testServiceIds {
 		appAddress := appAddresses[i]


### PR DESCRIPTION
## Summary
Ensure supplier service configurations for claim serviceIds are properly cached in the settlement context

Primary Changes:
- Add `cacheSupplierServiceConfig` function to hydrate supplier with service config when missing
- Update `cacheSupplier` to ensure cached suppliers include service configurations for all claims
- Use `slices` package to efficiently search for existing service configurations

Secondary changes:
- Import standard library `slices` package
- Add a test that ensures that claim settlement succeeds when a supplier is involved in multiple claims of different services.

## Issue

Chain halt with the following error:
```
could not settle pending claims due to error TLM "TLMRelayBurnEqualsMint": queueing operation: distributing rewards to supplier with operator address pokt1n0d0ktfk4594tfpr2saus9dfh89jwlmhnjewuw shareholders: service "service_6994" not found for supplier owner_address:"pokt1n0d0ktfk4594tfpr2saus9dfh89jwlmhnjewuw" operator_address:"pokt1n0d0ktfk4594tfpr2saus9dfh89jwlmhnjewuw" stake:<denom:"upokt" amount:"1000001" > services:<service_id:"service_7749" endpoints:<url:"https://beta-relayminer-7.us-nj.poktroll.com:443" rpc_type:JSON_RPC > rev_share:<address:"pokt1n0d0ktfk4594tfpr2saus9dfh89jwlmhnjewuw" rev_share_percentage:100 > > : constraint violation [/home/runner/go/pkg/mod/cosmossdk.io/errors@v1.0.1/errors.go:155]: internal token logic module error: failed to process token logic module [/home/runner/go/pkg/mod/cosmossdk.io/errors@v1.0.1/errors.go:155]
```

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [x] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
