### PR TITLE
[Security] Add validation for Morse account claims in MsgClaimMorseSupplier

### DIFF
--- a/x/migration/keeper/msg_server_claim_morse_supplier.go
+++ b/x/migration/keeper/msg_server_claim_morse_supplier.go
@@ -84,7 +84,7 @@ func (k msgServer) ClaimMorseSupplier(
 		// checks:
 		// if the morse sign is done by the output address, then we want to protect the operator, which requires
 		// the operator to first claim the node account using MsgClaimMorseAccount
-		if morseClaimableAccount.IsClaimed() {
+		if !morseClaimableAccount.IsClaimed() {
 			return nil, status.Error(
 				codes.FailedPrecondition,
 				migrationtypes.ErrMorseSupplierClaim.Wrapf(
@@ -125,7 +125,7 @@ func (k msgServer) ClaimMorseSupplier(
 			)
 		}
 
-		if msg.ShannonOwnerAddress != morseOutputAddressClaimableAccount.GetMorseSrcAddress() {
+		if msg.ShannonOwnerAddress != morseOutputAddressClaimableAccount.GetShannonDestAddress() {
 			return nil, status.Error(
 				codes.FailedPrecondition,
 				migrationtypes.ErrMorseSupplierClaim.Wrapf(


### PR DESCRIPTION
# DISCLAIMER
THIS PR JUST AIM TO DEMONSTRATE THE CHECKS LOGIC AND DOES NOT PRETEND TO BE IMPLEMENTED AS IS. 
THIS PR WAS NOT TESTED AND WAS JUST CODE FOLLOWING CODE LOGIC AND IDE SUGGESTIONS TO CLEARLY EXPLAIN THE NEEDS.

## Summary

Ensure proper claim checks for both operator and output addresses during Morse supplier claim processing. Protects against incorrect account bindings by validating Morse account claims and associated Shannon addresses. Introduces preconditions to enhance consistency and safeguard migration logic.