### PR TITLE
[RelayMiner] RelayMeter coin substraction panic

### DIFF
--- a/pkg/relayer/proxy/relay_meter.go
+++ b/pkg/relayer/proxy/relay_meter.go
@@ -197,13 +197,17 @@ func (rmtr *ProxyRelayMeter) ShouldRateLimit(ctx context.Context, reqMeta servic
 		maxAllowedOverServicing := appRelayMeter.maxCoin.Add(rmtr.overServicingAllowanceCoins)
 		if maxAllowedOverServicing.IsLT(newConsumedCoin) {
 			rmtr.logger.Warn().Msgf(
-				"application has been rate limited, stake needed: %s, has: %s",
+				"application with address %q has been rate limited, stake needed: (%s), has: (%s)",
+				reqMeta.SessionHeader.ApplicationAddress,
 				newConsumedCoin.String(),
-				appRelayMeter.maxCoin.String(),
+				maxAllowedOverServicing.String(),
 			)
 			return true
 		}
 	}
+
+	// Update the consumed coin amount to reflect the over-servicing.
+	appRelayMeter.consumedCoin = newConsumedCoin
 
 	appRelayMeter.numOverServicedRelays++
 	appRelayMeter.numOverServicedComputeUnits += appRelayMeter.service.ComputeUnitsPerRelay
@@ -250,6 +254,15 @@ func (rmtr *ProxyRelayMeter) SetNonApplicableRelayReward(ctx context.Context, re
 		)
 	}
 
+	// TODO_FOLLOWUP(@red-0ne): Consider fixing the relay meter logic to never have
+	// a less than relay cost consumed amount.
+	if sessionRelayMeter.consumedCoin.IsLT(relayCost) {
+		rmtr.logger.Warn().Msgf(
+			"[Non critical] Unable to decrease consumed stake amount for application %q",
+			sessionRelayMeter.app.GetAddress(),
+		)
+		return
+	}
 	// Decrease the consumed stake amount by relay cost.
 	newConsumedAmount := sessionRelayMeter.consumedCoin.Sub(relayCost)
 


### PR DESCRIPTION
## Summary

Prevent the `RelayMeter` to panic due to invalid coin subtraction 

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
