### PR TITLE
chore: bump onchain version to v0.1.14

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -68,7 +68,11 @@ var allUpgrades = []upgrades.Upgrade{
 	// - add morse_account_claiming_enabled migration module param
 	// - add compute_unit_cost_granularity shared module param
 	// - fix chain halt caused by zero relay claims
-	upgrades.Upgrade_0_1_13,
+	// upgrades.Upgrade_0_1_14,
+
+	// v0.1.14 - upgrade to:
+	// - Add Morse supplier claiming non-custodial Morse owner check (#1317)
+	upgrades.Upgrade_0_1_14,
 }
 
 // setUpgrades sets upgrade handlers for all upgrades and executes KVStore migration if an upgrade plan file exists.

--- a/app/upgrades/v0.1.14.go
+++ b/app/upgrades/v0.1.14.go
@@ -1,0 +1,41 @@
+package upgrades
+
+import (
+	"context"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/pokt-network/poktroll/app/keepers"
+)
+
+const (
+	Upgrade_0_1_14_PlanName = "v0.1.14"
+)
+
+// Upgrade_0_1_14 handles the upgrade to release `v0.1.14`.
+// This upgrade has no state migrations, it only releases new onchain features:
+// - Add Morse supplier claiming non-custodial Morse owner check (#1317)
+var Upgrade_0_1_14 = Upgrade{
+	PlanName: Upgrade_0_1_14_PlanName,
+	// No KVStore migrations in this upgrade.
+	StoreUpgrades: storetypes.StoreUpgrades{},
+
+	// Upgrade Handler
+	CreateUpgradeHandler: func(
+		mm *module.Manager,
+		keepers *keepers.Keepers,
+		configurator module.Configurator,
+	) upgradetypes.UpgradeHandler {
+		// Add new parameters by:
+		// 1. Inspecting the diff between v0.1.14-dev4..v0.1.14
+		// 2. Manually inspect changes in ignite's config.yml
+		// 3. Update the upgrade handler here accordingly
+		// Ref: https://github.com/pokt-network/poktroll/compare/v0.1.14-dev4..v0.1.14-dev4
+
+		return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+			return vm, nil
+		}
+	},
+}

--- a/app/upgrades/v0.1.14.go
+++ b/app/upgrades/v0.1.14.go
@@ -29,10 +29,10 @@ var Upgrade_0_1_14 = Upgrade{
 		configurator module.Configurator,
 	) upgradetypes.UpgradeHandler {
 		// Add new parameters by:
-		// 1. Inspecting the diff between v0.1.14-dev4..v0.1.14
+		// 1. Inspecting the diff between v0.1.13..v0.1.14
 		// 2. Manually inspect changes in ignite's config.yml
 		// 3. Update the upgrade handler here accordingly
-		// Ref: https://github.com/pokt-network/poktroll/compare/v0.1.14-dev4..v0.1.14-dev4
+		// Ref: https://github.com/pokt-network/poktroll/compare/v0.1.13..v0.1.14
 
 		return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 			return vm, nil

--- a/app/upgrades/vNEXT.go
+++ b/app/upgrades/vNEXT.go
@@ -9,7 +9,7 @@
 // 1. Add any upgrade specific changes in this file until an upgrade is planned
 // 2. Once ready for release:
 //   - Rename file to the target version (e.g., vNEXT.go → v0.1.14.go)
-//   - Change Upgrade_NEXT_PlanName constant to the new version (e.g. Upgrade_v0_1_14_PlanName)
+//   - Change Upgrade_NEXT_PlanName constant to the new version (e.g. Upgrade_0_1_14_PlanName)
 //   - Replace all mentions of "vNEXT" and "vPREV" with appropriate versions
 //
 // 3. Create a new vNEXT.go file for the subsequent upgrade
@@ -34,8 +34,7 @@ const (
 
 // Upgrade_NEXT handles the upgrade to release `vNEXT`.
 // This upgrade adds:
-// - the `compute_unit_cost_granularity` shared module param
-// - the `morse_account_claiming_enabled` migration module param
+// - ...
 var Upgrade_NEXT = Upgrade{
 	PlanName: Upgrade_NEXT_PlanName,
 	// No KVStore migrations in this upgrade.
@@ -48,10 +47,10 @@ var Upgrade_NEXT = Upgrade{
 		configurator module.Configurator,
 	) upgradetypes.UpgradeHandler {
 		// Add new parameters by:
-		// 1. Inspecting the diff between vPREV...vNEXT
+		// 1. Inspecting the diff between vPREV..vNEXT
 		// 2. Manually inspect changes in ignite's config.yml
 		// 3. Update the upgrade handler here accordingly
-		// Ref: https://github.com/pokt-network/poktroll/compare/vPREV...vNEXT
+		// Ref: https://github.com/pokt-network/poktroll/compare/vPREV..vNEXT
 
 		return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 			return vm, nil


### PR DESCRIPTION
## Summary

Onchain upgrade to v0.1.14.

## Issue

- N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Other (specify): onchain upgrade

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
