### PR TITLE
[Service] Allow AddService handler to update CUPR

### DIFF
--- a/docusaurus/docs/1_operate/1_cheat_sheets/1_service_cheatsheet.md
+++ b/docusaurus/docs/1_operate/1_cheat_sheets/1_service_cheatsheet.md
@@ -25,6 +25,7 @@ Visit the [Service FAQ](../4_faq/1_service_faq.md) for more information about in
   - [1. Add a Service](#1-add-a-service)
   - [2. Query for the Service](#2-query-for-the-service)
   - [3. What do I do next?](#3-what-do-i-do-next)
+- [How do I update an existing service `compute_units_per_relay`?](#how-do-i-update-an-existing-service-compute_units_per_relay)
 
 ## Introduction
 
@@ -82,3 +83,24 @@ pocketd query service show-service "svc-$USER" \
 ### 3. What do I do next?
 
 _TODO(@olshansk): Coming soon..._
+
+
+## How do I update an existing service `compute_units_per_relay`?
+
+Use the `add-service` command to modify the `compute_units_per_relay` for an existing service.
+Provide the `SERVICE_ID` of the `Service` you want to update, but with a new value for `COMPUTE_UNITS_PER_RELAY`.
+
+```bash
+pocketd tx service add-service \
+    ${SERVICE_ID} "${SERVICE_DESCRIPTION}" ${NEW_COMPUTE_UNITS_PER_RELAY} \
+    --fees 300upokt --from ${SERVICE_OWNER} --network=beta
+```
+
+For example:
+
+```bash
+pocketd tx service add-service \
+   "svc-$USER" "service description for $USER" 20 \
+   --fees 300upokt --from $USER \
+   --network=beta
+```

--- a/docusaurus/docs/1_operate/1_cheat_sheets/1_service_cheatsheet.md
+++ b/docusaurus/docs/1_operate/1_cheat_sheets/1_service_cheatsheet.md
@@ -25,7 +25,7 @@ Visit the [Service FAQ](../4_faq/1_service_faq.md) for more information about in
   - [1. Add a Service](#1-add-a-service)
   - [2. Query for the Service](#2-query-for-the-service)
   - [3. What do I do next?](#3-what-do-i-do-next)
-- [How do I update an existing service `compute_units_per_relay`?](#how-do-i-update-an-existing-service-compute_units_per_relay)
+- [How do I update an existing service's `compute_units_per_relay`?](#how-do-i-update-an-existing-services-compute_units_per_relay)
 
 ## Introduction
 
@@ -84,9 +84,10 @@ pocketd query service show-service "svc-$USER" \
 
 _TODO(@olshansk): Coming soon..._
 
-## How do I update an existing service `compute_units_per_relay`?
+## How do I update an existing service's `compute_units_per_relay`?
 
 Use the `add-service` command to modify the `compute_units_per_relay` for an existing service.
+
 Provide the `SERVICE_ID` of the `Service` you want to update, but with a new value for `COMPUTE_UNITS_PER_RELAY`.
 
 ```bash

--- a/docusaurus/docs/1_operate/1_cheat_sheets/1_service_cheatsheet.md
+++ b/docusaurus/docs/1_operate/1_cheat_sheets/1_service_cheatsheet.md
@@ -84,7 +84,6 @@ pocketd query service show-service "svc-$USER" \
 
 _TODO(@olshansk): Coming soon..._
 
-
 ## How do I update an existing service `compute_units_per_relay`?
 
 Use the `add-service` command to modify the `compute_units_per_relay` for an existing service.

--- a/x/service/keeper/msg_server_add_service.go
+++ b/x/service/keeper/msg_server_add_service.go
@@ -50,12 +50,17 @@ func (k msgServer) AddService(
 				).Error(),
 			)
 		}
-		return nil, status.Error(
-			codes.FailedPrecondition,
-			types.ErrServiceAlreadyExists.Wrapf(
-				"TODO_MAINNET_MIGRATION(@red-0ne): This is an ephemeral state of the code. Once we s/AddService/UpdateService/g, add the business logic here for updates here.",
-			).Error(),
-		)
+
+		// TODO_POST_MIGRATION: This logic will be replaced once the following PR is merged:
+		// https://github.com/pokt-network/poktroll/pull/1388
+		logger.Info(fmt.Sprintf("Updating ComputeUnitsPerRelay: %v", msg.Service.ComputeUnitsPerRelay))
+		foundService.ComputeUnitsPerRelay = msg.Service.ComputeUnitsPerRelay
+		k.SetService(ctx, foundService)
+
+		isSuccessful = true
+		return &types.MsgAddServiceResponse{
+			Service: &foundService,
+		}, nil
 	}
 
 	// Retrieve the address of the actor adding the service; the owner of the service.

--- a/x/service/keeper/msg_server_add_service_test.go
+++ b/x/service/keeper/msg_server_add_service_test.go
@@ -63,16 +63,6 @@ func TestMsgServer_AddService(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			desc: "valid - service added successfully",
-			setup: func(t *testing.T) {
-				// Add 10000000001 upokt to the account
-				keepertest.AddAccToAccMapCoins(t, newServiceOwnerAddr, pocket.DenomuPOKT, oneUPOKTGreaterThanFee)
-			},
-			address:     newServiceOwnerAddr,
-			service:     newService,
-			expectedErr: nil,
-		},
-		{
 			desc:    "invalid - service owner address is empty",
 			setup:   func(t *testing.T) {},
 			address: "", // explicitly set to empty string
@@ -175,7 +165,7 @@ func TestMsgServer_AddService(t *testing.T) {
 			desc: "invalid - sufficient balance of different denom",
 			setup: func(t *testing.T) {
 				// Adds 10000000001 wrong coins to the account
-				keepertest.AddAccToAccMapCoins(t, newServiceOwnerAddr, pocket.DenomuPOKT, oneUPOKTGreaterThanFee)
+				keepertest.AddAccToAccMapCoins(t, newServiceOwnerAddr, pocket.DenomMACT, oneUPOKTGreaterThanFee)
 			},
 			address:     newServiceOwnerAddr,
 			service:     newService,
@@ -188,9 +178,35 @@ func TestMsgServer_AddService(t *testing.T) {
 			service:     oldService,
 			expectedErr: types.ErrServiceInvalidOwnerAddress,
 		},
-		// {
-		// 	desc: "// TODO(@red-0ne, #781): valid - update compute_units_pre_relay if the owner is correct",
-		// },
+		// This test is placed after those that check for errors, because of the stateful
+		// nature of the test setup.
+		// If placed first, those above will follow the update service logic and
+		// will not return an error.
+		{
+			desc: "valid - service added successfully",
+			setup: func(t *testing.T) {
+				// Add 10000000001 upokt to the account
+				keepertest.AddAccToAccMapCoins(t, newServiceOwnerAddr, pocket.DenomuPOKT, oneUPOKTGreaterThanFee)
+			},
+			address:     newServiceOwnerAddr,
+			service:     newService,
+			expectedErr: nil,
+		},
+		{
+			desc: "valid - update compute_units_per_relay if the owner is correct",
+			setup: func(t *testing.T) {
+				// Add 10000000001 upokt to the account
+				keepertest.AddAccToAccMapCoins(t, oldServiceOwnerAddr, pocket.DenomuPOKT, oneUPOKTGreaterThanFee)
+			},
+			address: oldServiceOwnerAddr,
+			service: sharedtypes.Service{
+				Id:                   oldService.Id,
+				Name:                 oldService.Name,
+				ComputeUnitsPerRelay: 20, // Update to a new value
+				OwnerAddress:         oldServiceOwnerAddr,
+			},
+			expectedErr: nil,
+		},
 	}
 
 	for _, test := range tests {

--- a/x/service/types/params.go
+++ b/x/service/types/params.go
@@ -18,7 +18,7 @@ var (
 
 	KeyAddServiceFee       = []byte("AddServiceFee")
 	ParamAddServiceFee     = "add_service_fee"
-	MinAddServiceFee       = cosmostypes.NewCoin(pocket.DenomuPOKT, math.NewInt(0))
+	MinAddServiceFee       = cosmostypes.NewCoin(pocket.DenomuPOKT, math.NewInt(1_000_000_000))
 	KeyTargetNumRelays     = []byte("TargetNumRelays")
 	ParamTargetNumRelays   = "target_num_relays"
 	DefaultTargetNumRelays = uint64(10e4)

--- a/x/shared/types/service.go
+++ b/x/shared/types/service.go
@@ -14,7 +14,7 @@ const (
 	// ComputeUnitsPerRelayMax is the maximum allowed compute_units_per_relay value when adding or updating a service.
 	// TODO_MAINNET: The reason we have a maximum is to account for potential integer overflows.
 	// Should we revisit all uint64 and convert them to BigInts?
-	ComputeUnitsPerRelayMax uint64 = 2 ^ 16 // 65536
+	ComputeUnitsPerRelayMax uint64 = 1 << 16 // 65536 (2^16)
 
 	// TODO_IMPROVE: Consider making these configurable via governance parameters.
 	// The current values were selected arbitrarily simply to avoid excessive onchain bloat.


### PR DESCRIPTION
## Summary

Allow `AddService` keeper handler to update the `ComputeUnitsPerRealy` of an existing `Service` by the `ServiceOwner`

## Issue

- Issue: #1368 

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [x] For docs: `make docusaurus_start`
- [x] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [x] 'TODO's, configurations and other docs
