### PR TITLE
[SDK] Bump shannon-sdk version to latest main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,7 +103,7 @@ require (
 	// This is creating a circular dependency whereby exporting the protobufs into a separate
 	// repo is the first obvious idea, but has to be carefully considered, automated, and is not
 	// a hard blocker.
-	github.com/pokt-network/shannon-sdk v0.0.0-20250601170546-785400478d5f
+	github.com/pokt-network/shannon-sdk v0.0.0-20250603210336-969a825fddd5
 	go.uber.org/mock v0.5.2
 	golang.org/x/term v0.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1289,6 +1289,8 @@ github.com/pokt-network/ring-go v0.1.0 h1:hF7mDR4VVCIqqDAsrloP8azM9y1mprc99YgnTj
 github.com/pokt-network/ring-go v0.1.0/go.mod h1:8NHPH7H3EwrPX3XHfpyRI6bz4gApkE3+fd0XZRbMWP0=
 github.com/pokt-network/shannon-sdk v0.0.0-20250601170546-785400478d5f h1:coffZEKJSgpOCL4o8TqhzFInoOhJZ7bI8rMlhnkKI+w=
 github.com/pokt-network/shannon-sdk v0.0.0-20250601170546-785400478d5f/go.mod h1:2EAmqCZ/gcNGhycZeWMkrtmdpRzfMAJh2//XRS1Mzqs=
+github.com/pokt-network/shannon-sdk v0.0.0-20250603210336-969a825fddd5 h1:TTtN4ln+AWWPb8wbUZESAyZqUWFxV/kQNkNCEE6FgmM=
+github.com/pokt-network/shannon-sdk v0.0.0-20250603210336-969a825fddd5/go.mod h1:D7ZoOsLtOzDD7Vj9bnIIPFDbqfcUBR0Ic995vyfbdQM=
 github.com/pokt-network/smt v0.13.0 h1:C2F8FlJh34aU+DVeRU/Bt8BOkFXn4QjWMK+nbT9PUj4=
 github.com/pokt-network/smt v0.13.0/go.mod h1:S4Ho4OPkK2v2vUCHNtA49XDjqUC/OFYpBbynRVYmxvA=
 github.com/pokt-network/smt/kvstore/pebble v0.0.0-20240822175047-21ea8639c188 h1:QK1WmFKQ/OzNVob/br55Brh+EFbWhcdq41WGC8UMihM=


### PR DESCRIPTION
## Summary

Update the `go.mod` file to upgrade the version of the `shannon-sdk` dependency.

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [x] For small changes: `make go_develop_and_test` and `make test_e2e`
- [x] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
