### PR TITLE
[ChainHalt] Add validation for claim compute units to prevent chain halts

### DIFF
--- a/x/tokenomics/keeper/settle_pending_claims.go
+++ b/x/tokenomics/keeper/settle_pending_claims.go
@@ -244,6 +244,28 @@ func (k Keeper) SettlePendingClaims(ctx cosmostypes.Context) (
 			}
 		}
 
+		// TODO_TECHDEBT(@red-0ne): This check exists to avoid chain halts when CUPR params are changed.
+		// We log the error, remove the claim, and skip its settlement instead of failing.
+		// This code should be removed once CUPR supports historical values, allowing
+		// claims to be validated against the CUPR value that was active during the session
+		// when the claim was created.
+		service, err := settlementContext.GetService(serviceId)
+		if err != nil {
+			return settledResults, expiredResults, err
+		}
+		expectedClaimComputeUnits := numClaimRelays * service.ComputeUnitsPerRelay
+		if numClaimComputeUnits != expectedClaimComputeUnits {
+			logger.Error(tokenomicstypes.ErrTokenomicsRootHashInvalid.Wrapf(
+				"mismatch: claim compute units (%d) != number of relays (%d) * service compute units per relay (%d)",
+				numClaimComputeUnits,
+				numClaimRelays,
+				service.ComputeUnitsPerRelay,
+			).Error())
+
+			k.proofKeeper.RemoveClaim(ctx, sessionId, claim.SupplierOperatorAddress)
+			continue
+		}
+
 		// If this code path is reached, then either:
 		// 1. The claim does not require a proof.
 		// 2. The claim requires a proof and a valid proof was found.


### PR DESCRIPTION
## Summary
Add compute units validation in claim settlement to prevent chain halts when CUPR params change

### Primary Changes:
• Added validation to check that `claim compute units` equals `number of relays * service compute units per relay`
• Log error and remove invalid claims instead of failing settlement when validation fails
• Added comprehensive error logging with detailed mismatch information

Secondary changes:
• Added TODO comment documenting the temporary nature of this fix until CUPR supports historical values

## Issue

![image](https://github.com/user-attachments/assets/f947c77c-f355-4ed1-867f-54f3a74ccaaa)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [x] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [x] 'TODO's, configurations and other docs
