### PR TITLE
[Migration] Multisig Address Recovery Make sure we can recovr the wpokt multisig address

### DIFF
--- a/x/migration/recovery/recovery_allowlist.go
+++ b/x/migration/recovery/recovery_allowlist.go
@@ -11,7 +11,12 @@ import (
 // IsMorseAddressRecoverable checks if a given address exists in any of the
 // allowlists for Morse address recovery.
 func IsMorseAddressRecoverable(address string) bool {
-	// Check if the address is in the recovery allowlist
+	// Check if the address is in the Morse multi-sig allowlist
+	if listContainsTarget(morseMultiSigAllowList, address) {
+		return true
+	}
+
+	// Check if the address is in the lost app stake allowlist
 	if listContainsTarget(lostAppStakesAllowlist, address) {
 		return true
 	}
@@ -31,6 +36,7 @@ func IsMorseAddressRecoverable(address string) bool {
 
 // Ensure that all address slices are sorted in ascending order for use in binary search.
 func init() {
+	sort.Strings(morseMultiSigAllowList)
 	sort.Strings(lostAppStakesAllowlist)
 	sort.Strings(knownAppStakesAllowlist)
 	sort.Strings(moduleAccountsAllowlist)
@@ -40,6 +46,11 @@ func init() {
 func listContainsTarget(list []string, target string) bool {
 	_, found := slices.BinarySearch(list, target)
 	return found
+}
+
+var morseMultiSigAllowList = []string{
+	// wPOKT bridge: https://docs.pokt.network/welcome/usdpokt-token/bridging/wrapped-pokt-wpokt
+	"2eb054616797de8565506333afb334655e7774ed",
 }
 
 var lostAppStakesAllowlist = []string{


### PR DESCRIPTION
## Summary

**Why**: Simplify the process of migrating multisigs from Morse to Shannon.

**Changes**: Add multisig addresses to the recovery allowlist.

**Context**:  https://github.com/pokt-network/poktroll/pull/1318

**Next Steps**: 
1. Create a native [Shannon multisig](https://github.com/cosmos/cosmos-multisig-ui)
2. Recover Morse multisig as a shannon multisig
3. QED

![Screenshot 2025-06-01 at 10 23 30 AM](https://github.com/user-attachments/assets/4036be78-d631-4dd6-abe2-f5a8a0f6eaf2)
