### PR TITLE
[CLI] Add advanced customization flags for bulk commands.

### DIFF
--- a/x/migration/module/cmd/claim_morse_account_bulk.go
+++ b/x/migration/module/cmd/claim_morse_account_bulk.go
@@ -523,7 +523,7 @@ func mappingAccounts(
 		// Import Shannon private key into keyring.
 		morseShannonMapping.ShannonAccount.KeyringName = morseShannonMapping.ShannonAccount.Address.String()
 		logger.Logger.Info().
-			Str("name", morseShannonMapping.ShannonAccount.KeyringName).
+			Str("keyring_name", morseShannonMapping.ShannonAccount.KeyringName).
 			Str("morse_node_address", hex.EncodeToString(morseAccount.Address)).
 			Str("shannon_operator_address", morseShannonMapping.ShannonAccount.KeyringName).
 			Msg("Storing shannon operator address into the keyring")

--- a/x/migration/module/cmd/claim_morse_account_bulk.go
+++ b/x/migration/module/cmd/claim_morse_account_bulk.go
@@ -150,6 +150,7 @@ For more information, see: https://dev.poktroll.com/operate/morse_migration/clai
 		false,
 		"Export unarmored hex privkey. Requires --unsafe.")
 
+	// Shannon destination address for all funds
 	claimAcctBulkCmd.Flags().StringVar(&flagDestination, flagDestinationName, "", flagDestinationDesc)
 
 	// Flag for dry run mode.

--- a/x/migration/module/cmd/claim_morse_account_bulk.go
+++ b/x/migration/module/cmd/claim_morse_account_bulk.go
@@ -57,7 +57,7 @@ $ pocketd tx migration claim-accounts \
   --unsafe \
   --unarmored-json
 
-3. Set same Destination for many accounts and avoid creating new wallets for each account (like operators claiming remaining pocket on operation wallets):
+3. Set the same Destination for many accounts and avoid creating new wallets for each account (like operators claiming remaining pocket on operation wallets):
 
 $ pocketd tx migration claim-accounts \
   --input-file ./bulk-accounts.json \

