### PR TITLE
[Morse -> Shannon Migration] chore: prepare v0.1.11 upgrade for submission

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -58,8 +58,7 @@ var allUpgrades = []upgrades.Upgrade{
 	// v0.1.10 - upgrade to fix chain halts caused by the previous upgrade.
 	// upgrades.Upgrade_0_1_10,
 
-	// TODO_MAINNET_MIGRATION(@bryanchriswhite): Update the upgrade version number.
-	// v0.1.x - upgrade to fix chain halts caused by the previous upgrade.
+	// v0.1.11 - upgrade to add allow_morse_account_import_overwrite param.
 	upgrades.Upgrade_0_1_11,
 }
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -60,7 +60,7 @@ var allUpgrades = []upgrades.Upgrade{
 
 	// TODO_MAINNET_MIGRATION(@bryanchriswhite): Update the upgrade version number.
 	// v0.1.x - upgrade to fix chain halts caused by the previous upgrade.
-	upgrades.Upgrade_0_1_x,
+	upgrades.Upgrade_0_1_11,
 }
 
 // setUpgrades sets upgrade handlers for all upgrades and executes KVStore migration if an upgrade plan file exists.

--- a/app/upgrades/v0.1.11.go
+++ b/app/upgrades/v0.1.11.go
@@ -17,8 +17,13 @@ const (
 )
 
 // Upgrade_0_1_11 handles the upgrade to release `v0.1.11`.
-// This is planned to be issued on both Pocket Network's Shannon Alpha, Beta TestNets as well as MainNet.
-// It is an upgrade intended to reduce the memory footprint when iterating over Suppliers and Applications.
+// This upgrade adds:
+// - the `allow_morse_account_import_overwrite` migration module param
+//   - Set to `false` by default
+//   - Set to `true` on Alpha and Beta TestNets
+//
+// - a corresponding authz grant
+// - new `MsgRecoverMorseAccount` message with empty message handlers (scaffolding)
 // https://github.com/pokt-network/poktroll/compare/v0.1.10..v0.1.11
 var Upgrade_0_1_11 = Upgrade{
 	PlanName: Upgrade_0_1_11_PlanName,

--- a/app/upgrades/v0.1.11.go
+++ b/app/upgrades/v0.1.11.go
@@ -14,18 +14,16 @@ import (
 	"github.com/pokt-network/poktroll/app/keepers"
 )
 
-// TODO_MAINNET_MIGRATION(@bryanchriswhite): Update the upgrade version numbers, diffs, hashes, etc. and rename this file.
-
 const (
-	Upgrade_0_1_x_PlanName = "v0.1.x"
+	Upgrade_0_1_11_PlanName = "v0.1.11"
 )
 
-// Upgrade_0_1_x handles the upgrade to release `v0.1.x`.
+// Upgrade_0_1_11 handles the upgrade to release `v0.1.11`.
 // This is planned to be issued on both Pocket Network's Shannon Alpha, Beta TestNets as well as MainNet.
 // It is an upgrade intended to reduce the memory footprint when iterating over Suppliers and Applications.
-// https://github.com/pokt-network/poktroll/compare/v0.1.x..abc123
-var Upgrade_0_1_x = Upgrade{
-	PlanName: Upgrade_0_1_x_PlanName,
+// https://github.com/pokt-network/poktroll/compare/v0.1.10..v0.1.11
+var Upgrade_0_1_11 = Upgrade{
+	PlanName: Upgrade_0_1_11_PlanName,
 	// No migrations in this upgrade.
 	StoreUpgrades: storetypes.StoreUpgrades{},
 
@@ -36,7 +34,7 @@ var Upgrade_0_1_x = Upgrade{
 		configurator module.Configurator,
 	) upgradetypes.UpgradeHandler {
 		// Adds new authz authorizations from the diff:
-		// https://github.com/pokt-network/poktroll/compare/v0.1.x...abc123
+		// https://github.com/pokt-network/poktroll/compare/v0.1.10...v0.1.11
 		applyNewAuthorizations := func(ctx context.Context) (err error) {
 			// Validate before/after with:
 			// 	pocketd q authz grants-by-granter pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t --node=<network_rpc_url>
@@ -72,13 +70,13 @@ var Upgrade_0_1_x = Upgrade{
 		}
 
 		// Add new parameters by:
-		// 1. Inspecting the diff between v0.1.x...abc123
+		// 1. Inspecting the diff between v0.1.10...v0.1.11
 		// 2. Manually inspect changes in ignite's config.yml
 		// 3. Update the upgrade handler here accordingly
-		// Ref: https://github.com/pokt-network/poktroll/compare/v0.1.x...abc123
+		// Ref: https://github.com/pokt-network/poktroll/compare/v0.1.10...v0.1.11
 		applyNewParameters := func(ctx context.Context) (err error) {
 			logger := cosmostypes.UnwrapSDKContext(ctx).Logger()
-			logger.Info("Starting parameter updates", "upgrade_plan_name", Upgrade_0_1_x_PlanName)
+			logger.Info("Starting parameter updates", "upgrade_plan_name", Upgrade_0_1_11_PlanName)
 
 			// Get the current migration module params
 			migrationParams := keepers.MigrationKeeper.GetParams(ctx)

--- a/app/upgrades/v0.1.11.go
+++ b/app/upgrades/v0.1.11.go
@@ -2,7 +2,6 @@ package upgrades
 
 import (
 	"context"
-	"fmt"
 
 	cosmoslog "cosmossdk.io/log"
 	storetypes "cosmossdk.io/store/types"

--- a/docusaurus/docs/operate/morse_migration/4_state_transfer_playbook.md
+++ b/docusaurus/docs/operate/morse_migration/4_state_transfer_playbook.md
@@ -100,7 +100,7 @@ Distribute the `msg_import_morse_accounts_${SNAPSHOT_HEIGHT}_${SNAPSHOT_DATE}.js
 
 :::danger
 
-This can **ONLY BE DONE ONCE** on networks with the `allow_morse_import_overwrite` param disabled (e.g. MainNet).
+This can **ONLY BE DONE ONCE** on networks with the `allow_morse_account_import_overwrite` param disabled (e.g. MainNet).
 
 :::
 


### PR DESCRIPTION
## Summary

Prepares v0.1.11 onchain network upgrade for application.

- Add authz grant for `MsgRecoverMorseAccount`
- Add `allow_morse_import_override` migration module param
  - Set it to `true` for Alpha and Beta TestNets

## Issue

- #1294 

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Other (specify): upgrade

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
