### PR TITLE
[CLI] Fix claim morse suppliers bulk command

### DIFF
--- a/x/migration/module/cmd/claim_morse_supplier_bulk.go
+++ b/x/migration/module/cmd/claim_morse_supplier_bulk.go
@@ -292,11 +292,19 @@ func runClaimSuppliers(cmd *cobra.Command, _ []string) error {
 					return fmt.Errorf("the bulk claim tool does not have support for non-custodial nodes when the morse output address '%s' is a node", morseOutputAddress)
 				}
 				ownerAddressToMClaimableAccountMap[morseOutputAddress] = claimableMorseAccount
+
+				if !claimableMorseAccount.IsClaimed() {
+					return fmt.Errorf("morse output address '%s' is not claimed", morseOutputAddress)
+				}
 			} else {
 				// Custodial: use the current MorseClaimableAccount
 				isCustodial = true
 				ownerAddressToMClaimableAccountMap[morseOutputAddress] = claimableMorseNode
 			}
+		}
+
+		if ownerAddressToMClaimableAccountMap[morseOutputAddress] == nil {
+			return fmt.Errorf("failed to load MorseClaimableAccount for owner address '%s'", morseOutputAddress)
 		}
 
 		// Create a new Shannon account for the migration:

--- a/x/migration/module/cmd/claim_morse_supplier_bulk.go
+++ b/x/migration/module/cmd/claim_morse_supplier_bulk.go
@@ -242,7 +242,7 @@ func runClaimSuppliers(cmd *cobra.Command, _ []string) error {
 	}()
 
 	// Read Morse private keys from file and ensure its not empty.
-	morseNodeAccounts, nodeMorseKeysErr := getMorseAccountsFromFile(flagInputFilePath)
+	morseNodeAccounts, nodeMorseKeysErr := getMorseAccountsFromFile(flagMorsePrivateKeysFile)
 	if nodeMorseKeysErr != nil {
 		return nodeMorseKeysErr
 	}
@@ -324,7 +324,7 @@ func runClaimSuppliers(cmd *cobra.Command, _ []string) error {
 			shannonOwnerAddress = morseShannonMapping.ShannonAccount.Address.String()
 		} else {
 			// Non-custodial: use the MorseSrcAddress as the owner address
-			shannonOwnerAddress = ownerAddressToMClaimableAccountMap[morseOutputAddress].MorseSrcAddress
+			shannonOwnerAddress = ownerAddressToMClaimableAccountMap[morseOutputAddress].ShannonDestAddress
 		}
 
 		// Build the supplier stake config for this migration.


### PR DESCRIPTION
## Summary

Update file paths and key mapping logic in the Morse supplier migration command

### Primary Changes:

- Fix variable reference
- Fix wrong owner address assignation

## Issue

- CLI drop error file not found
- CLI drop error about wrong owner address format

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
