### PR TITLE
[RelayMiner] Fix Transaction Timeout Error Handling

### DIFF
--- a/pkg/client/tx/client.go
+++ b/pkg/client/tx/client.go
@@ -229,6 +229,15 @@ func NewTxClient(
 	return txnClient, nil
 }
 
+// TODO_REFACTOR(red-0ne): Improve transaction error handling architecture
+// The current approach returns an async error channel for all transactions, but this
+// adds unnecessary complexity. Based on our experience with Cosmos SDK's transaction
+// lifecycle, we should separate two distinct error types:
+// 1. Mempool inclusion errors - These occur immediately when broadcasting (synchronous)
+// 2. Transaction execution errors - These occur during block processing (asynchronous)
+// Creating distinct paths for these error types would simplify error handling throughout
+// the codebase and improve developer experience.
+//
 // SignAndBroadcastWithTimeoutHeight signs a set of Cosmos SDK messages, constructs
 // a transaction, and broadcasts it to the network. The function performs several
 // steps to ensure the messages and the resultant transaction are valid:
@@ -587,7 +596,8 @@ func (txnClient *txClient) goTimeoutPendingTransactions(ctx context.Context) {
 		txnClient.txsMutex.Lock()
 
 		// Retrieve transactions associated with the current block's height.
-		txsByHash, ok := txnClient.txTimeoutPool[block.Height()]
+		currentHeight := block.Height()
+		txsByHash, ok := txnClient.txTimeoutPool[currentHeight]
 		if !ok {
 			// If no transactions are found for the current block height, continue.
 			txnClient.txsMutex.Unlock()
@@ -610,23 +620,36 @@ func (txnClient *txClient) goTimeoutPendingTransactions(ctx context.Context) {
 			default:
 			}
 
-			// Transaction was not processed by its subscription: handle timeout.
-			txErrCh <- txnClient.getTxTimeoutError(ctx, txHash) // Send a timeout error.
-			close(txErrCh)                                      // Close the error channel.
-			delete(txsByHash, txHash)                           // Remove the transaction.
+			// Check if the transaction was not processed by its subscription: handle timeout.
+			if err := txnClient.getTxTimeoutError(ctx, currentHeight, txHash); err != nil {
+				// Send a tx client timeout error.
+				txErrCh <- err
+			}
+			close(txErrCh)            // Close the error channel.
+			delete(txsByHash, txHash) // Remove the transaction.
 		}
 
 		// Clean up the txTimeoutPool for the current block height.
-		delete(txnClient.txTimeoutPool, block.Height())
+		delete(txnClient.txTimeoutPool, currentHeight)
 		txnClient.txsMutex.Unlock()
 	}
 }
 
+// TODO_CONSIDERATION: Simplify error handling by removing custom tx client timeout errors
+// We should consider relying solely on CosmosSDK's built-in ErrTxTimeoutHeight error,
+// which is already returned by the BroadcastTx() method when a transaction fails to be
+// committed before its timeout height. This would eliminate duplicate error handling
+// and reduce code complexity.
+//
 // getTxTimeoutError checks if a transaction with the specified hash has timed out.
 // The function decodes the provided hexadecimal hash into bytes and queries the
 // transaction using the byte hash. If any error occurs during this process,
 // appropriate wrapped errors are returned for easier debugging.
-func (txnClient *txClient) getTxTimeoutError(ctx context.Context, txHashHex string) error {
+func (txnClient *txClient) getTxTimeoutError(
+	ctx context.Context,
+	currentHeight int64,
+	txHashHex string,
+) error {
 	// Decode the provided hex hash into bytes.
 	txHash, err := hex.DecodeString(txHashHex)
 	if err != nil {
@@ -639,8 +662,22 @@ func (txnClient *txClient) getTxTimeoutError(ctx context.Context, txHashHex stri
 		return ErrQueryTx.Wrapf("with hash: %s: %s", txHashHex, err)
 	}
 
-	// Return a timeout error with details about the transaction.
-	return ErrTxTimeout.Wrapf("with hash %s: %s", txHashHex, txResponse.TxResult.Log)
+	if txResponse.TxResult.Code != 0 {
+		// Return a tx client timeout error with details about the transaction error log.
+		return ErrTxTimeout.Wrapf(
+			"with tx hash %s and height %d: %s",
+			txHashHex, currentHeight, txResponse.TxResult.Log,
+		)
+	}
+
+	// Transaction was successful even if it was expected to timeout.
+	txnClient.logger.Warn().Msgf(
+		"expecting tx with hash %s to timeout but was successful at height %d",
+		txHashHex,
+		currentHeight,
+	)
+	return nil
+
 }
 
 // getFeeAmount calculates the transaction fee amount based on client settings.

--- a/pkg/client/tx/client.go
+++ b/pkg/client/tx/client.go
@@ -658,7 +658,7 @@ func (txnClient *txClient) getTxTimeoutError(
 
 	// Query the transaction using the decoded byte hash.
 	txResponse, err := txnClient.txCtx.QueryTx(ctx, txHash, false)
-	if err != nil {
+	if err != nil || txResponse == nil {
 		return ErrQueryTx.Wrapf("with hash: %s: %s", txHashHex, err)
 	}
 
@@ -673,8 +673,7 @@ func (txnClient *txClient) getTxTimeoutError(
 	// Transaction was successful even if it was expected to timeout.
 	txnClient.logger.Warn().Msgf(
 		"expecting tx with hash %s to timeout but was successful at height %d",
-		txHashHex,
-		currentHeight,
+		txHashHex, currentHeight,
 	)
 	return nil
 

--- a/pkg/client/tx/errors.go
+++ b/pkg/client/tx/errors.go
@@ -13,9 +13,9 @@ var (
 	// to the mempool.
 	ErrCheckTx = sdkerrors.Register(codespace, 5, "error during ABCI check tx")
 
-	// ErrTxTimeout is raised when a transaction has taken too long to
+	// ErrTxTimeout is raised by the tx client when a transaction has taken too long to
 	// complete, surpassing a predefined threshold.
-	ErrTxTimeout = sdkerrors.Register(codespace, 6, "tx timed out")
+	ErrTxTimeout = sdkerrors.Register(codespace, 6, "tx client timed out")
 
 	// ErrQueryTx indicates an error occurred while trying to query for the status
 	// of a specific transaction, likely due to issues with the query parameters


### PR DESCRIPTION
## Summary

Enhance transaction timeout error handling with better validation, error messages, and logging.

### Primary Changes:
- Add validation to check if transactions are actually successful before reporting timeout errors
- Improve error reporting by including transaction height in timeout error messages
- Add warning log when a transaction expected to timeout is actually successful

### Secondary changes:
- Add TODOs for future refactoring of transaction error handling architecture
- Add considerations about simplifying error handling by leveraging SDK's built-in errors

## Issue

![image](https://github.com/user-attachments/assets/2b7afd4e-800f-4b45-887a-01049c7a02c9)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [x] 'TODO's, configurations and other docs
