### PR TITLE
[Tooling] Fix pocketd path on gov params script

### DIFF
--- a/tools/scripts/params/gov_params.sh
+++ b/tools/scripts/params/gov_params.sh
@@ -243,7 +243,7 @@ query_module_params() {
     local show_header=${2:-true}
 
     # Build the query command
-    local query_cmd="./pocketd query $module params --home=$HOME_DIR"
+    local query_cmd="pocketd query $module params --home=$HOME_DIR"
     if [ "$NETWORK" != "local" ]; then
         query_cmd="$query_cmd --network=$NETWORK"
     fi
@@ -323,7 +323,7 @@ export_module_params() {
     local output_file=$2
 
     # Build the query command
-    local query_cmd="./pocketd query $module params --home=$HOME_DIR"
+    local query_cmd="pocketd query $module params --home=$HOME_DIR"
     if [ "$NETWORK" != "local" ]; then
         query_cmd="$query_cmd --network=$NETWORK"
     fi
@@ -422,7 +422,7 @@ case $COMMAND in
     # Existing update logic starts here
 
     # Build the query command
-    QUERY_CMD="./pocketd query $MODULE_NAME params --home=$HOME_DIR"
+    QUERY_CMD="pocketd query $MODULE_NAME params --home=$HOME_DIR"
     if [ "$NETWORK" != "local" ]; then
         QUERY_CMD="$QUERY_CMD --network=$NETWORK"
     fi


### PR DESCRIPTION
## Summary


This pull request change the `tools/scripts/params/gov_params.sh` file. It removes the `./` prefix from the `pocketd` command in multiple functions to simplify command execution.

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
