### PR TITLE
[Tooling] CLI: add `--auto-sequence` flag

### DIFF
--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -1,0 +1,9 @@
+package cmd
+
+import cosmoserrors "cosmossdk.io/errors"
+
+const codespace = "cli"
+
+var (
+	ErrAutoSequence = cosmoserrors.Register(codespace, 1100, "auto-sequence flag error")
+)

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -1,5 +1,17 @@
 package flags
 
+import (
+	"fmt"
+
+	"cosmossdk.io/depinject"
+	cosmosclient "github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+
+	cmd2 "github.com/pokt-network/poktroll/cmd"
+	"github.com/pokt-network/poktroll/pkg/client/query"
+)
+
 const (
 	// OmittedDefaultFlagValue is used whenever a flag is required but no reasonable default value can be provided.
 	// In most cases, this forces the user to specify the flag value to avoid unintended behavior.
@@ -19,4 +31,89 @@ const (
 
 	FlagNoPassphrase      = "no-passphrase"
 	FlagNoPassphraseUsage = "attempt to use an empty passphrase to decrypt the exported Morse key file for signing"
+
+	FlagAutoSequence      = "auto-sequence"
+	FlagAutoSequenceUsage = "Sets the --offline, --account-number, and --sequence flags based on cached and/or onchain account state for the given --from address"
+	DefaultAutoSequence   = false
 )
+
+// TODO_IN_THIS_COMMIT: godoc..
+func CheckAutoSequenceFlag(cmd *cobra.Command, clientCtx cosmosclient.Context) error {
+	shouldAutoSequence, err := cmd.PersistentFlags().GetBool(FlagAutoSequence)
+	if err != nil {
+		return cmd2.ErrAutoSequence.Wrapf("%s", err)
+	}
+
+	if shouldAutoSequence {
+		// Check if --offline, --account-number, or --sequence flags are already set.
+		// This also ensures that each of these flags is registered, which is required.
+		offline, err := cmd.Flags().GetBool(flags.FlagOffline)
+		if err != nil {
+			return cmd2.ErrAutoSequence.Wrapf("%s", err)
+		}
+
+		sequenceNumber, err := cmd.Flags().GetUint64(flags.FlagSequence)
+		if err != nil {
+			return cmd2.ErrAutoSequence.Wrapf("%s", err)
+		}
+
+		accountNumber, err := cmd.Flags().GetUint64(flags.FlagAccountNumber)
+		if err != nil {
+			return cmd2.ErrAutoSequence.Wrapf("%s", err)
+		}
+
+		// If --offline or --sequence flags are already set, return an error.
+		if offline || sequenceNumber != 0 {
+			return cmd2.ErrAutoSequence.Wrap("cannot set --auto-sequence flag when --offline or --sequence flags are already set")
+		}
+
+		// Set --offline flag to true so that the tx client doesn't query for the account state.
+		if err := cmd.Flags().Set(flags.FlagOffline, "true"); err != nil {
+			return cmd2.ErrAutoSequence.Wrapf("%s", err)
+		}
+
+		// Construct an account query client.
+		authClient, err := query.NewAccountQuerier(depinject.Supply(clientCtx))
+		if err != nil {
+			return cmd2.ErrAutoSequence.Wrapf("unable to construct account query client: %s", err)
+		}
+
+		// Query for the account with --from address.
+		fromAddress, err := cmd.Flags().GetString(flags.FlagFrom)
+		if err != nil {
+			return err
+		}
+
+		account, err := authClient.GetAccount(cmd.Context(), fromAddress)
+		if err != nil {
+			return cmd2.ErrAutoSequence.Wrapf("unable to get account with address %s: %s", fromAddress, err)
+		}
+
+		switch {
+		// If the --account-number flag is not set, apply the account number from the query result.
+		// DEV_NOTE: 0 is the default value for --account-number flag.
+		case accountNumber == 0:
+			// Set --account-number flag to the account number.
+			accountNumber = account.GetAccountNumber()
+		// If the --account-number flag is set, ensure that it matches the account number from the query result.
+		case accountNumber != account.GetAccountNumber():
+			return fmt.Errorf(
+				"account number %d does not match the account number %d of the account with address %s",
+				accountNumber, account.GetAccountNumber(), fromAddress,
+			)
+		// Otherwise, use the account number provided in the --account-number flag.
+		default:
+		}
+
+		// Set the --sequence flag to the sequence number from the query result.
+		if err := cmd.Flags().Set(flags.FlagSequence, fmt.Sprintf("%d", account.GetSequence())); err != nil {
+			return cmd2.ErrAutoSequence.Wrapf("%s", err)
+		}
+
+		// TODO_IN_THIS_COMMIT: add and check a cache for the account sequence number.
+		// TODO_IN_THIS_COMMIT: add and check a cache for the account sequence number.
+		// TODO_IN_THIS_COMMIT: add and check a cache for the account sequence number.
+	}
+
+	return nil
+}

--- a/cmd/pocketd/cmd/root.go
+++ b/cmd/pocketd/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/pokt-network/poktroll/app"
+	flags2 "github.com/pokt-network/poktroll/cmd/flags"
 	relayercmd "github.com/pokt-network/poktroll/pkg/relayer/cmd"
 )
 
@@ -111,7 +112,11 @@ For additional documentation, see https://dev.poktroll.com/tools/user_guide/pock
 			customAppTemplate, customAppConfig := initAppConfig()
 			customCMTConfig := initCometBFTConfig()
 
-			return server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig, customCMTConfig)
+			if err := server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig, customCMTConfig); err != nil {
+				return err
+			}
+
+			return flags2.CheckAutoSequenceFlag(cmd, clientCtx)
 		},
 	}
 
