### PR TITLE
[Bug] Missing supplier service at claim settlement

### DIFF
--- a/load-testing/tests/relays_stress_helpers_test.go
+++ b/load-testing/tests/relays_stress_helpers_test.go
@@ -962,7 +962,7 @@ func (s *relaysSuite) signWithRetries(
 	// All messages have to be signed by the keyName provided.
 	// TODO_TECHDEBT: Extend the txContext to support multiple signers.
 	for i := 0; i < maxRetries; i++ {
-		err := s.txContext.SignTx(actorKeyName, txBuilder, false, false)
+		err := s.txContext.SignTx(actorKeyName, txBuilder, false, false, false)
 		if err == nil {
 			return nil
 		}

--- a/x/migration/keeper/msg_server_claim_morse_supplier.go
+++ b/x/migration/keeper/msg_server_claim_morse_supplier.go
@@ -260,6 +260,12 @@ func (k msgServer) ClaimMorseSupplier(
 		return claimMorseSupplierResponse, nil
 	}
 
+	// TODO_HACK(@olshansky, #): Ensure that claimable suppliers have valid service configs.
+	// This is a quick workaround upon encountering this issue: https://gist.github.com/okdas/3328c0c507b5dba8b31ab871589f34b0
+	if err = sharedtypes.ValidateSupplierServiceConfigs(msg.Services); err != nil {
+		return nil, err
+	}
+
 	// Stake (or update) the supplier.
 	msgStakeSupplier := suppliertypes.NewMsgStakeSupplier(
 		shannonSigningAddress.String(),

--- a/x/tokenomics/types/errors.go
+++ b/x/tokenomics/types/errors.go
@@ -23,7 +23,7 @@ var (
 	ErrTokenomicsEmittingEventFailed            = sdkerrors.Register(ModuleName, 1114, "failed to emit event")
 	ErrTokenomicsServiceNotFound                = sdkerrors.Register(ModuleName, 1115, "service not found")
 	ErrTokenomicsConstraint                     = sdkerrors.Register(ModuleName, 1116, "constraint violation")
-	ErrTokenomicsSettlementInternal             = sdkerrors.Register(ModuleName, 1117, "internal token logic module error")
+	ErrTokenomicsSettlementInternal             = sdkerrors.Register(ModuleName, 1117, "internal claim settlement error")
 	ErrTokenomicsTLMInternal                    = sdkerrors.Register(ModuleName, 1118, "internal token logic module error")
 	ErrTokenomicsProcessingTLM                  = sdkerrors.Register(ModuleName, 1119, "failed to process token logic module")
 	ErrTokenomicsCoinIsZero                     = sdkerrors.Register(ModuleName, 1120, "coin amount cannot be zero")


### PR DESCRIPTION
## Summary

Add hack to avoid trying to claim for suppliers that are not staked for the claim's servie

## Issue

- Issue_or_PR: https://gist.github.com/okdas/3328c0c507b5dba8b31ab871589f34b0

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