--- a/x/migration/module/cmd/claim_morse_account_bulk.go
+++ b/x/migration/module/cmd/claim_morse_account_bulk.go
@@ -490,7 +490,6 @@ func mappingAccounts(
 		// mock empty private key
 		shannonPrivateKey = &secp256k1.PrivKey{}
 	} else {
-		// otherwise create a new shannon key
 		// Create a new Shannon account
 		// 1. Generate a secp256k1 private key
 		shannonPrivateKey = secp256k1.GenPrivKey()

--- a/x/migration/module/cmd/claim_morse_account_bulk.go
+++ b/x/migration/module/cmd/claim_morse_account_bulk.go
@@ -67,7 +67,7 @@ $ pocketd tx migration claim-accounts \
   --keyring-backend test \
   --unsafe \
   --unarmored-json \
-  --destination <SHANNON-ADDRESS> # This is the new here (BE CAREFUL WHAT YOU SET HERE)
+  --destination <SHANNON-ADDRESS> # MAKE SURE YOU HAVE THE PRIVATE KEYS FOR THIS ADDRESS
 `,
 		Short: "Claim many Morse accounts as unstaked accounts (i.e. non-actor, balance only account)",
 		Long: `Claim many Morse accounts as unstaked accounts (i.e. non-actor, balance only account).

--- a/x/migration/module/cmd/claim_morse_account_bulk.go
+++ b/x/migration/module/cmd/claim_morse_account_bulk.go
@@ -476,7 +476,7 @@ func mappingAccounts(
 	var destinationReadErr error
 	var hasDestination bool
 
-	// assign morse to this one
+	// Check if a shannon address was specified or if a new key should be generated
 	if flagDestination != "" {
 		shannonAddress, destinationReadErr = sdk.AccAddressFromBech32(flagDestination)
 		if destinationReadErr != nil {

--- a/x/migration/module/cmd/claim_morse_account_bulk.go
+++ b/x/migration/module/cmd/claim_morse_account_bulk.go
@@ -135,21 +135,25 @@ For more information, see: https://dev.poktroll.com/operate/morse_migration/clai
 // marshalAccountInfo serializes account info to JSON.
 // - Includes private key if both --unsafe and --unarmored-json are set.
 // - Otherwise, only address is included.
-func marshalAccountInfo(address string, privateKey []byte) ([]byte, error) {
+func marshalAccountInfo(address string, privateKey []byte, keyringName string) ([]byte, error) {
 	// Prepare the unsafe struct in the case both --unsafe and --unarmored-json are set.
 	unsafeStruct := struct {
-		Address    string `json:"address"`
-		PrivateKey string `json:"private_key"`
+		Address     string `json:"address"`
+		PrivateKey  string `json:"private_key"`
+		KeyringName string `json:"keyring,omitempty"`
 	}{
-		Address:    address,
-		PrivateKey: hex.EncodeToString(privateKey),
+		Address:     address,
+		PrivateKey:  hex.EncodeToString(privateKey),
+		KeyringName: keyringName,
 	}
 
 	// Prepare the safe struct in the case only --unarmored-json is set.
 	safeStruct := struct {
-		Address string `json:"address"`
+		Address     string `json:"address"`
+		KeyringName string `json:"keyring,omitempty"`
 	}{
-		Address: address,
+		Address:     address,
+		KeyringName: keyringName,
 	}
 
 	// Marshal the struct based on the flags.
@@ -444,9 +448,9 @@ func mappingAccounts(
 	}
 
 	// Import Shannon private key into keyring.
-	name := morseShannonMapping.ShannonAccount.Address.String()
+	morseShannonMapping.ShannonAccount.KeyringName = morseShannonMapping.ShannonAccount.Address.String()
 	keyringErr := clientCtx.Keyring.ImportPrivKeyHex(
-		name,
+		morseShannonMapping.ShannonAccount.KeyringName,
 		hex.EncodeToString(morseShannonMapping.ShannonAccount.PrivateKey.Key),
 		"secp256k1",
 	)

--- a/x/migration/module/cmd/claim_morse_account_bulk.go
+++ b/x/migration/module/cmd/claim_morse_account_bulk.go
@@ -533,7 +533,7 @@ func mappingAccounts(
 			"secp256k1",
 		)
 		if keyringErr != nil {
-			logger.Logger.Error().Msg("failed to import private key for shannon account, please check the logs and try again")
+			logger.Logger.Error().Err(keyringErr).Msg("failed to import private key for shannon account. Please check the logs and try again")
 			return morseShannonMapping, keyringErr
 		}
 	}

--- a/x/migration/module/cmd/claim_morse_account_bulk.go
+++ b/x/migration/module/cmd/claim_morse_account_bulk.go
@@ -526,7 +526,7 @@ func mappingAccounts(
 			Str("keyring_name", morseShannonMapping.ShannonAccount.KeyringName).
 			Str("morse_node_address", hex.EncodeToString(morseAccount.Address)).
 			Str("shannon_operator_address", morseShannonMapping.ShannonAccount.KeyringName).
-			Msg("Storing shannon operator address into the keyring")
+			Msg("Storing shannon operator address in thekeyring")
 		keyringErr := clientCtx.Keyring.ImportPrivKeyHex(
 			morseShannonMapping.ShannonAccount.KeyringName,
 			hex.EncodeToString(morseShannonMapping.ShannonAccount.PrivateKey.Key),

--- a/x/migration/module/cmd/claim_morse_account_bulk.go
+++ b/x/migration/module/cmd/claim_morse_account_bulk.go
@@ -336,7 +336,7 @@ func runBulkClaimAccount(cmd *cobra.Command, _ []string) error {
 	if flagDryRunClaim {
 		logger.Logger.Info().
 			Str("path", flagOutputFilePath).
-			Msg("tx will not be broadcasted due to: '--dry-run-claim=true' so please check output file for more details.")
+			Msg("tx IS NOT being broadcasted because: '--dry-run-claim=true'.")
 		return nil
 	}
 

--- a/x/migration/module/cmd/claim_morse_account_bulk.go
+++ b/x/migration/module/cmd/claim_morse_account_bulk.go
@@ -518,8 +518,8 @@ func mappingAccounts(
 		return morseShannonMapping, nil
 	}
 
+	// If an explicit shannon dest address was not specified, the newly generated private key MUST be stored.
 	if !hasDestination {
-		// we need to store the pk
 		// Import Shannon private key into keyring.
 		morseShannonMapping.ShannonAccount.KeyringName = morseShannonMapping.ShannonAccount.Address.String()
 		logger.Logger.Info().

--- a/x/migration/module/cmd/claim_morse_supplier_bulk.go
+++ b/x/migration/module/cmd/claim_morse_supplier_bulk.go
@@ -382,10 +382,13 @@ func runClaimSuppliers(cmd *cobra.Command, _ []string) error {
 		// Import the generated Shannon private key into the keyring.
 		keyName := shannonOperatorAddress
 		if flagNewKeyPrefix != "" {
+			// Default suffix is the address
 			suffix := shannonOperatorAddress
+			// Override the default suffix if the index flag is provided
 			if flagUseIndexNames {
 				suffix = fmt.Sprintf("%d", i)
 			}
+			// The final keyring name is: 'prefix-idx' or 'prefix-address'
 			keyName = fmt.Sprintf("%s-%s", flagNewKeyPrefix, suffix)
 		}
 		morseShannonMapping.ShannonAccount.KeyringName = keyName

--- a/x/migration/module/cmd/claim_morse_supplier_bulk.go
+++ b/x/migration/module/cmd/claim_morse_supplier_bulk.go
@@ -670,8 +670,8 @@ func updateRevShareMapToFullAllocation(owner, operator string, revShareMap map[s
 		}
 	}
 
-	// allows operator to be automatically added to the share map to fund on everytime it gets rewards
-	// this avoids the need to send funds from time to time and also avoids incur in network feeds for those sending.
+	// Allows the operator to automatically be added to the revshare map to get funds on every reward.
+	// This covers the operator's tx fees and increases their rewards.
 	if flagAddOperatorShare > 0 && !operatorFound {
 		if totalShare > 100 {
 			return nil, fmt.Errorf("total revenue share is > 100%")

--- a/x/migration/module/cmd/claim_morse_supplier_bulk.go
+++ b/x/migration/module/cmd/claim_morse_supplier_bulk.go
@@ -80,8 +80,8 @@ What this command does:
 
 Additional options:
 1. Supports a '--dry-run-claim' mode that simulates the transaction but doesn't broadcast it onchain.
-2. Supports '--add-operator-share=[INT]' which adds operator rev share automatically. Useful to ensure operator wallet has always funds to work.
-3. Supports '--name-prefix-pattern=[prefix]' which will add that prefix to the name used to store the key on the keyring. Results will looks like: '[PREFIX]-[ADDRESS]'
+2. Supports '--add-operator-share=[INT]' which adds operator rev share automatically. Useful to ensure the operator wallet always has funds to work.
+3. Supports '--name-prefix-pattern=[prefix]' which adds a prefix to the name used to store the key on the keyring. Results will looks like: '[PREFIX]-[ADDRESS]'
 4. Supports '--use-index-names' which will replace the ADDRESS as suffix to use the index of the node in the list. Results will looks like: '[PREFIX]-[INDEX]'
 5. Enables exporting unarmored (plain) JSON output with sensitive keys.
 

--- a/x/migration/module/cmd/claim_morse_supplier_bulk.go
+++ b/x/migration/module/cmd/claim_morse_supplier_bulk.go
@@ -428,7 +428,7 @@ func runClaimSuppliers(cmd *cobra.Command, _ []string) error {
 	if flagDryRunClaim {
 		logger.Logger.Info().
 			Str("path", flagOutputFilePath).
-			Msg("tx will not be broadcasted due to: '--dry-run-claim=true' so please check output file for more details.")
+			Msg("tx IS NOT being broadcasted because: '--dry-run-claim=true'.")details.")
 		return nil
 	}
 

--- a/x/migration/module/cmd/claim_morse_supplier_bulk.go
+++ b/x/migration/module/cmd/claim_morse_supplier_bulk.go
@@ -428,7 +428,7 @@ func runClaimSuppliers(cmd *cobra.Command, _ []string) error {
 	if flagDryRunClaim {
 		logger.Logger.Info().
 			Str("path", flagOutputFilePath).
-			Msg("tx IS NOT being broadcasted because: '--dry-run-claim=true'.")details.")
+			Msg("tx IS NOT being broadcasted because: '--dry-run-claim=true'.")
 		return nil
 	}
 

--- a/x/migration/module/cmd/claim_morse_supplier_bulk.go
+++ b/x/migration/module/cmd/claim_morse_supplier_bulk.go
@@ -171,6 +171,7 @@ More info: https://dev.poktroll.com/operate/morse_migration/claiming`,
 	// Flags to export private keys in the output file.
 	claimSuppliersCmd.Flags().BoolVar(&flagUnsafe, FlagUnsafe, false, FlagUnsafeDesc)
 	claimSuppliersCmd.Flags().BoolVar(&flagUnarmoredJSON, FlagUnarmoredJSON, false, FlagUnarmoredJSONDesc)
+
 	// Flags to customize the new Shannon account.
 	claimSuppliersCmd.Flags().StringVar(&flagNewKeyPrefix, flagNewKeyPrefixName, "", flagNewKeyPrefixDesc)
 	claimSuppliersCmd.Flags().Uint64Var(&flagAddOperatorShare, flagAddOperatorShareName, 0, flagAddOperatorShareDesc)

--- a/x/migration/module/cmd/claim_morse_supplier_bulk.go
+++ b/x/migration/module/cmd/claim_morse_supplier_bulk.go
@@ -269,7 +269,7 @@ func runClaimSuppliers(cmd *cobra.Command, _ []string) error {
 	ownerAddressToMClaimableAccountMap := map[string]*types.MorseClaimableAccount{}
 
 	// Iterate over each Morse node private key to process migration.
-	for i, morseNodeAccount := range morseNodeAccounts {
+	for idx, morseNodeAccount := range morseNodeAccounts {
 		morseNodeAddress := hex.EncodeToString(morseNodeAccount.Address)
 
 		// Ensure the Morse output address is not empty (i.e., is a node)

--- a/x/migration/module/cmd/claim_morse_supplier_bulk.go
+++ b/x/migration/module/cmd/claim_morse_supplier_bulk.go
@@ -201,7 +201,7 @@ More info: https://dev.poktroll.com/operate/morse_migration/claiming`,
 // - Prepares and submits claim transactions.
 // - Handles output and error reporting.
 func runClaimSuppliers(cmd *cobra.Command, _ []string) error {
-	logger.Logger.Info().Msg("Initializing claim suppliers process...")
+	logger.Logger.Info().Msg("Starting the bulk claim-suppliers process...")
 	ctx := cmd.Context()
 
 	// Derive a cosmos-sdk client context from the cobra command.

--- a/x/migration/module/cmd/types.go
+++ b/x/migration/module/cmd/types.go
@@ -30,7 +30,7 @@ type MorseAccountInfo struct {
 // - Includes private key if unsafe/unarmored flags are set.
 func (m MorseAccountInfo) MarshalJSON() ([]byte, error) {
 	addressStr := hex.EncodeToString(m.Address)
-	return marshalAccountInfo(addressStr, m.PrivateKey)
+	return marshalAccountInfo(addressStr, m.PrivateKey, "")
 }
 
 // ShannonAccountInfo holds Shannon account data.
@@ -41,13 +41,16 @@ type ShannonAccountInfo struct {
 
 	// PrivateKey is the Shannon account private key in secp256k1 format.
 	PrivateKey secp256k1.PrivKey `json:"private_key"`
+
+	// KeyringName is the name of the key in the keyring.
+	KeyringName string `json:"keyring_name"`
 }
 
 // MarshalJSON customizes ShannonAccountInfo JSON output.
 // - Includes private key if unsafe/unarmored flags are set.
 func (s ShannonAccountInfo) MarshalJSON() ([]byte, error) {
 	addressStr := s.Address.String()
-	return marshalAccountInfo(addressStr, s.PrivateKey.Bytes())
+	return marshalAccountInfo(addressStr, s.PrivateKey.Bytes(), s.KeyringName)
 }
 
 // newMorseImportWorkspace returns a new morseImportWorkspace with fields initialized to their zero values.


### PR DESCRIPTION
## Summary

Add advanced customization flags and keyring improvements for supplier migration.

### Primary Changes:

- Introduced new flags (`--add-operator-share`, `--name-prefix-pattern`, `--use-index-names`) for enhanced supplier migration configuration.
- Improved keyring integration to support dynamic key naming during migrations.
- Fixed YAML stake config handling for operator rewards and rev share allocation adjustments.
- Updated JSON serialization for accounts to include keyring name support.

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [x] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [x] 'TODO's, configurations and other docs
- [x] I have manually tested the CLI commands modified on this PR. 
