### PR TITLE
[Upgrade] chore: prepare v0.1.16 onchain upgrade

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -78,10 +78,10 @@ var allUpgrades = []upgrades.Upgrade{
 	// - Add compute units validation in claim settlement to prevent chain halts when CUPR params change (#1407)
 	// upgrades.Upgrade_0_1_15,
 
-	// vNext - upgrade to:
+	// v0.1.16 - upgrade to:
 	// - Normalize Morse accounts recovery allowlist addresses (to uppercase).
 	// - Normalize Morse source address when handling Morse account recovery message.
-	upgrades.Upgrade_NEXT,
+	upgrades.Upgrade_0_1_16,
 }
 
 // setUpgrades sets upgrade handlers for all upgrades and executes KVStore migration if an upgrade plan file exists.

--- a/app/upgrades/v0.1.16.go
+++ b/app/upgrades/v0.1.16.go
@@ -1,0 +1,59 @@
+package upgrades
+
+import (
+	"context"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/pokt-network/poktroll/app/keepers"
+)
+
+// TODO_NEXT_UPGRADE: Rename NEXT with the appropriate next
+// upgrade version number and update comment versions.
+
+const (
+	Upgrade_0_1_16_PlanName = "v0.1.16"
+)
+
+// Upgrade_0_1_16 handles the upgrade to release `v0.1.16`.
+// - Normalize Morse accounts recovery allowlist addresses (to uppercase).
+// - Normalize Morse source address when handling Morse account recovery message.
+var Upgrade_0_1_16 = Upgrade{
+	PlanName: Upgrade_0_1_16_PlanName,
+	// No KVStore migrations in this upgrade.
+	StoreUpgrades: storetypes.StoreUpgrades{},
+
+	// Upgrade Handler
+	CreateUpgradeHandler: func(
+		mm *module.Manager,
+		keepers *keepers.Keepers,
+		configurator module.Configurator,
+	) upgradetypes.UpgradeHandler {
+		// Add new parameters by:
+		// 1. Inspecting the diff between v0.1.15..v0.1.16
+		// 2. Manually inspect changes in ignite's config.yml
+		// 3. Update the upgrade handler here accordingly
+		// Ref: https://github.com/pokt-network/poktroll/compare/v0.1.15..v0.1.16
+
+		return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+			logger := cosmostypes.UnwrapSDKContext(ctx).Logger()
+
+			// Adds new authz that were previously incorrect. See #1425
+			// These can be validated like so:
+			// pocketd query authz grants-by-granter <addr> --network=<network> -o json --grpc-insecure=false
+			// 	| jq '.grants[]|select(.authorization.value.msg == "/pocket.migration.MsgRecoverMorseAccount")'
+			grantAuthorizationMessages := []string{
+				"/pocket.migration.MsgUpdateParams",
+				"/pocket.service.MsgRecoverMorseAccount",
+			}
+			if err := applyNewAuthorizations(ctx, keepers, logger, grantAuthorizationMessages); err != nil {
+				return vm, err
+			}
+
+			return vm, nil
+		}
+	},
+}

--- a/app/upgrades/v0.1.16.go
+++ b/app/upgrades/v0.1.16.go
@@ -11,9 +11,6 @@ import (
 	"github.com/pokt-network/poktroll/app/keepers"
 )
 
-// TODO_NEXT_UPGRADE: Rename NEXT with the appropriate next
-// upgrade version number and update comment versions.
-
 const (
 	Upgrade_0_1_16_PlanName = "v0.1.16"
 )

--- a/app/upgrades/vNEXT.go
+++ b/app/upgrades/vNEXT.go
@@ -1,22 +1,23 @@
-// vNEXT_.go - Canonical Upgrade
+// vNEXT_Template.go - Canonical Upgrade Template
 //
 // ────────────────────────────────────────────────────────────────
-//
-//	PURPOSE:
-//	 - This file is the canonical  for all future onchain upgrade files in the poktroll repo.
-//	 - DO NOT add upgrade-specific logic or changes to this file.
-//	 - YOU SHOULD NEVER NEED TO CHANGE THIS FILE
+// TEMPLATE PURPOSE:
+//   - This file is the canonical TEMPLATE for all future onchain upgrade files in the poktroll repo.
+//   - DO NOT add upgrade-specific logic or changes to this file.
+//   - YOU SHOULD NEVER NEED TO CHANGE THIS FILE
 //
 // USAGE INSTRUCTIONS:
