### PR TITLE
[Supplier] Bug when Claiming Morse Supplier that's fully unstaked

### DIFF
--- a/x/migration/keeper/msg_server_claim_morse_supplier.go
+++ b/x/migration/keeper/msg_server_claim_morse_supplier.go
@@ -6,6 +6,7 @@ import (
 	"cosmossdk.io/errors"
 	"cosmossdk.io/math"
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -140,20 +141,24 @@ func (k msgServer) ClaimMorseSupplier(
 		}
 	}
 
-	// If:
+	// If both of the following are true:
 	// 1. The Morse Supplier started unstaking before the state shift
 	// 2. The Morse Supplier fully unstaked after the state shift at the time of claim
-	// Then the Shannon owner address is where the staked balance needs to go
+	// Then the Shannon owner address is where the staked balance needs to be minted to.
+	// DEV_NOTE: The "stake is subsequently escrowed "
 	hasUnbonded := morseNodeClaimableAccount.HasUnbonded(ctx)
+	var stakedTokensDestAddr sdk.AccAddress
 	if hasUnbonded {
-		shannonSigningAddress = shannonOwnerAddr
+		stakedTokensDestAddr = shannonOwnerAddr
+	} else {
+		stakedTokensDestAddr = shannonSigningAddress
 	}
 
-	// Mint the Morse node/supplier's stake to the shannonSigningAddress account balance.
-	// The Supplier stake is subsequently escrowed from the shannonSigningAddress account balance
+	// Mint the Morse node/supplier's stake to the stakedTokensDestAddr account balance.
+	// The Supplier stake is subsequently escrowed from the stakedTokensDestAddr account balance
 	// UNLESS it has already unbonded during the migration.
 	// NOTE: The supplier module's staking fee parameter will be deducted from the claimed balance below.
-	if err = k.MintClaimedMorseTokens(ctx, shannonSigningAddress, morseNodeClaimableAccount.GetSupplierStake()); err != nil {
+	if err = k.MintClaimedMorseTokens(ctx, stakedTokensDestAddr, morseNodeClaimableAccount.GetSupplierStake()); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 


### PR DESCRIPTION
> [!IMPORTANT]
> This is potentially a critical vulnerability

## Summary

Currently, if both of the following are true:
1. A Supplier started unstaking BEFORE state shift 
2. The Supplier FINISHED unbonding AFTER state shift at the time of claim

Then, for NON-CUSTODIAL nodes, the the staked assets go to the `operator` INSTEAD of the `owner.`


## Origin Document

https://discord.com/channels/553741558869131266/1336462284645601280/1382205197480231093

<img width="1037" alt="Screenshot 2025-06-10 at 10 05 58 PM" src="https://github.com/user-attachments/assets/ebef2b57-d864-4d6c-84a8-777ce407bcdf" />
<img width="1030" alt="Screenshot 2025-06-10 at 10 05 54 PM" src="https://github.com/user-attachments/assets/654d186f-8de9-4a18-9480-9eca3e0d4f84" />

## Explanation

In `x/migration/keeper/msg_server_claim_morse_supplier.go`, we have this code snippet:

```go
	// Mint the Morse node/supplier's stake to the shannonSigningAddress account balance.
	// The Supplier stake is subsequently escrowed from the shannonSigningAddress account balance
	// UNLESS it has already unbonded during the migration.
	// NOTE: The supplier module's staking fee parameter will be deducted from the claimed balance below.
	if err = k.MintClaimedMorseTokens(ctx, shannonSigningAddress, morseNodeClaimableAccount.GetSupplierStake()); err != nil {
		return nil, status.Error(codes.Internal, err.Error())
	}
```

Which says: `	// The Supplier stake is subsequently escrowed from the shannonSigningAddress account balance`

However, this happens:

```go
	// If unbonding is complete:
	// - No further minting is needed
	// - Block time is estimated and used to set the unstake session end height
	// - Emit event to signal unbonding start
	if hasUnbonded {
		events = append(events, morseSupplierClaimedEvent)
		events = append(events, morseSupplierUnbondingEndEvent)
		if err = emitEvents(ctx, events); err != nil {
			return nil, err
		}

		return claimMorseSupplierResponse, nil
	}
```

Before this:

```bash
	supplier, err := k.supplierKeeper.StakeSupplier(ctx, logger, msgStakeSupplier)
	if err != nil {
		// DEV_NOTE: StakeSupplier SHOULD ALWAYS return a gRPC status error.
		return nil, err
	}
```

So the comment doesn't end up holding true