### PR TITLE
[Tooling] fix: network flag

### DIFF
--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -48,22 +48,26 @@ func ParseAndSetNetworkRelatedFlags(cmd *cobra.Command) error {
 }
 
 // setNetworkRelatedFlags sets the following flags according to the given arguments
-// ONLY if they have not already been set:
+// ONLY if they have not already been set AND are registered on the given command:
 // * --chain-id
 // * --node
 // * --grpc-addr
 //
 // DEV_NOTE: --grpc-insecure is also set, but ONLY for LocalNet.
 func setNetworkRelatedFlags(cmd *cobra.Command, chainId, nodeUrl, grpcAddr string) error {
-	if !cmd.Flags().Changed(cosmosflags.FlagChainID) {
-		if err := cmd.Flags().Set(cosmosflags.FlagChainID, chainId); err != nil {
-			return err
+	if chainIDFlag := cmd.Flags().Lookup(cosmosflags.FlagChainID); chainIDFlag != nil {
+		if !cmd.Flags().Changed(cosmosflags.FlagChainID) {
+			if err := cmd.Flags().Set(cosmosflags.FlagChainID, chainId); err != nil {
+				return err
+			}
 		}
 	}
 
-	if !cmd.Flags().Changed(cosmosflags.FlagNode) {
-		if err := cmd.Flags().Set(cosmosflags.FlagNode, nodeUrl); err != nil {
-			return err
+	if nodeFlag := cmd.Flags().Lookup(cosmosflags.FlagNode); nodeFlag != nil {
+		if !cmd.Flags().Changed(cosmosflags.FlagNode) {
+			if err := cmd.Flags().Set(cosmosflags.FlagNode, nodeUrl); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -76,15 +80,16 @@ func setNetworkRelatedFlags(cmd *cobra.Command, chainId, nodeUrl, grpcAddr strin
 		}
 	}
 
-	// TODO_TECHDEBT(@bryanchriswhite): This should only be set on transactions, not queries.
 	// Also set --grpc-insecure flag, but ONLY for LocalNet.
-	// if chainId == pocket.LocalNetChainId {
-	// 	if !cmd.Flags().Changed(cosmosflags.FlagGRPCInsecure) {
-	// 		if err := cmd.Flags().Set(cosmosflags.FlagGRPCInsecure, "true"); err != nil {
-	// 			return err
-	// 		}
-	// 	}
-	// }
+	if chainId == pocket.LocalNetChainId {
+		if grpcInsecureFlag := cmd.Flags().Lookup(cosmosflags.FlagGRPCInsecure); grpcInsecureFlag != nil {
+			if !cmd.Flags().Changed(cosmosflags.FlagGRPCInsecure) {
+				if err := cmd.Flags().Set(cosmosflags.FlagGRPCInsecure, "true"); err != nil {
+					return err
+				}
+			}
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Ensure that `--network` flag usage only modifies flags which are registered on the current command.

## Issue

- N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
