### PR TITLE
[Bug] Nil txResponse on Supplier client

### DIFF
--- a/pkg/client/supplier/client.go
+++ b/pkg/client/supplier/client.go
@@ -92,15 +92,17 @@ func (sClient *supplierClient) SubmitProofs(
 	//  with offchain pkgs/nomenclature.
 	txResponse, eitherErr := sClient.txClient.SignAndBroadcastWithTimeoutHeight(ctx, timeoutHeight, msgs...)
 
-	logger.Info().
-		Str("tx_hash", txResponse.TxHash).
-		Msg("[PROVING] Transaction submitted")
-
-	if len(txResponse.RawLog) > 0 {
-		logger.Error().
+	if txResponse != nil {
+		logger.Info().
 			Str("tx_hash", txResponse.TxHash).
-			Str("log", txResponse.RawLog).
-			Msgf("[PROVING] Failed to submit transaction")
+			Msg("[PROVING] Transaction submitted")
+
+		if len(txResponse.RawLog) > 0 {
+			logger.Error().
+				Str("tx_hash", txResponse.TxHash).
+				Str("log", txResponse.RawLog).
+				Msgf("[PROVING] Failed to submit transaction")
+		}
 	}
 
 	err, errCh := eitherErr.SyncOrAsyncError()
@@ -155,15 +157,17 @@ func (sClient *supplierClient) CreateClaims(
 	//  with offchain pkgs/nomenclature.
 	txResponse, eitherErr := sClient.txClient.SignAndBroadcastWithTimeoutHeight(ctx, timeoutHeight, msgs...)
 
-	logger.Info().
-		Str("tx_hash", txResponse.TxHash).
-		Msg("[CLAIMING] Transaction submitted")
-
-	if len(txResponse.RawLog) > 0 {
-		logger.Error().
+	if txResponse != nil {
+		logger.Info().
 			Str("tx_hash", txResponse.TxHash).
-			Str("log", txResponse.RawLog).
-			Msgf("[CLAIMING] Failed to submit transaction")
+			Msg("[CLAIMING] Transaction submitted")
+
+		if len(txResponse.RawLog) > 0 {
+			logger.Error().
+				Str("tx_hash", txResponse.TxHash).
+				Str("log", txResponse.RawLog).
+				Msgf("[CLAIMING] Failed to submit transaction")
+		}
 	}
 
 	err, errCh := eitherErr.SyncOrAsyncError()


### PR DESCRIPTION
## Summary

This pull request adds null checks for `txResponse` in logging statements within the `SubmitProofs` and `CreateClaims` methods of `pkg/client/supplier/client.go`.

These changes ensure that logging operations are only performed when `txResponse` is not nil, improving the robustness of the code.

## Issue

![image](https://github.com/user-attachments/assets/bce6d204-4f6c-4aa0-957f-4887c879867e)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [x] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
