### PR TITLE
[CLI] Update RelayMiner to use default tx flags

### DIFF
--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -28,19 +28,19 @@ func ParseAndSetNetworkRelatedFlags(cmd *cobra.Command) error {
 
 	// LocalNet
 	case flags.LocalNetworkName:
-		return setNetworkRelatedFlags(cmd, pocket.LocalNetChainId, pocket.LocalNetRPCURL, pocket.LocalNetGRPCAddr, pocket.LocalNetFaucetBaseURL)
+		return setNetworkRelatedFlags(cmd, pocket.LocalNetChainId, pocket.LocalNetRPCURL, pocket.LocalNetGRPCAddr, "true", pocket.LocalNetFaucetBaseURL)
 
 	// Alpha TestNet
 	case flags.AlphaNetworkName:
-		return setNetworkRelatedFlags(cmd, pocket.AlphaTestNetChainId, pocket.AlphaTestNetRPCURL, pocket.AlphaNetGRPCAddr, pocket.AlphaTestNetFaucetBaseURL)
+		return setNetworkRelatedFlags(cmd, pocket.AlphaTestNetChainId, pocket.AlphaTestNetRPCURL, pocket.AlphaNetGRPCAddr, "false", pocket.AlphaTestNetFaucetBaseURL)
 
 	// Beta TestNet
 	case flags.BetaNetworkName:
-		return setNetworkRelatedFlags(cmd, pocket.BetaTestNetChainId, pocket.BetaTestNetRPCURL, pocket.BetaNetGRPCAddr, pocket.BetaTestNetFaucetBaseURL)
+		return setNetworkRelatedFlags(cmd, pocket.BetaTestNetChainId, pocket.BetaTestNetRPCURL, pocket.BetaNetGRPCAddr, "false", pocket.BetaTestNetFaucetBaseURL)
 
 	// MainNet
 	case flags.MainNetworkName:
-		return setNetworkRelatedFlags(cmd, pocket.MainNetChainId, pocket.MainNetRPCURL, pocket.MainNetGRPCAddr, pocket.MainNetFaucetBaseURL)
+		return setNetworkRelatedFlags(cmd, pocket.MainNetChainId, pocket.MainNetRPCURL, pocket.MainNetGRPCAddr, "false", pocket.MainNetFaucetBaseURL)
 
 	default:
 		return fmt.Errorf("unknown --network specified %q", networkStr)
@@ -52,10 +52,11 @@ func ParseAndSetNetworkRelatedFlags(cmd *cobra.Command) error {
 // * --chain-id
 // * --node
 // * --grpc-addr
-// * --base-url
-//
-// DEV_NOTE: --grpc-insecure is also set, but ONLY for LocalNet.
-func setNetworkRelatedFlags(cmd *cobra.Command, chainId, nodeUrl, grpcAddr, faucetBaseUrl string) error {
+// * --grpc-insecure
+// * --faucet-base-url
+
+func setNetworkRelatedFlags(cmd *cobra.Command, chainId, nodeUrl, grpcAddr, grpcInsecure, faucetBaseUrl string) error {
+	// --chain-id flag
 	if chainIDFlag := cmd.Flags().Lookup(cosmosflags.FlagChainID); chainIDFlag != nil {
 		if !cmd.Flags().Changed(cosmosflags.FlagChainID) {
 			if err := cmd.Flags().Set(cosmosflags.FlagChainID, chainId); err != nil {
@@ -64,6 +65,7 @@ func setNetworkRelatedFlags(cmd *cobra.Command, chainId, nodeUrl, grpcAddr, fauc
 		}
 	}
 
+	// --node flag
 	if nodeFlag := cmd.Flags().Lookup(cosmosflags.FlagNode); nodeFlag != nil {
 		if !cmd.Flags().Changed(cosmosflags.FlagNode) {
 			if err := cmd.Flags().Set(cosmosflags.FlagNode, nodeUrl); err != nil {
@@ -72,6 +74,7 @@ func setNetworkRelatedFlags(cmd *cobra.Command, chainId, nodeUrl, grpcAddr, fauc
 		}
 	}
 
+	// --grpc-addr flag
 	if grpcFlag := cmd.Flags().Lookup(cosmosflags.FlagGRPC); grpcFlag != nil {
 		if !cmd.Flags().Changed(cosmosflags.FlagGRPC) {
 			if err := cmd.Flags().Set(cosmosflags.FlagGRPC, grpcAddr); err != nil {
@@ -80,21 +83,20 @@ func setNetworkRelatedFlags(cmd *cobra.Command, chainId, nodeUrl, grpcAddr, fauc
 		}
 	}
 
-	if faucetBaseURLFlag := cmd.Flags().Lookup(flags.FlagFaucetBaseURL); faucetBaseURLFlag != nil {
-		if !cmd.Flags().Changed(flags.FlagFaucetBaseURL) {
-			if err := cmd.Flags().Set(flags.FlagFaucetBaseURL, faucetBaseUrl); err != nil {
+	// --grpc-insecure flag
+	if grpcInsecureFlag := cmd.Flags().Lookup(cosmosflags.FlagGRPCInsecure); grpcInsecureFlag != nil {
+		if !cmd.Flags().Changed(cosmosflags.FlagGRPCInsecure) {
+			if err := cmd.Flags().Set(cosmosflags.FlagGRPCInsecure, grpcInsecure); err != nil {
 				return err
 			}
 		}
 	}
 
-	// Also set --grpc-insecure flag if it is registered, but ONLY for LocalNet.
-	if chainId == pocket.LocalNetChainId {
-		if grpcInsecureFlag := cmd.Flags().Lookup(cosmosflags.FlagGRPCInsecure); grpcInsecureFlag != nil {
-			if !cmd.Flags().Changed(cosmosflags.FlagGRPCInsecure) {
-				if err := cmd.Flags().Set(cosmosflags.FlagGRPCInsecure, "true"); err != nil {
-					return err
-				}
+	// --faucet-base-url flag
+	if faucetBaseURLFlag := cmd.Flags().Lookup(flags.FlagFaucetBaseURL); faucetBaseURLFlag != nil {
+		if !cmd.Flags().Changed(flags.FlagFaucetBaseURL) {
+			if err := cmd.Flags().Set(flags.FlagFaucetBaseURL, faucetBaseUrl); err != nil {
+				return err
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/go-kit/kit v0.13.0
 	github.com/gogo/status v1.1.0
 	github.com/golang/mock v1.6.0
-	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/golang/protobuf v1.5.4
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0

--- a/pkg/relayer/cmd/cmd_relay.go
+++ b/pkg/relayer/cmd/cmd_relay.go
@@ -57,7 +57,7 @@ var (
 // - Useful for local testing, debugging, and verifying Supplier setup
 // - See TODO_IMPROVE for planned enhancements
 func relayCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmdRelay := &cobra.Command{
 		Use:   "relay --app <app> --supplier <supplier> --payload <payload> [--supplier-public-endpoint-override <url>]",
 		Short: "Send a relay as an application to a particular supplier",
 		Long: `Send a test relay to a Supplier's RelayMiner from a staked Application.
@@ -99,22 +99,20 @@ For more info, run 'relay --help'.`,
 		RunE: runRelay,
 	}
 
-	// Cosmos flags
-	cmd.Flags().StringVar(&flagNodeRPCURLRelay, cosmosflags.FlagNode, "tcp://127.0.0.1:26657", "Cosmos node RPC URL (defaults to LocalNet)")
-	cmd.Flags().StringVar(&flagNodeGRPCURLRelay, cosmosflags.FlagGRPC, "localhost:9090", "Cosmos node GRPC URL (defaults to LocalNet)")
-	cmd.Flags().BoolVar(&flagNodeGRPCInsecureRelay, cosmosflags.FlagGRPCInsecure, true, "Used to initialize the Cosmos query context with grpc security options (defaults to true for LocalNet)")
-	cmd.Flags().String(cosmosflags.FlagKeyringBackend, "", "Select keyring's backend (os|file|kwallet|pass|test)")
-
 	// Custom Flags
-	cmd.Flags().StringVar(&flagRelayApp, "app", "", "(Required) Staked application address")
-	cmd.Flags().StringVar(&flagRelayPayload, "payload", "", "(Required) JSON-RPC payload")
-	cmd.Flags().StringVar(&flagRelaySupplier, "supplier", "", "(Optional) Staked Supplier address")
-	cmd.Flags().StringVar(&flagSupplierPublicEndpointOverride, "supplier-public-endpoint-override", "", "(Optional) Override the publicly exposed endpoint of the Supplier (useful for LocalNet testing)")
+	cmdRelay.Flags().StringVar(&flagRelayApp, "app", "", "(Required) Staked application address")
+	cmdRelay.Flags().StringVar(&flagRelayPayload, "payload", "", "(Required) JSON-RPC payload")
+	cmdRelay.Flags().StringVar(&flagRelaySupplier, "supplier", "", "(Optional) Staked Supplier address")
+	cmdRelay.Flags().StringVar(&flagSupplierPublicEndpointOverride, "supplier-public-endpoint-override", "", "(Optional) Override the publicly exposed endpoint of the Supplier (useful for LocalNet testing)")
 
-	_ = cmd.MarkFlagRequired("app")
-	_ = cmd.MarkFlagRequired("payload")
+	// This command depends on the conventional cosmos-sdk CLI tx flags.
+	cosmosflags.AddTxFlagsToCmd(cmdRelay)
 
-	return cmd
+	// Required flags
+	_ = cmdRelay.MarkFlagRequired("app")
+	_ = cmdRelay.MarkFlagRequired("payload")
+
+	return cmdRelay
 }
 
 // runRelay executes the relay command logic.

--- a/pkg/relayer/cmd/cmd_start.go
+++ b/pkg/relayer/cmd/cmd_start.go
@@ -72,10 +72,11 @@ func runRelayer(cmd *cobra.Command, _ []string) error {
 	ctx, cancelCtx := context.WithCancel(cmd.Context())
 	defer cancelCtx() // Ensure context cancellation
 
+	logLevel := cmd.Flag(cosmosflags.FlagLogLevel).Value.String()
 	// Set up logger options
 	// TODO_TECHDEBT: Populate logger from config (ideally, from viper).
 	loggerOpts := []polylog.LoggerOption{
-		polyzero.WithLevel(polyzero.ParseLevel(flagLogLevel)),
+		polyzero.WithLevel(polyzero.ParseLevel(logLevel)),
 		polyzero.WithOutput(os.Stderr),
 	}
 

--- a/pkg/relayer/cmd/cmd_start.go
+++ b/pkg/relayer/cmd/cmd_start.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/spf13/cobra"
 
-	"github.com/pokt-network/poktroll/cmd/flags"
 	"github.com/pokt-network/poktroll/cmd/signals"
 	"github.com/pokt-network/poktroll/pkg/deps/config"
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -30,7 +29,7 @@ import (
 // - Cache various data
 // - Rate limit incoming requests
 func startCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	cmdStart := &cobra.Command{
 		Use:   "start --config <path-to-relay-miner-config-file> --chain-id <chain-id>",
 		Short: "Start a RelayMiner",
 		Long: `Start a RelayMiner Process.
@@ -48,25 +47,18 @@ RelayMiner Responsibilities:
 	}
 
 	// Custom flags
-	cmd.Flags().StringVar(&flagRelayMinerConfig, "config", "", "(Required) The path to the relayminer config file")
-	cmd.Flags().BoolVar(&flagQueryCaching, config.FlagQueryCaching, true, "(Optional) Enable or disable onchain query caching")
+	cmdStart.Flags().StringVar(&flagRelayMinerConfig, "config", "", "(Required) The path to the relayminer config file")
+	cmdStart.Flags().BoolVar(&flagQueryCaching, config.FlagQueryCaching, true, "(Optional) Enable or disable onchain query caching")
 
-	// Cosmos flags
-	cmd.Flags().StringVar(&flagNodeRPCURL, cosmosflags.FlagNode, flags.OmittedDefaultFlagValue, "Register the default Cosmos node flag, which is needed to initialize the Cosmos query and tx contexts correctly. It can be used to override the `QueryNodeRPCURL` and `TxNodeRPCURL` fields in the config file if specified.")
-	cmd.Flags().StringVar(&flagNodeGRPCURL, cosmosflags.FlagGRPC, flags.OmittedDefaultFlagValue, "Register the default Cosmos node grpc flag, which is needed to initialize the Cosmos query context with grpc correctly. It can be used to override the `QueryNodeGRPCURL` field in the config file if specified.")
-	cmd.Flags().StringVar(&flagLogLevel, cosmosflags.FlagLogLevel, "debug", "The logging level (debug|info|warn|error)")
-	cmd.Flags().String(cosmosflags.FlagKeyringBackend, "", "Select keyring's backend (os|file|kwallet|pass|test)")
-	cmd.Flags().Bool(cosmosflags.FlagGRPCInsecure, true, "Used to initialize the Cosmos query context with grpc security options. It can be used to override the `QueryNodeGRPCInsecure` field in the config file if specified.")
-	cmd.Flags().String(cosmosflags.FlagChainID, "pocket", "The network chain ID")
-	cmd.Flags().Float64(cosmosflags.FlagGasAdjustment, 1.7, "The adjustment factor to be multiplied by the gas estimate returned by the tx simulation")
-	cmd.Flags().String(cosmosflags.FlagGasPrices, "1upokt", "Set the gas unit price in upokt")
+	// This command depends on the conventional cosmos-sdk CLI tx flags.
+	cosmosflags.AddTxFlagsToCmd(cmdStart)
 
 	// Required flags
-	_ = cmd.MarkFlagRequired("config")
+	_ = cmdStart.MarkFlagRequired("config")
 	// TODO_TECHDEBT(@olshansk): Consider making this part of the relay miner config file or erroring in a more user-friendly way.
-	_ = cmd.MarkFlagRequired(cosmosflags.FlagChainID)
+	_ = cmdStart.MarkFlagRequired(cosmosflags.FlagChainID)
 
-	return cmd
+	return cmdStart
 }
 
 // runRelayer starts the relay miner with the provided configuration and context.

--- a/pkg/relayer/cmd/deps.go
+++ b/pkg/relayer/cmd/deps.go
@@ -40,10 +40,13 @@ func setupRelayerDependencies(
 	queryNodeGRPCUrl := relayMinerConfig.PocketNode.QueryNodeGRPCUrl
 	txNodeRPCUrl := relayMinerConfig.PocketNode.TxNodeRPCUrl
 
+	nodeRPCURL := cmd.Flag(cosmosflags.FlagNode).Value.String()
+	nodeGRPCURL := cmd.Flag(cosmosflags.FlagGRPC).Value.String()
+
 	// Override config file's `QueryNodeGRPCUrl` with `--grpc-addr` flag if specified.
 	// TODO(#223): Remove this check once viper is used as SoT for overridable config values.
-	if flagNodeGRPCURL != flags.OmittedDefaultFlagValue {
-		parsedFlagNodeGRPCUrl, err := url.Parse(flagNodeGRPCURL)
+	if nodeGRPCURL != flags.OmittedDefaultFlagValue {
+		parsedFlagNodeGRPCUrl, err := url.Parse(nodeGRPCURL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse grpc query URL: %w", err)
 		}
@@ -52,8 +55,8 @@ func setupRelayerDependencies(
 
 	// Override config file's `QueryNodeUrl` and `txNodeRPCUrl` with `--node` flag if specified.
 	// TODO(#223): Remove this check once viper is used as SoT for overridable config values.
-	if flagNodeRPCURL != flags.OmittedDefaultFlagValue {
-		parsedFlagNodeRPCUrl, err := url.Parse(flagNodeRPCURL)
+	if nodeRPCURL != flags.OmittedDefaultFlagValue {
+		parsedFlagNodeRPCUrl, err := url.Parse(nodeRPCURL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse rpc query URL: %w", err)
 		}

--- a/pkg/relayer/cmd/flags.go
+++ b/pkg/relayer/cmd/flags.go
@@ -7,12 +7,6 @@ package cmd
 var (
 	// flagRelayMinerConfig is the relay miner config file path from `--config` flag.
 	flagRelayMinerConfig string
-	// flagNodeRPCURL is the Cosmos node RPC URL flag value.
-	flagNodeRPCURL string
-	// flagNodeGRPCURL is the Cosmos node GRPC URL flag value.
-	flagNodeGRPCURL string
-	// flagLogLevel is the log level variable (used by cosmos and polylog).
-	flagLogLevel string
 	// flagQueryCaching is the query caching flag value.
 	flagQueryCaching bool
 )


### PR DESCRIPTION
- Use default cosmos tx flags in `pocketd relayminer ...`
- Fix the `grpc-insecure` bug with `--network`