### PR TITLE
[CI] pin action-gh-release version to v2.3.2

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -164,7 +164,7 @@ jobs:
       # Only publish GitHub releases for tag events
       - name: Add release and publish binaries
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631
+        uses: softprops/action-gh-release@v2.3.2
         with:
           files: |
             release/*


### PR DESCRIPTION
Now that the issue with GitHub Action is fixed (https://github.com/softprops/action-gh-release/issues/628 and https://github.com/softprops/action-gh-release/issues/627), we can go back to using version instead of gitsha.
 
Basically reverts #1458 and pins to the latest (at the moment) version.