-//  1. To start a new upgrade cycle, copy this file to vNEXT.go:
-//     cp ./app/upgrades/vNEXT_.go ./app/upgrades/vNEXT.go
-//  2. Look for the word "" in `vNEXT.go` and replace it with an empty string.
-//  3. Make all upgrade-specific changes in vNEXT.go only.
-//  4. When an upgrade is finalized, rename vNEXT.go to the target version (e.g., v0.1.14.go) and update all identifiers accordingly.
-//  5. To reset, restore, or start a new upgrade cycle, repeat step 1.
+//  1. To start a new upgrade cycle, rename vNEXT.go to the target version (e.g., v0.1.14.go) and update all identifiers accordingly:
+//     cp ./app/upgrades/vNEXT.go ./app/upgrades/v0.1.14.go
+//  2. Then, copy this file to vNEXT.go:
+//     cp ./app/upgrades/vNEXT_Template.go ./app/upgrades/vNEXT.go
+//  3. Look for the word "Template" in `vNEXT.go` and replace it with an empty string.
+//  4. Make all upgrade-specific changes in vNEXT.go only.
+//  5. To reset, restore, or start a new upgrade cycle, repeat fromstep 1.
+//  6. Update the last entry in the `allUpgrades` slice in `app/upgrades.go` to point to the new upgrade version variable.
 //
-// vNEXT_.go should NEVER be modified for upgrade-specific logic.
-// Only update this file to improve the  itself.
+// vNEXT_Template.go should NEVER be modified for upgrade-specific logic.
+// Only update this file to improve the template itself.
 //
 //	See also: https://github.com/pokt-network/poktroll/compare/vPREV..vNEXT
 //
@@ -28,7 +29,6 @@ import (
 
 	storetypes "cosmossdk.io/store/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
-	cosmostypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
 	"github.com/pokt-network/poktroll/app/keepers"
@@ -42,8 +42,8 @@ const (
 )
 
 // Upgrade_NEXT handles the upgrade to release `vNEXT`.
-// - Normalize Morse accounts recovery allowlist addresses (to uppercase).
-// - Normalize Morse source address when handling Morse account recovery message.
+// This upgrade adds:
+// - ...
 var Upgrade_NEXT = Upgrade{
 	PlanName: Upgrade_NEXT_PlanName,
 	// No KVStore migrations in this upgrade.
@@ -62,20 +62,6 @@ var Upgrade_NEXT = Upgrade{
 		// Ref: https://github.com/pokt-network/poktroll/compare/vPREV..vNEXT
 
 		return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
-			logger := cosmostypes.UnwrapSDKContext(ctx).Logger()
-
-			// Adds new authz that were previously incorrect. See #1425
-			// These can be validated like so:
-			// pocketd query authz grants-by-granter <addr> --network=<network> -o json --grpc-insecure=false
-			// 	| jq '.grants[]|select(.authorization.value.msg == "/pocket.migration.MsgRecoverMorseAccount")'
-			grantAuthorizationMessages := []string{
-				"/pocket.migration.MsgUpdateParams",
-				"/pocket.service.MsgRecoverMorseAccount",
-			}
-			if err := applyNewAuthorizations(ctx, keepers, logger, grantAuthorizationMessages); err != nil {
-				return vm, err
-			}
-
 			return vm, nil
 		}
 	},

--- a/app/upgrades/vNEXT_Template.go
+++ b/app/upgrades/vNEXT_Template.go
@@ -7,12 +7,14 @@
 //   - YOU SHOULD NEVER NEED TO CHANGE THIS FILE
 //
 // USAGE INSTRUCTIONS:
-//  1. To start a new upgrade cycle, copy this file to vNEXT.go:
+//  1. To start a new upgrade cycle, rename vNEXT.go to the target version (e.g., v0.1.14.go) and update all identifiers accordingly:
+//     cp ./app/upgrades/vNEXT.go ./app/upgrades/v0.1.14.go
+//  2. Then, copy this file to vNEXT.go:
 //     cp ./app/upgrades/vNEXT_Template.go ./app/upgrades/vNEXT.go
-//  2. Look for the word "Template" in `vNEXT.go` and replace it with an empty string.
-//  3. Make all upgrade-specific changes in vNEXT.go only.
-//  4. When an upgrade is finalized, rename vNEXT.go to the target version (e.g., v0.1.14.go) and update all identifiers accordingly.
-//  5. To reset, restore, or start a new upgrade cycle, repeat step 1.
+//  3. Look for the word "Template" in `vNEXT.go` and replace it with an empty string.
+//  4. Make all upgrade-specific changes in vNEXT.go only.
+//  5. To reset, restore, or start a new upgrade cycle, repeat fromstep 1.
+//  6. Update the last entry in the `allUpgrades` slice in `app/upgrades.go` to point to the new upgrade version variable.
 //
 // vNEXT_Template.go should NEVER be modified for upgrade-specific logic.
 // Only update this file to improve the template itself.


### PR DESCRIPTION
## Summary

Prepare v0.1.16 onchain upgrade. 

## Issue

- #1421

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Other (specify): onchain upgrade

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
