### PR TITLE
[Keyring] 🥸 fix: set BIP44 coin type 😿

### DIFF
--- a/app/pocket/constants.go
+++ b/app/pocket/constants.go
@@ -2,6 +2,8 @@ package pocket
 
 // TODO_TECHDEBT(@bryanchriswhite): Use this everywhere in the codebase.
 const (
-	DenomuPOKT = "upokt"
-	DenomMACT  = "mact"
+	DenomuPOKT   = "upokt"
+	DenomMACT    = "mact"
+	CoinTypePOKT = 635
+	// See: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
 )

--- a/cmd/pocketd/cmd/config.go
+++ b/cmd/pocketd/cmd/config.go
@@ -9,6 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/pokt-network/poktroll/app"
+	"github.com/pokt-network/poktroll/app/pocket"
 	"github.com/pokt-network/poktroll/telemetry"
 )
 
@@ -77,6 +78,7 @@ func InitSDKConfig() {
 // we have an added check to return early in case the config has already been set to the expected value.
 func checkOrInitSDKConfig() {
 	config := sdk.GetConfig()
+	config.SetCoinType(pocket.CoinTypePOKT)
 
 	// Check if the config is already set with the correct prefixes
 	if config.GetBech32AccountAddrPrefix() == app.AccountAddressPrefix {


### PR DESCRIPTION
## Summary

Sets the heirarchical-deterministic path's coin type according to the [SLIP-0044 registry](https://github.com/satoshilabs/slips/blob/master/slip-0044.md#motivation) (635). 

## Issue

- https://discord.com/channels/824324475256438814/997192534168182905/1377640996678144110

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Other (specify): 😅😭💩⛈️

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
