### PR TITLE
[Ops] Add support for skipping upgrade heights in node installer scripts

### DIFF
--- a/tools/scripts/upgrades/prepare_upgrade_tx.sh
+++ b/tools/scripts/upgrades/prepare_upgrade_tx.sh
@@ -29,16 +29,16 @@ VERSION="$1"
 shift # Remove version from arguments
 
 RELEASE_URL="https://github.com/pokt-network/poktroll/releases/download/$VERSION"
-CHECKSUM_URL="$RELEASE_URL/release_checksum"
+# TODO_TECHDEBT: Enable checksum downloading once they are provided again
+# CHECKSUM_URL="$RELEASE_URL/release_checksum"
 OUTPUT_DIR="tools/scripts/upgrades"
 
 # Default checksum inclusion:
-# - local & alpha: false
-# - beta & main: true
+# - local, alpha, beta & main: false
 INCLUDE_CHECKSUM_ALPHA=false
-INCLUDE_CHECKSUM_BETA=true
+INCLUDE_CHECKSUM_BETA=false
 INCLUDE_CHECKSUM_LOCAL=false
-INCLUDE_CHECKSUM_MAIN=true
+INCLUDE_CHECKSUM_MAIN=false
 
 # Test-only flag: only generate for local & alpha
 TEST_ONLY=false
@@ -86,8 +86,8 @@ fi
 # Create output directory if it doesn't exist
 mkdir -p "$OUTPUT_DIR"
 
-# Only download and parse checksum if not in test-only mode
-if [ "$TEST_ONLY" != true ]; then
+# Only download and parse checksum if not in test-only mode and CHECKSUM_URL is provided
+if [ "$TEST_ONLY" != true ] && [ -n "$CHECKSUM_URL" ]; then
   # Create a temporary file for the checksum
   TEMP_CHECKSUM=$(mktemp)
 


### PR DESCRIPTION
## Summary
Update installer scripts to handle upgrade height skipping and modify release checksum behavior.

### Primary Changes:
- Add support for downloading and applying `--unsafe-skip-upgrades` flags in the full-node.sh installer
- Configure the node systemd service to use the downloaded skip upgrade heights
- Modify the upgrade tx preparation script to make checksums optional for all networks

### Secondary changes:
- Add URL constant for skip upgrade heights file location
- Update comments to reflect changes in checksum behavior
- Add detailed logging during the skip upgrades configuration process

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [x] 'TODO's, configurations and other docs
