### PR TITLE
[Tooling] fix: normalize all Morse hex address cases to uppercase

### DIFF
--- a/pkg/encoding/hex.go
+++ b/pkg/encoding/hex.go
@@ -16,3 +16,9 @@ func NormalizeTxHashHex(txHash string) string {
 func TxHashBytesToNormalizedHex(txHash []byte) string {
 	return NormalizeTxHashHex(fmt.Sprintf("%x", txHash))
 }
+
+// NormalizeMorseHexAddress defines canonical and unambiguous representation for a
+// morse address hexadecimal string; upper-case.
+func NormalizeMorseHexAddress(morseAddress string) string {
+	return strings.ToUpper(morseAddress)
+}

--- a/testutil/sample/sample.go
+++ b/testutil/sample/sample.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/pokt-network/poktroll/pkg/encoding"
 )
 
 // AccAddressAndPubKey returns a sample account address and public key
@@ -77,5 +79,5 @@ func AccAddressFromConsBech32(consBech32 string) string {
 // MorseAddressHex returns the hex-encoded string representation of the address
 // corresponding to a random Morse (ed25519) keypair.
 func MorseAddressHex() string {
-	return hex.EncodeToString(ConsAddress().Bytes())
+	return encoding.NormalizeMorseHexAddress(hex.EncodeToString(ConsAddress().Bytes()))
 }

--- a/x/migration/keeper/morse_claimable_account.go
+++ b/x/migration/keeper/morse_claimable_account.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/runtime"
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/pokt-network/poktroll/pkg/encoding"
 	migrationtypes "github.com/pokt-network/poktroll/x/migration/types"
 )
 
@@ -102,6 +103,8 @@ func (k Keeper) ImportFromMorseAccountState(
 	for _, morseAccount := range morseAccountState.Accounts {
 		// DEV_NOTE: Ensure all MorseClaimableAccounts are initially unclaimed.
 		morseAccount.ClaimedAtHeight = 0
+		// DEV_NOTE: Ensure all MorseClaimableAccounts use the normalized hex address case (upper).
+		morseAccount.MorseSrcAddress = encoding.NormalizeMorseHexAddress(morseAccount.MorseSrcAddress)
 		k.SetMorseClaimableAccount(ctx, *morseAccount)
 	}
 }

--- a/x/migration/keeper/query_morse_claimable_account.go
+++ b/x/migration/keeper/query_morse_claimable_account.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/pokt-network/poktroll/pkg/encoding"
 	"github.com/pokt-network/poktroll/x/migration/types"
 )
 
@@ -52,9 +53,10 @@ func (k Keeper) MorseClaimableAccount(
 		return nil, status.Error(codes.InvalidArgument, "invalid request")
 	}
 
+	normalizedMorseAddress := encoding.NormalizeMorseHexAddress(req.Address)
 	morseClaimableAccount, found := k.GetMorseClaimableAccount(
 		ctx,
-		req.Address,
+		normalizedMorseAddress,
 	)
 	if !found {
 		return nil, status.Error(codes.NotFound, "not found")

--- a/x/migration/keeper/query_morse_claimable_account_test.go
+++ b/x/migration/keeper/query_morse_claimable_account_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/types/query"
@@ -50,6 +51,20 @@ func TestMorseClaimableAccountQuerySingle(t *testing.T) {
 		{
 			desc: "InvalidRequest",
 			err:  status.Error(codes.InvalidArgument, "invalid request"),
+		},
+		{
+			desc: "Uppercase Address",
+			request: &types.QueryMorseClaimableAccountRequest{
+				Address: strings.ToUpper(msgs[0].MorseSrcAddress),
+			},
+			response: &types.QueryMorseClaimableAccountResponse{MorseClaimableAccount: msgs[0]},
+		},
+		{
+			desc: "Lowercase Address",
+			request: &types.QueryMorseClaimableAccountRequest{
+				Address: strings.ToLower(msgs[0].MorseSrcAddress),
+			},
+			response: &types.QueryMorseClaimableAccountResponse{MorseClaimableAccount: msgs[0]},
 		},
 	}
 	for _, tc := range tests {

--- a/x/migration/types/message_claim_morse_account.go
+++ b/x/migration/types/message_claim_morse_account.go
@@ -5,6 +5,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/gogoproto/proto"
+
+	"github.com/pokt-network/poktroll/pkg/encoding"
 )
 
 var (
@@ -87,5 +89,5 @@ func (msg *MsgClaimMorseAccount) getSigningBytes() ([]byte, error) {
 
 // GetMorseSignerAddress returns the morse address which was used to sign the claim message.
 func (msg *MsgClaimMorseAccount) GetMorseSignerAddress() string {
-	return msg.GetMorsePublicKey().Address().String()
+	return encoding.NormalizeMorseHexAddress(msg.GetMorsePublicKey().Address().String())
 }

--- a/x/migration/types/message_claim_morse_application.go
+++ b/x/migration/types/message_claim_morse_application.go
@@ -6,6 +6,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/gogoproto/proto"
 
+	"github.com/pokt-network/poktroll/pkg/encoding"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
 
@@ -101,5 +102,5 @@ func (msg *MsgClaimMorseApplication) getSigningBytes() ([]byte, error) {
 
 // GetMorseSignerAddress returns the morse address which was used to sign the claim message.
 func (msg *MsgClaimMorseApplication) GetMorseSignerAddress() string {
-	return msg.GetMorsePublicKey().Address().String()
+	return encoding.NormalizeMorseHexAddress(msg.GetMorsePublicKey().Address().String())
 }

--- a/x/migration/types/message_claim_morse_supplier.go
+++ b/x/migration/types/message_claim_morse_supplier.go
@@ -6,6 +6,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/gogoproto/proto"
 
+	"github.com/pokt-network/poktroll/pkg/encoding"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
 
@@ -27,6 +28,8 @@ func NewMsgClaimMorseSupplier(
 	services []*sharedtypes.SupplierServiceConfig,
 	shannonSigningAddr string,
 ) (*MsgClaimMorseSupplier, error) {
+	morseNodeAddress = encoding.NormalizeMorseHexAddress(morseNodeAddress)
+
 	msg := &MsgClaimMorseSupplier{
 		MorseNodeAddress:       morseNodeAddress,
 		ShannonOwnerAddress:    shannonOwnerAddress,
@@ -126,5 +129,5 @@ func (msg *MsgClaimMorseSupplier) getSigningBytes() ([]byte, error) {
 // - The Morse node address (i.e. operator)
 // - The Morse output address (i.e. owner)
 func (msg *MsgClaimMorseSupplier) GetMorseSignerAddress() string {
-	return msg.GetMorsePublicKey().Address().String()
+	return encoding.NormalizeMorseHexAddress(msg.GetMorsePublicKey().Address().String())
 }


### PR DESCRIPTION
## Summary

Normalize all Morse hex addresses usages to upper case so that different cases of the same string are treated as the same address.

## Issue

- #1343

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [x] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