@@ -139,6 +144,8 @@ For additional documentation, see https://dev.poktroll.com/tools/user_guide/pock
 	rootCmd.AddCommand(
 		relayercmd.RelayerCmd(),
 	)
+
+	rootCmd.PersistentFlags().Bool(flags2.FlagAutoSequence, flags2.DefaultAutoSequence, flags2.FlagAutoSequenceUsage)
 
 	return rootCmd
 }

--- a/pkg/store/interface.go
+++ b/pkg/store/interface.go
@@ -1,0 +1,9 @@
+package store
+
+// TODO_IN_THIS_COMMIT: godoc...
+type KeyValueStore interface {
+	Get(key []byte) []byte
+	Has(key []byte) bool
+	Set(key []byte, value []byte)
+	Delete(key []byte)
+}

--- a/pkg/store/kvstore.go
+++ b/pkg/store/kvstore.go
@@ -1,0 +1,35 @@
+package store
+
+import (
+	cosmoslog "cosmossdk.io/log"
+	"cosmossdk.io/store/metrics"
+	"cosmossdk.io/store/rootmulti"
+	cosmostypes "cosmossdk.io/store/types"
+	cosmosdb "github.com/cosmos/cosmos-db"
+)
+
+// TODO_IN_THIS_COMMIT: godoc...
+func NewMultiStore(
+	persistencePath string,
+	storeTypesByStoreKey map[cosmostypes.StoreKey]cosmostypes.StoreType,
+) (_ cosmostypes.MultiStore, closeFn func() error, _ error) {
+	db, err := cosmosdb.NewPebbleDB("test_db", persistencePath, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO_IN_THIS_COMMIT: comment... disable logging and metrics...
+	multiStore := rootmulti.NewStore(db, cosmoslog.NewNopLogger(), metrics.NewMetrics([][]string{}))
+
+	// Mount all sub-stores.
+	for storeKey, storeType := range storeTypesByStoreKey {
+		multiStore.MountStoreWithDB(storeKey, storeType, db)
+	}
+
+	// Load the entire multistore.
+	if err = multiStore.LoadLatestVersion(); err != nil {
+		return nil, nil, err
+	}
+
+	return multiStore, db.Close, nil
+}

--- a/pkg/store/kvstore_test.go
+++ b/pkg/store/kvstore_test.go
@@ -1,0 +1,70 @@
+package store
+
+import (
+	"fmt"
+	"path"
+	"testing"
+
+	cosmostypes "cosmossdk.io/store/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMultiStore(t *testing.T) {
+	// Will be deleted once the test completes.
+	tempDBPath := path.Join(t.TempDir(), fmt.Sprintf("%s.db", t.Name()))
+
+	// Mount a single "test" store.
+	testStoreKey := cosmostypes.NewKVStoreKey("test")
+	storeTypesByStoreKey := map[cosmostypes.StoreKey]cosmostypes.StoreType{
+		testStoreKey: cosmostypes.StoreTypeDB,
+	}
+
+	multiStore, closeDB, err := NewMultiStore(tempDBPath, storeTypesByStoreKey)
+	require.NoError(t, err)
+	require.NotNil(t, multiStore)
+
+	testStore := multiStore.GetKVStore(testStoreKey)
+	require.NotNil(t, testStore)
+
+	t.Run("basic operations", func(t *testing.T) {
+		// The store should initially be empty.
+		value1 := testStore.Get([]byte("key1"))
+		require.Equal(t, []byte(nil), value1)
+
+		// Store a value.
+		testStore.Set([]byte("key1"), []byte("value1"))
+
+		// The store should now have a value.
+		gotValue1 := testStore.Get([]byte("key1"))
+		require.Equal(t, []byte("value1"), gotValue1)
+
+		// Store another value.
+		testStore.Set([]byte("key2"), []byte("value2"))
+
+		// The store should now have two values.
+		gotValue1 = testStore.Get([]byte("key1"))
+		require.Equal(t, []byte("value1"), gotValue1)
+		gotValue2 := testStore.Get([]byte("key2"))
+		require.Equal(t, []byte("value2"), gotValue2)
+	})
+
+	t.Run("load from persistence", func(t *testing.T) {
+		// Close the existing multi-store/DB.
+		err := closeDB()
+		require.NoError(t, err)
+
+		// Load the persisted multi-store.
+		multiStore, closeDB, err = NewMultiStore(tempDBPath, storeTypesByStoreKey)
+		require.NoError(t, err)
+		require.NotNil(t, multiStore)
+
+		persistedTestStore := multiStore.GetKVStore(testStoreKey)
+		require.NotNil(t, persistedTestStore)
+
+		// The store should have two values that were stored in the previous test.
+		gotValue1 := persistedTestStore.Get([]byte("key1"))
+		require.Equal(t, []byte("value1"), gotValue1)
+		gotValue2 := persistedTestStore.Get([]byte("key2"))
+		require.Equal(t, []byte("value2"), gotValue2)
+	})
+}

--- a/x/application/types/message_delegate_to_gateway_test.go
+++ b/x/application/types/message_delegate_to_gateway_test.go
@@ -3,8 +3,9 @@ package types
 import (
 	"testing"
 
-	"github.com/pokt-network/poktroll/testutil/sample"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/poktroll/testutil/sample"
 )
 
 func TestMsgDelegateToGateway_ValidateBasic(t *testing.T) {


### PR DESCRIPTION
## Summary

Add `--auto-sequence` flag to streamline broadcasting multiple TXs per block; i.e. automate application of `--offline`, `--account-number`, and `--sequence`.

## Issue

- #1267 

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
