### PR TITLE
[Bug] Non deterministic proof validation

### DIFF
--- a/pkg/crypto/rand/float.go
+++ b/pkg/crypto/rand/float.go
@@ -2,6 +2,7 @@ package rand
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/binary"
 	"math/rand"
 
@@ -9,7 +10,7 @@ import (
 )
 
 // SeededFloat64 generates a deterministic float64 between 0 and 1 given a seed.
-//
+
 // TODO_MAINNET: To support other language implementations of the protocol, the
 // pseudo-random number generator used here should be language-agnostic (i.e. not
 // golang specific).
@@ -22,4 +23,15 @@ func SeededFloat64(seedParts ...[]byte) float64 {
 	pseudoRand := rand.New(rand.NewSource(seed))
 
 	return pseudoRand.Float64()
+}
+
+func DeterministicFloat64(seedParts ...[]byte) float64 {
+	// Join seed parts
+	seedBytes := bytes.Join(seedParts, nil)
+	// Hash to fixed 32-byte output
+	hash := sha256.Sum256(seedBytes)
+	// Use first 8 bytes as uint64
+	num := binary.BigEndian.Uint64(hash[0:8])
+	// Normalize to [0,1)
+	return float64(num) / float64(^uint64(0))
 }

--- a/proto/pocket/proof/types.proto
+++ b/proto/pocket/proof/types.proto
@@ -15,26 +15,26 @@ import "gogoproto/gogo.proto";
 
 message Proof {
   // Address of the supplier's operator that submitted this proof.
-  string supplier_operator_address = 1 [(gogoproto.nullable) = false, (cosmos_proto.scalar) = "cosmos.AddressString"];
+  string supplier_operator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
   // The session header of the session that this claim is for.
-  pocket.session.SessionHeader session_header = 2 [(gogoproto.nullable) = false];
+  pocket.session.SessionHeader session_header = 2;
   // The serialized SMST compacted proof from the `#ClosestProof()` method.
-  bytes closest_merkle_proof = 3 [(gogoproto.nullable) = false];
+  bytes closest_merkle_proof = 3;
 }
 
 // Claim is the serialized object stored onchain for claims pending to be proven
 message Claim {
   // Address of the supplier's operator that submitted this claim.
-  string supplier_operator_address = 1 [(gogoproto.nullable) = false, (cosmos_proto.scalar) = "cosmos.AddressString"]; // the address of the supplier's operator that submitted this claim
+  string supplier_operator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"]; // the address of the supplier's operator that submitted this claim
 
   // Session header this claim is for.
-  pocket.session.SessionHeader session_header = 2 [(gogoproto.nullable) = false];
+  pocket.session.SessionHeader session_header = 2;
 
   // Root hash from smt.SMST#Root().
-  bytes root_hash = 3 [(gogoproto.nullable) = false];
+  bytes root_hash = 3;
 
   // Important: This field MUST only be set by proofKeeper#EnsureValidProofSignaturesAndClosestPath
-  ClaimProofStatus proof_validation_status = 4 [(gogoproto.nullable) = false];
+  ClaimProofStatus proof_validation_status = 4;
 }
 
 enum ProofRequirementReason {

--- a/proto/pocket/proof/types.proto
+++ b/proto/pocket/proof/types.proto
@@ -15,26 +15,26 @@ import "gogoproto/gogo.proto";
 
 message Proof {
   // Address of the supplier's operator that submitted this proof.
-  string supplier_operator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string supplier_operator_address = 1 [(gogoproto.nullable) = false, (cosmos_proto.scalar) = "cosmos.AddressString"];
   // The session header of the session that this claim is for.
-  pocket.session.SessionHeader session_header = 2;
+  pocket.session.SessionHeader session_header = 2 [(gogoproto.nullable) = false];
   // The serialized SMST compacted proof from the `#ClosestProof()` method.
-  bytes closest_merkle_proof = 3;
+  bytes closest_merkle_proof = 3 [(gogoproto.nullable) = false];
 }
 
 // Claim is the serialized object stored onchain for claims pending to be proven
 message Claim {
   // Address of the supplier's operator that submitted this claim.
-  string supplier_operator_address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"]; // the address of the supplier's operator that submitted this claim
+  string supplier_operator_address = 1 [(gogoproto.nullable) = false, (cosmos_proto.scalar) = "cosmos.AddressString"]; // the address of the supplier's operator that submitted this claim
 
   // Session header this claim is for.
-  pocket.session.SessionHeader session_header = 2;
+  pocket.session.SessionHeader session_header = 2 [(gogoproto.nullable) = false];
 
   // Root hash from smt.SMST#Root().
-  bytes root_hash = 3;
+  bytes root_hash = 3 [(gogoproto.nullable) = false];
 
   // Important: This field MUST only be set by proofKeeper#EnsureValidProofSignaturesAndClosestPath
-  ClaimProofStatus proof_validation_status = 4;
+  ClaimProofStatus proof_validation_status = 4 [(gogoproto.nullable) = false];
 }
 
 enum ProofRequirementReason {

--- a/x/proof/keeper/msg_server_submit_proof.go
+++ b/x/proof/keeper/msg_server_submit_proof.go
@@ -128,7 +128,13 @@ func (k msgServer) SubmitProof(
 	relayMiningDifficulty, _ := k.serviceKeeper.GetRelayMiningDifficulty(ctx, serviceId)
 
 	claimedUPOKT, err := claim.GetClaimeduPOKT(sharedParams, relayMiningDifficulty)
+	if err != nil {
+		return nil, status.Error(codes.Internal, types.ErrProofInvalidClaimRootHash.Wrap(err.Error()).Error())
+	}
 	numEstimatedComputeUnits, err := claim.GetNumEstimatedComputeUnits(relayMiningDifficulty)
+	if err != nil {
+		return nil, status.Error(codes.Internal, types.ErrProofInvalidClaimRootHash.Wrap(err.Error()).Error())
+	}
 
 	// Check if a prior proof already exists.
 	_, isExistingProof = k.GetProof(ctx, proof.SessionHeader.SessionId, proof.SupplierOperatorAddress)


### PR DESCRIPTION
## Summary
Implement deterministic proof validation by processing proofs in consistent order and moving non-concurrency safe operations outside goroutines

### Primary Changes:
• Refactor proof validation to process results in deterministic order using `proofKeys` slice
• Move event emission and claim persistence outside goroutines to ensure deterministic execution flow
• Replace `processedProofs` map with `validationResult` struct and result map for coordinated validation

### Secondary changes:
• Add `crypto/sha256` import for deterministic hashing
• Introduce `validationResult` struct to capture validation outcomes
• Add mutex protection around `GetClaim()` calls in validation goroutines
• Improve logging with proof keys for better traceability

## Issue:

The issue is likely caused by the order at which the `EventProofValidityChecked` are emitted by the concurrent proof validation.

![image](https://github.com/user-attachments/assets/784cd2be-95df-45e0-ac85-cb47de61c88c)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [x] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
