### PR TITLE
[Docs] fix: migration E2E playbook address var typos

### DIFF
--- a/docusaurus/docs/2_explore/4_morse_migration/11_localnet_testing.md
+++ b/docusaurus/docs/2_explore/4_morse_migration/11_localnet_testing.md
@@ -336,9 +336,9 @@ pocketd query bank balance $SHANNON_ADDR_SUPPLIER_1 upokt -o json --node=http://
 
 ```bash
 pocketd tx migration claim-supplier \
-  ${MORSE_ADDR_OWNER_1} pocket-account-${MORSE_ADDR_OWNER_1}.json \
+  ${MORSE_ADDR_SUPPLIER_1} pocket-account-${MORSE_ADDR_OWNER_1}.json \
   ${MORSE_SUPPLIER_1_PREFIX}_claim_supplier_1_supplier_config.yaml \
-  --from=${MORSE_SUPPLIER_1_PREFIX}-claim-supplier-1 \
+  --from=${MORSE_OWNER_1_PREFIX}-claim-owner-1 \
   --node=http://localhost:26657 --chain-id=pocket \
   --home=./localnet/pocketd --keyring-backend=test --no-passphrase \
   --gas=auto --gas-adjustment=1.5 --yes
@@ -367,7 +367,7 @@ pocketd query bank balance $SHANNON_ADDR_OWNER_1 upokt -o json --node=http://127
 **Check supplier's unstaked balance after claim:**
 
 ```bash
-pocketd query bank balance $SHANNON_ADDR_OWNER_1 upokt -o json --node=http://127.0.0.1:26657 --home=./localnet/pocketd | jq '.balance.amount'
+pocketd query bank balance $SHANNON_ADDR_SUPPLIER_1 upokt -o json --node=http://127.0.0.1:26657 --home=./localnet/pocketd | jq '.balance.amount'
 ```
 
 ---


### PR DESCRIPTION
## Summary

- The Morse node/supplier address should be the first argument of the `claim-supplier` command
- It's more realistic if the Shannon owner is the msg signer
- Query the Shannon operator balance instead of owner balance (again)

## Issue

- N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
