### PR TITLE
[SUPPLIER][PARAMS] Reducing supplier unbonding from 21 days to 7 days

### DIFF
--- a/tools/scripts/params/bulk_params_main/shared_params.json
+++ b/tools/scripts/params/bulk_params_main/shared_params.json
@@ -10,7 +10,7 @@
           "claim_window_open_offset_blocks": "1",
           "claim_window_close_offset_blocks": "4",
           "proof_window_close_offset_blocks": "4",
-          "supplier_unbonding_period_sessions": "6048",
+          "supplier_unbonding_period_sessions": "2016",
           "application_unbonding_period_sessions": "2",
           "compute_units_to_tokens_multiplier": "33482",
           "gateway_unbonding_period_sessions": "1",


### PR DESCRIPTION
## Summary

Temporarily reducing the unbonding period from 21 days to 7 days for nodes affected during the migration. We will revert this change on June 26th 2025.

### Primary Changes:

- Reduce `supplier_unbonding_period_sessions` from `6048` -> `2016`

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Other (specify): Parameter change

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
