### PR TITLE
[Morse -> Shannon Migration] fix: non-custodial owner supplier claim signature

### DIFF
--- a/x/migration/types/message_claim_morse_supplier.go
+++ b/x/migration/types/message_claim_morse_supplier.go
@@ -41,16 +41,16 @@ func NewMsgClaimMorseSupplier(
 	if morsePrivateKey != nil {
 		msg.MorsePublicKey = morsePrivateKey.PubKey().Bytes()
 
-		if err := msg.SignMorseSignature(morsePrivateKey); err != nil {
-			return nil, err
-		}
-
 		// Assume that the morsePrivateKey corresponds to ONE OF THE FOLLOWING:
 		// - The morse node address (i.e. operator): leave signer_is_output_address as false
 		// - The morse output address (i.e. owner): set signer_is_output_address to true
 		// If any other private key is used, the claim message will error.
 		if msg.GetMorseSignerAddress() != morseNodeAddress {
 			msg.SignerIsOutputAddress = true
+		}
+
+		if err := msg.SignMorseSignature(morsePrivateKey); err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
## Summary

TL;DR, fixes owner signed non-custodial supplier claim message signatures.

Finish modifying the claim messages BEFORE signing it.

## Issue

- N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
