### PR TITLE
[Upgrade] v0.1.18

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -81,11 +81,15 @@ var allUpgrades = []upgrades.Upgrade{
 	// v0.1.16 - upgrade to:
 	// - Normalize Morse accounts recovery allowlist addresses (to uppercase).
 	// - Normalize Morse source address when handling Morse account recovery message.
-	upgrades.Upgrade_0_1_16,
+	// upgrades.Upgrade_0_1_16,
 
 	// v0.1.17 - upgrade to:
 	// - Fix for non-deterministic behavior in the unstaking of Morse suppliers
-	upgrades.Upgrade_0_1_17,
+	// upgrades.Upgrade_0_1_17,
+
+	// v0.1.18 - upgrade to:
+	// - Updates the Morse recoverable account allowlists
+	upgrades.Upgrade_0_1_18,
 }
 
 // setUpgrades sets upgrade handlers for all upgrades and executes KVStore migration if an upgrade plan file exists.

--- a/app/upgrades/v0.1.18.go
+++ b/app/upgrades/v0.1.18.go
@@ -1,0 +1,41 @@
+package upgrades
+
+import (
+	"context"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/pokt-network/poktroll/app/keepers"
+)
+
+const (
+	Upgrade_0_1_18_PlanName = "v0.1.18"
+)
+
+// Upgrade_0_1_18 handles the upgrade to release `v0.1.18`.
+// This upgrade adds:
+// - Updates the Morse recoverable account allowlists
+var Upgrade_0_1_18 = Upgrade{
+	PlanName: Upgrade_0_1_18_PlanName,
+	// No KVStore migrations in this upgrade.
+	StoreUpgrades: storetypes.StoreUpgrades{},
+
+	// Upgrade Handler
+	CreateUpgradeHandler: func(
+		mm *module.Manager,
+		keepers *keepers.Keepers,
+		configurator module.Configurator,
+	) upgradetypes.UpgradeHandler {
+		// Add new parameters by:
+		// 1. Inspecting the diff between v0.1.17..v0.1.18
+		// 2. Manually inspect changes in ignite's config.yml
+		// 3. Update the upgrade handler here accordingly
+		// Ref: https://github.com/pokt-network/poktroll/compare/v0.1.17..v0.1.18
+
+		return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+			return vm, nil
+		}
+	},
+}


### PR DESCRIPTION
## Summary

Add the v0.1.18

- Updates the Morse recoverable accounts allowlists

## Issue

- N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Other (specify): onchain upgrade

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
