### PR TITLE
[Docs] fix: migration state transfer playbook - bash variable name

### DIFF
--- a/docusaurus/docs/2_explore/4_morse_migration/4_state_transfer_playbook.md
+++ b/docusaurus/docs/2_explore/4_morse_migration/4_state_transfer_playbook.md
@@ -84,7 +84,7 @@ Follow the steps there, and resume **from the next step (i.e. skip this step)**.
 
 ```bash
 export MSG_IMPORT_MORSE_ACCOUNTS_PATH="./msg_import_morse_accounts_${MAINNET_SNAPSHOT_HEIGHT}_${MAINNET_SNAPSHOT_DATE}.json"
-pocketd tx migration collect-morse-accounts "$MORSE_STATE_EXPORT_PATH" "$MSG_IMPORT_MORSE_ACCOUNTS_PATH"
+pocketd tx migration collect-morse-accounts "$MORSE_MAINNET_STATE_EXPORT_PATH" "$MSG_IMPORT_MORSE_ACCOUNTS_PATH"
 ```
 
 ### 4. Distribute Canonical Account State Import Message


### PR DESCRIPTION
## Summary

Fix a typo in the migration docs, state transfer playbook. `MORSE_STATE_EXPORT` was renamed to `MORSE_MAINNET_STATE_EXPORT` but one reference didn't get updated.

## Issue

- N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
