### PR TITLE
Review/1443

### DIFF
--- a/cmd/faucet/serve.go
+++ b/cmd/faucet/serve.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pokt-network/poktroll/cmd/signals"
 	"github.com/pokt-network/poktroll/pkg/client"
 	"github.com/pokt-network/poktroll/pkg/client/tx"
+	"github.com/pokt-network/poktroll/pkg/deps/config"
 	"github.com/pokt-network/poktroll/pkg/faucet"
 )
 
@@ -87,7 +88,7 @@ func preRunServe(cmd *cobra.Command, _ []string) (err error) {
 	txClientOpts = append(txClientOpts, unorderedOpt)
 
 	// Construct the tx client.
-	txClient, err = flags.GetTxClientFromFlags(cmd.Context(), cmd, txClientOpts...)
+	txClient, err = config.GetTxClientFromFlags(cmd.Context(), cmd, txClientOpts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/flags/error.go
+++ b/cmd/flags/error.go
@@ -1,0 +1,10 @@
+package flags
+
+import cosmoserrors "cosmossdk.io/errors"
+
+var (
+	namespace = "flags"
+
+	ErrFlagNotRegistered = cosmoserrors.Register(namespace, 1200, "flag not registered")
+	ErrFlagInvalidValue  = cosmoserrors.Register(namespace, 1201, "flag value is invalid")
+)

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -1,5 +1,10 @@
 package flags
 
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
 const (
 	// OmittedDefaultFlagValue is used whenever a flag is required but no reasonable default value can be provided.
 	// In most cases, this forces the user to specify the flag value to avoid unintended behavior.
@@ -49,3 +54,43 @@ const (
 	BetaNetworkName  = "beta"
 	MainNetworkName  = "main"
 )
+
+// GetFlagValueString returns the value of the flag with the given name.
+// If the flag is not registered, an error is returned.
+func GetFlagValueString(cmd *cobra.Command, flagName string) (string, error) {
+	flag, err := GetFlag(cmd, flagName)
+	if err != nil {
+		return "", err
+	}
+
+	return flag.Value.String(), nil
+}
+
+// GetFlagBool returns the value of the flag with the given name.
+// If the flag is not registered, an error is returned.
+func GetFlagBool(cmd *cobra.Command, flagName string) (bool, error) {
+	flagValueString, err := GetFlagValueString(cmd, flagName)
+	if err != nil {
+		return false, err
+	}
+
+	switch flagValueString {
+	case BooleanTrueValue:
+		return true, nil
+	case BooleanFalseValue:
+		return false, nil
+	default:
+		return false, ErrFlagInvalidValue.Wrapf("expected 'true' or 'false', gor: %s", flagValueString)
+	}
+}
+
+// GetFlag returns the flag with the given name.
+// If the flag is not registered, an error is returned.
+func GetFlag(cmd *cobra.Command, flagName string) (*pflag.Flag, error) {
+	flag := cmd.Flag(flagName)
+	if flag == nil {
+		return nil, ErrFlagNotRegistered.Wrapf("flag name: %s", flagName)
+	}
+
+	return flag, nil
+}

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -53,6 +53,35 @@ const (
 	AlphaNetworkName = "alpha"
 	BetaNetworkName  = "beta"
 	MainNetworkName  = "main"
+
+	BooleanTrueValue  = "true"
+	BooleanFalseValue = "false"
+
+	/* Relayminer Command flags */
+	FlagApp        = "app"
+	FlagAppUsage   = "(Required) Staked application address"
+	DefaultFlagApp = ""
+
+	FlagPayload        = "payload"
+	FlagPayloadUsage   = "(Required) JSON-RPC payload"
+	DefaultFlagPayload = ""
+
+	FlagSupplier        = "supplier"
+	FlagSupplierUsage   = "(Optional) Staked Supplier address"
+	DefaultFlagSupplier = ""
+
+	FlagSupplierPublicEndpointOverride        = "supplier-public-endpoint-override"
+	FlagSupplierPublicEndpointOverrideUsage   = "(Optional) Override the publicly exposed endpoint of the Supplier (useful for LocalNet testing)"
+	DefaultFlagSupplierPublicEndpointOverride = ""
+
+	FlagConfig        = "config"
+	FlagConfigUsage   = "(Required) The path to the relayminer config file"
+	DefaultFlagConfig = ""
+
+	// FlagQueryCaching is the flag name to enable or disable query caching.
+	FlagQueryCaching        = "query-caching"
+	FlagQueryCachingUsage   = "(Optional) Enable or disable onchain query caching"
+	DefaultFlagQueryCaching = true
 )
 
 // GetFlagValueString returns the value of the flag with the given name.

--- a/cmd/flags/flags_test.go
+++ b/cmd/flags/flags_test.go
@@ -1,0 +1,65 @@
+package flags
+
+import (
+	"testing"
+
+	cosmosflags "github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFlagValueString(t *testing.T) {
+	testCmd := &cobra.Command{
+		Use:   "test",
+		Short: "Test",
+		Long:  `Test`,
+	}
+
+	// Register relevant flags for testing, defaulting to empty values.
+	testCmd.Flags().String(FlagNetwork, "", "network flag")
+
+	networkNames := []string{
+		LocalNetworkName,
+		AlphaNetworkName,
+		BetaNetworkName,
+		MainNetworkName,
+	}
+
+	for _, networkName := range networkNames {
+		// Set the network flag to the correct value.
+		err := testCmd.Flag(FlagNetwork).Value.Set(networkName)
+		require.NoError(t, err)
+
+		// Assert that GetFlagValueString returns the expected value.
+		networkFlagValue, err := GetFlagValueString(testCmd, FlagNetwork)
+		require.NoError(t, err)
+		require.Equal(t, networkName, networkFlagValue)
+	}
+}
+
+func TestGetFlagValueBool(t *testing.T) {
+	testCmd := &cobra.Command{
+		Use:   "test",
+		Short: "Test",
+		Long:  `Test`,
+	}
+
+	// Register relevant flags for testing, defaulting to empty values.
+	testCmd.Flags().String(cosmosflags.FlagGRPCInsecure, "", "network flag")
+
+	boolValues := []string{
+		BooleanTrueValue,
+		BooleanFalseValue,
+	}
+
+	for _, boolValue := range boolValues {
+		// Set the network flag to the correct value.
+		err := testCmd.Flag(cosmosflags.FlagGRPCInsecure).Value.Set(boolValue)
+		require.NoError(t, err)
+
+		// Assert that GetFlagValueString returns the expected value.
+		networkFlagValue, err := GetFlagValueString(testCmd, cosmosflags.FlagGRPCInsecure)
+		require.NoError(t, err)
+		require.Equal(t, boolValue, networkFlagValue)
+	}
+}

--- a/cmd/logger/logger.go
+++ b/cmd/logger/logger.go
@@ -35,7 +35,7 @@ const unknownLevel = "???"
 // of a Cobra command.
 //
 // TODO_CONSIDERATION: Apply this pattern to all CLI commands.
-func PreRunESetup(_ *cobra.Command, _ []string) error {
+func PreRunESetup(cmd *cobra.Command, _ []string) error {
 	var (
 		logWriter io.Writer
 		err       error
@@ -55,6 +55,10 @@ func PreRunESetup(_ *cobra.Command, _ []string) error {
 		polyzero.WithLevel(logLevel),
 		polyzero.WithSetupFn(NewSetupConsoleWriter(logWriter)),
 	)
+
+	// Set the logger on the context and update the command's context.
+	loggerCtx := Logger.WithContext(cmd.Context())
+	cmd.SetContext(loggerCtx)
 
 	return nil
 }

--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -28,19 +28,47 @@ func ParseAndSetNetworkRelatedFlags(cmd *cobra.Command) error {
 
 	// LocalNet
 	case flags.LocalNetworkName:
-		return setNetworkRelatedFlags(cmd, pocket.LocalNetChainId, pocket.LocalNetRPCURL, pocket.LocalNetGRPCAddr, "true", pocket.LocalNetFaucetBaseURL)
+		return setNetworkRelatedFlags(
+			cmd,
+			pocket.LocalNetChainId,
+			pocket.LocalNetRPCURL,
+			pocket.LocalNetGRPCAddr,
+			flags.BooleanTrueValue,
+			pocket.LocalNetFaucetBaseURL,
+		)
 
 	// Alpha TestNet
 	case flags.AlphaNetworkName:
-		return setNetworkRelatedFlags(cmd, pocket.AlphaTestNetChainId, pocket.AlphaTestNetRPCURL, pocket.AlphaNetGRPCAddr, "false", pocket.AlphaTestNetFaucetBaseURL)
+		return setNetworkRelatedFlags(
+			cmd,
+			pocket.AlphaTestNetChainId,
+			pocket.AlphaTestNetRPCURL,
+			pocket.AlphaNetGRPCAddr,
+			flags.BooleanFalseValue,
+			pocket.AlphaTestNetFaucetBaseURL,
+		)
 
 	// Beta TestNet
 	case flags.BetaNetworkName:
-		return setNetworkRelatedFlags(cmd, pocket.BetaTestNetChainId, pocket.BetaTestNetRPCURL, pocket.BetaNetGRPCAddr, "false", pocket.BetaTestNetFaucetBaseURL)
+		return setNetworkRelatedFlags(
+			cmd,
+			pocket.BetaTestNetChainId,
+			pocket.BetaTestNetRPCURL,
+			pocket.BetaNetGRPCAddr,
+			flags.BooleanFalseValue,
+			pocket.BetaTestNetFaucetBaseURL,
+		)
 
 	// MainNet
 	case flags.MainNetworkName:
-		return setNetworkRelatedFlags(cmd, pocket.MainNetChainId, pocket.MainNetRPCURL, pocket.MainNetGRPCAddr, "false", pocket.MainNetFaucetBaseURL)
+		return setNetworkRelatedFlags(
+			cmd,
+			pocket.MainNetChainId,
+			pocket.MainNetRPCURL,
+			pocket.MainNetGRPCAddr,
+			flags.BooleanFalseValue,
+			pocket.MainNetFaucetBaseURL,
+		)
 
 	default:
 		return fmt.Errorf("unknown --network specified %q", networkStr)
@@ -57,45 +85,45 @@ func ParseAndSetNetworkRelatedFlags(cmd *cobra.Command) error {
 
 func setNetworkRelatedFlags(cmd *cobra.Command, chainId, nodeUrl, grpcAddr, grpcInsecure, faucetBaseUrl string) error {
 	// --chain-id flag
-	if chainIDFlag := cmd.Flags().Lookup(cosmosflags.FlagChainID); chainIDFlag != nil {
+	if chainIDFlag := cmd.Flag(cosmosflags.FlagChainID); chainIDFlag != nil {
 		if !cmd.Flags().Changed(cosmosflags.FlagChainID) {
-			if err := cmd.Flags().Set(cosmosflags.FlagChainID, chainId); err != nil {
+			if err := chainIDFlag.Value.Set(chainId); err != nil {
 				return err
 			}
 		}
 	}
 
 	// --node flag
-	if nodeFlag := cmd.Flags().Lookup(cosmosflags.FlagNode); nodeFlag != nil {
+	if nodeFlag := cmd.Flag(cosmosflags.FlagNode); nodeFlag != nil {
 		if !cmd.Flags().Changed(cosmosflags.FlagNode) {
-			if err := cmd.Flags().Set(cosmosflags.FlagNode, nodeUrl); err != nil {
+			if err := nodeFlag.Value.Set(nodeUrl); err != nil {
 				return err
 			}
 		}
 	}
 
 	// --grpc-addr flag
-	if grpcFlag := cmd.Flags().Lookup(cosmosflags.FlagGRPC); grpcFlag != nil {
+	if grpcFlag := cmd.Flag(cosmosflags.FlagGRPC); grpcFlag != nil {
 		if !cmd.Flags().Changed(cosmosflags.FlagGRPC) {
-			if err := cmd.Flags().Set(cosmosflags.FlagGRPC, grpcAddr); err != nil {
+			if err := grpcFlag.Value.Set(grpcAddr); err != nil {
 				return err
 			}
 		}
 	}
 
 	// --grpc-insecure flag
-	if grpcInsecureFlag := cmd.Flags().Lookup(cosmosflags.FlagGRPCInsecure); grpcInsecureFlag != nil {
+	if grpcInsecureFlag := cmd.Flag(cosmosflags.FlagGRPCInsecure); grpcInsecureFlag != nil {
 		if !cmd.Flags().Changed(cosmosflags.FlagGRPCInsecure) {
-			if err := cmd.Flags().Set(cosmosflags.FlagGRPCInsecure, grpcInsecure); err != nil {
+			if err := grpcInsecureFlag.Value.Set(grpcInsecure); err != nil {
 				return err
 			}
 		}
 	}
 
 	// --faucet-base-url flag
-	if faucetBaseURLFlag := cmd.Flags().Lookup(flags.FlagFaucetBaseURL); faucetBaseURLFlag != nil {
+	if faucetBaseURLFlag := cmd.Flag(flags.FlagFaucetBaseURL); faucetBaseURLFlag != nil {
 		if !cmd.Flags().Changed(flags.FlagFaucetBaseURL) {
-			if err := cmd.Flags().Set(flags.FlagFaucetBaseURL, faucetBaseUrl); err != nil {
+			if err := faucetBaseURLFlag.Value.Set(faucetBaseUrl); err != nil {
 				return err
 			}
 		}

--- a/cmd/rpc_test.go
+++ b/cmd/rpc_test.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	cosmosflags "github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pokt-network/poktroll/app/pocket"
+	"github.com/pokt-network/poktroll/cmd/flags"
+	"github.com/pokt-network/poktroll/cmd/logger"
+	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
+)
+
+var (
+	// flagsToLog is a list of flags that will be logged by the logger in the
+	// test command for the purpose of asserting against the log output.
+	flagsToLog = []string{
+		flags.FlagNetwork,
+		cosmosflags.FlagChainID,
+		cosmosflags.FlagNode,
+		cosmosflags.FlagGRPC,
+		cosmosflags.FlagGRPCInsecure,
+		flags.FlagFaucetBaseURL,
+	}
+	flagLogFmt = "flag %q value: %s"
+
+	testLogBuffer = new(bytes.Buffer)
+)
+
+// testPreRunE resets the log buffer, sets up the global logger, and sets it on the command context.
+func testPreRunE(cmd *cobra.Command, args []string) error {
+	// Reset the log buffer on each command execution.
+	testLogBuffer.Reset()
+
+	// Set the log level to debug, and write to a buffer for testing.
+	logger.Logger = polyzero.NewLogger(
+		polyzero.WithLevel(polyzero.DebugLevel),
+		polyzero.WithSetupFn(logger.NewSetupConsoleWriter(testLogBuffer)),
+	)
+
+	// Normally, the root command's PersistentPreRunE would call this.
+	return ParseAndSetNetworkRelatedFlags(cmd)
+}
+
+// testRunE logs the values of the flags that were set on the command.
+func testRunE(cmd *cobra.Command, _ []string) error {
+	for _, flagName := range flagsToLog {
+		if cmd.Flag(flagName) == nil {
+			return fmt.Errorf("flag %q not registered", flagName)
+		}
+
+		flagValue := cmd.Flag(flagName).Value.String()
+		logger.Logger.Debug().Msgf(flagLogFmt, flagName, flagValue)
+	}
+
+	return nil
+}
+
+func TestNetworkRelatedFlags(t *testing.T) {
+	testCmd := &cobra.Command{
+		Use:     "test",
+		Short:   "Test",
+		Long:    `Test`,
+		PreRunE: testPreRunE,
+		RunE:    testRunE,
+	}
+
+	// Register relevant flags for testing, defaulting to empty values.
+	testCmd.Flags().String(flags.FlagNetwork, "", "network flag")
+	testCmd.Flags().String(cosmosflags.FlagGRPC, "", "grpc addr flag")
+	testCmd.Flags().String(cosmosflags.FlagGRPCInsecure, "", "grpc insecure flag")
+	testCmd.Flags().String(flags.FlagFaucetBaseURL, "", "faucet base url flag")
+	cosmosflags.AddTxFlagsToCmd(testCmd)
+
+	testCases := []struct {
+		networkFlagValue               string
+		expectedChainIDFlagValue       string
+		expectedNodeFlagValue          string
+		expectedGRPCAddrFlagValue      string
+		expectedGRPCInsecureFlagValue  bool
+		expectedFaucetBaseURLFlagValue string
+	}{
+		{
+			networkFlagValue:               flags.LocalNetworkName,
+			expectedChainIDFlagValue:       pocket.LocalNetChainId,
+			expectedNodeFlagValue:          pocket.LocalNetRPCURL,
+			expectedGRPCAddrFlagValue:      pocket.LocalNetGRPCAddr,
+			expectedGRPCInsecureFlagValue:  true,
+			expectedFaucetBaseURLFlagValue: pocket.LocalNetFaucetBaseURL,
+		},
+		{
+			networkFlagValue:               flags.AlphaNetworkName,
+			expectedChainIDFlagValue:       pocket.AlphaTestNetChainId,
+			expectedNodeFlagValue:          pocket.AlphaTestNetRPCURL,
+			expectedGRPCAddrFlagValue:      pocket.AlphaNetGRPCAddr,
+			expectedGRPCInsecureFlagValue:  false,
+			expectedFaucetBaseURLFlagValue: pocket.AlphaTestNetFaucetBaseURL,
+		},
+		{
+			networkFlagValue:               flags.BetaNetworkName,
+			expectedChainIDFlagValue:       pocket.BetaTestNetChainId,
+			expectedNodeFlagValue:          pocket.BetaTestNetRPCURL,
+			expectedGRPCAddrFlagValue:      pocket.BetaNetGRPCAddr,
+			expectedGRPCInsecureFlagValue:  false,
+			expectedFaucetBaseURLFlagValue: pocket.BetaTestNetFaucetBaseURL,
+		},
+		{
+			networkFlagValue:               flags.MainNetworkName,
+			expectedChainIDFlagValue:       pocket.MainNetChainId,
+			expectedNodeFlagValue:          pocket.MainNetRPCURL,
+			expectedGRPCAddrFlagValue:      pocket.MainNetGRPCAddr,
+			expectedGRPCInsecureFlagValue:  false,
+			expectedFaucetBaseURLFlagValue: pocket.MainNetFaucetBaseURL,
+		},
+	}
+
+	for _, test := range testCases {
+		desc := fmt.Sprintf("with %q network flag value", test.networkFlagValue)
+		t.Run(desc, func(t *testing.T) {
+			// Set flags and execute as if invoked from the command line.
+			err := testCmd.Flag(flags.FlagNetwork).Value.Set("test")
+			require.NoError(t, err)
+
+			testCmd.SetArgs([]string{
+				fmt.Sprintf("--%s=%s", flags.FlagNetwork, test.networkFlagValue),
+			})
+
+			err = testCmd.ExecuteContext(t.Context())
+			require.NoError(t, err)
+
+			t.Logf("test log buffer:\n%s", testLogBuffer.String())
+
+			// Assert that the flags were set as expected.
+			chainIDFlag, err := flags.GetFlag(testCmd, cosmosflags.FlagChainID)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedChainIDFlagValue, chainIDFlag.Value.String())
+			expectedLogString := fmt.Sprintf(flagLogFmt, cosmosflags.FlagChainID, test.expectedChainIDFlagValue)
+			require.Contains(t, testLogBuffer.String(), expectedLogString)
+
+			nodeFlag, err := flags.GetFlag(testCmd, cosmosflags.FlagNode)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedNodeFlagValue, nodeFlag.Value.String())
+			expectedLogString = fmt.Sprintf(flagLogFmt, cosmosflags.FlagNode, test.expectedNodeFlagValue)
+			require.Contains(t, testLogBuffer.String(), expectedLogString)
+
+			grpcAddrFlag, err := flags.GetFlag(testCmd, cosmosflags.FlagGRPC)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedGRPCAddrFlagValue, grpcAddrFlag.Value.String())
+			expectedLogString = fmt.Sprintf(flagLogFmt, cosmosflags.FlagGRPC, test.expectedGRPCAddrFlagValue)
+			require.Contains(t, testLogBuffer.String(), expectedLogString)
+
+			grpcInsecureFlagBool, err := flags.GetFlagBool(testCmd, cosmosflags.FlagGRPCInsecure)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedGRPCInsecureFlagValue, grpcInsecureFlagBool)
+			expectedLogString = fmt.Sprintf(flagLogFmt, cosmosflags.FlagGRPCInsecure, fmt.Sprintf("%v", test.expectedGRPCInsecureFlagValue))
+			require.Contains(t, testLogBuffer.String(), expectedLogString)
+
+			faucetBaseURLFlag, err := flags.GetFlag(testCmd, flags.FlagFaucetBaseURL)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedFaucetBaseURLFlagValue, faucetBaseURLFlag.Value.String())
+			expectedLogString = fmt.Sprintf(flagLogFmt, flags.FlagFaucetBaseURL, test.expectedFaucetBaseURLFlagValue)
+			require.Contains(t, testLogBuffer.String(), expectedLogString)
+		})
+	}
+}

--- a/pkg/deps/config/suppliers.go
+++ b/pkg/deps/config/suppliers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosmos/gogoproto/grpc"
 	"github.com/spf13/cobra"
 
+	"github.com/pokt-network/poktroll/cmd/flags"
 	"github.com/pokt-network/poktroll/pkg/cache"
 	"github.com/pokt-network/poktroll/pkg/cache/memory"
 	"github.com/pokt-network/poktroll/pkg/client"
@@ -33,9 +34,6 @@ import (
 	"github.com/pokt-network/poktroll/pkg/relayer/relay_authenticator"
 	"github.com/pokt-network/poktroll/pkg/relayer/session"
 )
-
-// FlagQueryCaching is the flag name to enable or disable query caching.
-const FlagQueryCaching = "query-caching"
 
 // SupplierFn is a function that is used to supply a depinject config.
 type SupplierFn func(
@@ -526,7 +524,7 @@ func NewSupplyKeyValueCacheFn[T any](opts ...querycache.CacheOption[cache.KeyVal
 		cmd *cobra.Command,
 	) (depinject.Config, error) {
 		// Check if query caching is enabled
-		queryCachingEnabled, err := cmd.Flags().GetBool(FlagQueryCaching)
+		queryCachingEnabled, err := cmd.Flags().GetBool(flags.FlagQueryCaching)
 		if err != nil {
 			return nil, err
 		}
@@ -562,7 +560,7 @@ func NewSupplyParamsCacheFn[T any](opts ...querycache.CacheOption[client.ParamsC
 		cmd *cobra.Command,
 	) (depinject.Config, error) {
 		// Check if params caching is enabled
-		queryCachingEnabled, err := cmd.Flags().GetBool(FlagQueryCaching)
+		queryCachingEnabled, err := cmd.Flags().GetBool(flags.FlagQueryCaching)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/deps/config/tx_client.go
+++ b/pkg/deps/config/tx_client.go
@@ -1,4 +1,4 @@
-package flags
+package config
 
 import (
 	"context"
@@ -13,7 +13,6 @@ import (
 	"github.com/pokt-network/poktroll/pkg/client"
 	"github.com/pokt-network/poktroll/pkg/client/tx"
 	"github.com/pokt-network/poktroll/pkg/client/tx/types"
-	"github.com/pokt-network/poktroll/pkg/deps/config"
 )
 
 // GetTxClientFromFlags constructs a new TxClient instance using the provided command flags.
@@ -47,11 +46,11 @@ func GetTxClientFromFlags(
 	}
 
 	// Construct dependencies for the tx client
-	deps, err := config.SupplyConfig(ctx, cmd, []config.SupplierFn{
-		config.NewSupplyLoggerFromCtx(ctx),
-		config.NewSupplyEventsQueryClientFn(queryNodeRPCUrl),
-		config.NewSupplyBlockQueryClientFn(queryNodeRPCUrl),
-		config.NewSupplyBlockClientFn(queryNodeRPCUrl),
+	deps, err := SupplyConfig(ctx, cmd, []SupplierFn{
+		NewSupplyLoggerFromCtx(ctx),
+		NewSupplyEventsQueryClientFn(queryNodeRPCUrl),
+		NewSupplyBlockQueryClientFn(queryNodeRPCUrl),
+		NewSupplyBlockClientFn(queryNodeRPCUrl),
 	})
 	if err != nil {
 		return nil, err
@@ -74,7 +73,7 @@ func GetTxClientFromFlags(
 		return nil, err
 	}
 
-	gasAndFeesOptions, err := config.GetTxClientGasAndFeesOptionsFromFlags(cmd, gasSettingStr)
+	gasAndFeesOptions, err := GetTxClientGasAndFeesOptionsFromFlags(cmd, gasSettingStr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/faucet/faucet_test.go
+++ b/pkg/faucet/faucet_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -78,7 +79,10 @@ func TestMain(m *testing.M) {
 func TestNewFaucet(t *testing.T) {
 	// Ensure the CLI logger is set up.
 	logger.LogOutput = flags.DefaultLogOutput
-	err := logger.PreRunESetup(nil, nil)
+	cmd, err := (&cobra.Command{}).ExecuteC()
+	require.NoError(t, err)
+
+	err = logger.PreRunESetup(cmd, []string{})
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(t.Context())

--- a/pkg/relayer/cmd/cmd_relay.go
+++ b/pkg/relayer/cmd/cmd_relay.go
@@ -121,10 +121,22 @@ func runRelay(cmd *cobra.Command, args []string) error {
 	ctx, cancelCtx := context.WithCancel(cmd.Context())
 	defer cancelCtx() // Ensure context cancellation
 
-	logLevel := cmd.Flag(cosmosflags.FlagLogLevel).Value.String()
-	nodeRPCURL := cmd.Flag(cosmosflags.FlagNode).Value.String()
-	nodeGRPCURL := cmd.Flag(cosmosflags.FlagGRPC).Value.String()
-	nodeGRPCInsecure, err := cmd.Flags().GetBool(cosmosflags.FlagGRPCInsecure)
+	logLevel, err := flags.GetFlagValueString(cmd, cosmosflags.FlagLogLevel)
+	if err != nil {
+		return err
+	}
+
+	nodeRPCURL, err := flags.GetFlagValueString(cmd, cosmosflags.FlagNode)
+	if err != nil {
+		return err
+	}
+
+	nodeGRPCURL, err := flags.GetFlagValueString(cmd, cosmosflags.FlagGRPC)
+	if err != nil {
+		return err
+	}
+
+	nodeGRPCInsecure, err := flags.GetFlagBool(cmd, cosmosflags.FlagGRPCInsecure)
 	if err != nil {
 		return err
 	}

--- a/pkg/relayer/cmd/cmd_relay.go
+++ b/pkg/relayer/cmd/cmd_relay.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 
+	"github.com/pokt-network/poktroll/cmd/flags"
 	"github.com/pokt-network/poktroll/pkg/polylog"
 	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
 	apptypes "github.com/pokt-network/poktroll/x/application/types"
@@ -90,17 +91,22 @@ For more info, run 'relay --help'.`,
 	}
 
 	// Custom Flags
-	cmdRelay.Flags().StringVar(&flagRelayApp, "app", "", "(Required) Staked application address")
-	cmdRelay.Flags().StringVar(&flagRelayPayload, "payload", "", "(Required) JSON-RPC payload")
-	cmdRelay.Flags().StringVar(&flagRelaySupplier, "supplier", "", "(Optional) Staked Supplier address")
-	cmdRelay.Flags().StringVar(&flagSupplierPublicEndpointOverride, "supplier-public-endpoint-override", "", "(Optional) Override the publicly exposed endpoint of the Supplier (useful for LocalNet testing)")
+	cmdRelay.Flags().StringVar(&flagRelayApp, flags.FlagApp, flags.DefaultFlagApp, flags.FlagAppUsage)
+	cmdRelay.Flags().StringVar(&flagRelayPayload, flags.FlagPayload, flags.DefaultFlagPayload, flags.FlagPayloadUsage)
+	cmdRelay.Flags().StringVar(&flagRelaySupplier, flags.FlagSupplier, flags.DefaultFlagSupplier, flags.FlagSupplierUsage)
+	cmdRelay.Flags().StringVar(
+		&flagSupplierPublicEndpointOverride,
+		flags.FlagSupplierPublicEndpointOverride,
+		flags.DefaultFlagSupplierPublicEndpointOverride,
+		flags.FlagSupplierPublicEndpointOverrideUsage,
+	)
 
 	// This command depends on the conventional cosmos-sdk CLI tx flags.
 	cosmosflags.AddTxFlagsToCmd(cmdRelay)
 
 	// Required flags
-	_ = cmdRelay.MarkFlagRequired("app")
-	_ = cmdRelay.MarkFlagRequired("payload")
+	_ = cmdRelay.MarkFlagRequired(flags.FlagApp)
+	_ = cmdRelay.MarkFlagRequired(flags.FlagPayload)
 
 	return cmdRelay
 }

--- a/pkg/relayer/cmd/cmd_start.go
+++ b/pkg/relayer/cmd/cmd_start.go
@@ -47,14 +47,14 @@ RelayMiner Responsibilities:
 	}
 
 	// Custom flags
-	cmdStart.Flags().StringVar(&flagRelayMinerConfig, "config", "", "(Required) The path to the relayminer config file")
-	cmdStart.Flags().BoolVar(&flagQueryCaching, config.FlagQueryCaching, true, "(Optional) Enable or disable onchain query caching")
+	cmdStart.Flags().StringVar(&flagRelayMinerConfig, flags.FlagConfig, flags.DefaultFlagConfig, flags.FlagConfigUsage)
+	cmdStart.Flags().BoolVar(&flagQueryCaching, flags.FlagQueryCaching, flags.DefaultFlagQueryCaching, flags.FlagQueryCachingUsage)
 
 	// This command depends on the conventional cosmos-sdk CLI tx flags.
 	cosmosflags.AddTxFlagsToCmd(cmdStart)
 
 	// Required flags
-	_ = cmdStart.MarkFlagRequired("config")
+	_ = cmdStart.MarkFlagRequired(flags.FlagConfig)
 	// TODO_TECHDEBT(@olshansk): Consider making this part of the relay miner config file or erroring in a more user-friendly way.
 	_ = cmdStart.MarkFlagRequired(cosmosflags.FlagChainID)
 

--- a/x/migration/module/cmd/claim_morse_account.go
+++ b/x/migration/module/cmd/claim_morse_account.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pokt-network/poktroll/cmd/flags"
+	"github.com/pokt-network/poktroll/pkg/deps/config"
 	"github.com/pokt-network/poktroll/x/migration/types"
 )
 
@@ -122,7 +123,7 @@ func runClaimAccount(cmd *cobra.Command, args []string) error {
 	}
 
 	// Construct a tx client.
-	txClient, err := flags.GetTxClientFromFlags(ctx, cmd)
+	txClient, err := config.GetTxClientFromFlags(ctx, cmd)
 	if err != nil {
 		return err
 	}

--- a/x/migration/module/cmd/claim_morse_account_bulk.go
+++ b/x/migration/module/cmd/claim_morse_account_bulk.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pokt-network/poktroll/cmd/flags"
 	"github.com/pokt-network/poktroll/cmd/logger"
+	"github.com/pokt-network/poktroll/pkg/deps/config"
 	"github.com/pokt-network/poktroll/x/migration/types"
 )
 
@@ -201,7 +202,7 @@ func runBulkClaimAccount(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Construct a tx client.
-	txClient, err := flags.GetTxClientFromFlags(ctx, cmd)
+	txClient, err := config.GetTxClientFromFlags(ctx, cmd)
 	if err != nil {
 		return err
 	}

--- a/x/migration/module/cmd/claim_morse_application.go
+++ b/x/migration/module/cmd/claim_morse_application.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pokt-network/poktroll/cmd/flags"
+	"github.com/pokt-network/poktroll/pkg/deps/config"
 	"github.com/pokt-network/poktroll/x/migration/types"
 	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
@@ -130,7 +131,7 @@ func runClaimApplication(cmd *cobra.Command, args []string) error {
 	}
 
 	// Construct a tx client.
-	txClient, err := flags.GetTxClientFromFlags(ctx, cmd)
+	txClient, err := config.GetTxClientFromFlags(ctx, cmd)
 	if err != nil {
 		return err
 	}

--- a/x/migration/module/cmd/claim_morse_supplier.go
+++ b/x/migration/module/cmd/claim_morse_supplier.go
@@ -13,8 +13,9 @@ import (
 
 	"github.com/pokt-network/poktroll/cmd/flags"
 	"github.com/pokt-network/poktroll/cmd/logger"
+	"github.com/pokt-network/poktroll/pkg/deps/config"
 	"github.com/pokt-network/poktroll/x/migration/types"
-	"github.com/pokt-network/poktroll/x/supplier/config"
+	supplierconfig "github.com/pokt-network/poktroll/x/supplier/config"
 )
 
 // TODO_MAINNET_MIGRATION: Add a few examples,
@@ -160,7 +161,7 @@ func runClaimSupplier(cmd *cobra.Command, args []string) error {
 	}
 
 	// Construct a tx client.
-	txClient, err := flags.GetTxClientFromFlags(ctx, cmd)
+	txClient, err := config.GetTxClientFromFlags(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -181,7 +182,7 @@ func runClaimSupplier(cmd *cobra.Command, args []string) error {
 
 // loadSupplierStakeConfigYAML loads, parses, and validates the supplier stake
 // config from configYAMLPath.
-func loadSupplierStakeConfigYAML(configYAMLPath string) (*config.SupplierStakeConfig, error) {
+func loadSupplierStakeConfigYAML(configYAMLPath string) (*supplierconfig.SupplierStakeConfig, error) {
 	// Read the YAML file from the provided path.
 	yamlStakeConfigBz, err := os.ReadFile(configYAMLPath)
 	if err != nil {
@@ -189,14 +190,14 @@ func loadSupplierStakeConfigYAML(configYAMLPath string) (*config.SupplierStakeCo
 	}
 
 	// Unmarshal the YAML into a config.YAMLStakeConfig struct.
-	var yamlStakeConfig config.YAMLStakeConfig
+	var yamlStakeConfig supplierconfig.YAMLStakeConfig
 	if err = yaml.Unmarshal(yamlStakeConfigBz, &yamlStakeConfig); err != nil {
 		return nil, err
 	}
 
 	// Validate that the stake amount is not set in the YAML config.
 	if len(yamlStakeConfig.StakeAmount) != 0 {
-		return nil, config.ErrSupplierConfigInvalidStake.Wrapf("stake_amount MUST NOT be set in the supplier config YAML; it is automatically determined by the onchain MorseClaimableAccount state")
+		return nil, supplierconfig.ErrSupplierConfigInvalidStake.Wrapf("stake_amount MUST NOT be set in the supplier config YAML; it is automatically determined by the onchain MorseClaimableAccount state")
 	}
 
 	// Validate the owner and operator addresses.
@@ -216,7 +217,7 @@ func loadSupplierStakeConfigYAML(configYAMLPath string) (*config.SupplierStakeCo
 		return nil, err
 	}
 
-	return &config.SupplierStakeConfig{
+	return &supplierconfig.SupplierStakeConfig{
 		OwnerAddress:    yamlStakeConfig.OwnerAddress,
 		OperatorAddress: yamlStakeConfig.OperatorAddress,
 		Services:        supplierServiceConfigs,

--- a/x/migration/module/cmd/claim_morse_supplier_bulk.go
+++ b/x/migration/module/cmd/claim_morse_supplier_bulk.go
@@ -18,8 +18,9 @@ import (
 
 	"github.com/pokt-network/poktroll/cmd/flags"
 	"github.com/pokt-network/poktroll/cmd/logger"
+	"github.com/pokt-network/poktroll/pkg/deps/config"
 	"github.com/pokt-network/poktroll/x/migration/types"
-	"github.com/pokt-network/poktroll/x/supplier/config"
+	supplierconfig "github.com/pokt-network/poktroll/x/supplier/config"
 )
 
 var (
@@ -378,7 +379,7 @@ func runClaimSuppliers(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Construct a tx client.
-	txClient, err := flags.GetTxClientFromFlags(ctx, cmd)
+	txClient, err := config.GetTxClientFromFlags(ctx, cmd)
 	if err != nil {
 		return err
 	}
@@ -477,7 +478,7 @@ func getMorseAccountsFromFile(morseNodesFile string) ([]MorseAccountInfo, error)
 // - Stake amount is omitted (set by protocol logic).
 // - Owner/operator addresses should not be set in the template.
 // - Only service configs and revenue share settings should be included.
-func loadTemplateSupplierStakeConfigYAML(configYAMLPath string) (*config.YAMLStakeConfig, error) {
+func loadTemplateSupplierStakeConfigYAML(configYAMLPath string) (*supplierconfig.YAMLStakeConfig, error) {
 	// Read the YAML file from the provided path.
 	yamlStakeConfigBz, err := os.ReadFile(configYAMLPath)
 	if err != nil {
@@ -485,7 +486,7 @@ func loadTemplateSupplierStakeConfigYAML(configYAMLPath string) (*config.YAMLSta
 	}
 
 	// Unmarshal the YAML into a config.YAMLStakeConfig struct.
-	var yamlStakeConfig config.YAMLStakeConfig
+	var yamlStakeConfig supplierconfig.YAMLStakeConfig
 	if err = yaml.Unmarshal(yamlStakeConfigBz, &yamlStakeConfig); err != nil {
 		return nil, err
 	}
@@ -555,8 +556,8 @@ func queryMorseClaimableAccount(
 func buildSupplierStakeConfig(
 	ownerAddress string,
 	operatorAddress string,
-	templateSupplierStakeConfig *config.YAMLStakeConfig,
-) (*config.SupplierStakeConfig, error) {
+	templateSupplierStakeConfig *supplierconfig.YAMLStakeConfig,
+) (*supplierconfig.SupplierStakeConfig, error) {
 	if ownerAddress == "" {
 		return nil, fmt.Errorf("owner address must be non-empty")
 	}
@@ -607,7 +608,7 @@ func buildSupplierStakeConfig(
 		return nil, err
 	}
 
-	return &config.SupplierStakeConfig{
+	return &supplierconfig.SupplierStakeConfig{
 		OwnerAddress:    yamlStakeConfig.OwnerAddress,
 		OperatorAddress: yamlStakeConfig.OperatorAddress,
 		Services:        supplierServiceConfigs,

--- a/x/migration/module/cmd/import_morse_accounts.go
+++ b/x/migration/module/cmd/import_morse_accounts.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pokt-network/poktroll/cmd/flags"
+	"github.com/pokt-network/poktroll/pkg/deps/config"
 	migrationtypes "github.com/pokt-network/poktroll/x/migration/types"
 )
 
@@ -151,7 +152,7 @@ func runImportMorseAccounts(cmd *cobra.Command, args []string) error {
 	)
 
 	// Initialize the tx client.
-	txClient, err := flags.GetTxClientFromFlags(ctx, cmd)
+	txClient, err := config.GetTxClientFromFlags(ctx, cmd)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

< One line summary>

- Simplify flag access
- Add regression test coverage over important flag related logic
  - `--network` flag
  - Flag accessor helpers
- Move `GetTxClientFromFlags` to the pkg/deps/config pkg
  - Avoid an import cycle
  - Organizational improvement
- Consolidate relayminer flags into flags pkg for consistency
- Improve global logger PreRunE to set the logger on the command context

## Issue

- 1443

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Other (specify) out-of-band review

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
