### PR TITLE
[BETA][SUPPLIER][PARAMS] Matching beta `supplier_params.json` to mainnet

### DIFF
--- a/tools/scripts/params/bulk_params_beta/supplier_params.json
+++ b/tools/scripts/params/bulk_params_beta/supplier_params.json
@@ -7,11 +7,11 @@
         "params": {
           "min_stake": {
             "denom": "upokt",
-            "amount": "1000000"
+            "amount": "59500000000"
           },
           "staking_fee": {
             "denom": "upokt",
-            "amount": "1"
+            "amount": "1000000"
           }
         }
       }


### PR DESCRIPTION
## Summary

Matching beta `supplier_params.json` to mainnet

### Primary Changes:

- `supplier_params.json` `min_stake`: `100000upokt` -> `59500000000upokt`
- `supplier_params.json` `staking_fee`: `1upokt` -> `1000000upokt`

## Issue

- #1476 

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Other: param update

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
