### PR TITLE
[RelayMiner] Improve Context Handling and Session Tree Management in Relayer

### DIFF
--- a/pkg/client/events/replay_client.go
+++ b/pkg/client/events/replay_client.go
@@ -264,7 +264,7 @@ func (rClient *replayClient[T]) retryPublishEventsFactory(ctx context.Context) f
 		// Subscribe to the eventBzObs and block until the channel closes.
 		// Then pass this as an error to force the retry.OnError to resubscribe.
 		go func() {
-			eventsBzObserver := eventsBzObs.Subscribe(ctx)
+			eventsBzObserver := eventsBzObs.Subscribe(eventsBzCtx)
 			for range eventsBzObserver.Ch() {
 				// Wait for the channel to close.
 				continue

--- a/pkg/client/tx/client.go
+++ b/pkg/client/tx/client.go
@@ -461,10 +461,10 @@ func (txnClient *txClient) addPendingTransactions(
 	defer txnClient.txsMutex.Unlock()
 
 	// Initialize txTimeoutPool map if necessary.
-	txsByHash, ok := txnClient.txTimeoutPool[timeoutHeight]
+	txsByHash, ok := txnClient.txTimeoutPool[timeoutHeight+1]
 	if !ok {
 		txsByHash = make(map[string]chan error)
-		txnClient.txTimeoutPool[timeoutHeight] = txsByHash
+		txnClient.txTimeoutPool[timeoutHeight+1] = txsByHash
 	}
 
 	// Initialize txErrorChans map in txTimeoutPool map if necessary.

--- a/pkg/client/tx/client_test.go
+++ b/pkg/client/tx/client_test.go
@@ -365,7 +365,7 @@ $ go test -v -count=1 -run TestTxClient_SignAndBroadcast_CheckTxError ./pkg/clie
 
 func TestTxClient_SignAndBroadcast_Timeout(t *testing.T) {
 	var (
-		timeoutHeight = int64(5)
+		timeoutHeight = int64(6)
 		// expectedErrMsg is the expected error message that will be returned
 		// by the transaction client. It is computed and assigned in the
 		// testtx.NewOneTimeErrCheckTxTxContext helper function.

--- a/pkg/client/tx/context.go
+++ b/pkg/client/tx/context.go
@@ -193,7 +193,7 @@ func (txCtx cosmosTxContext) GetSimulatedTxGas(
 		grpc.MaxCallSendMsgSize(maxGRPCMsgSize),
 		grpc.MaxCallRecvMsgSize(maxGRPCMsgSize),
 	}
-	simRes, err := txSvcClient.Simulate(context.Background(), simRequest, gRPCOpts...)
+	simRes, err := txSvcClient.Simulate(ctx, simRequest, gRPCOpts...)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/relayer/session/claim.go
+++ b/pkg/relayer/session/claim.go
@@ -63,11 +63,8 @@ func (rs *relayerSessionsManager) createClaims(
 	// In this case, the error may not be persistent.
 	logging.LogErrors(ctx, filter.EitherError(ctx, eitherClaimedSessionsObs))
 
-	// Delete expired session trees so they don't get claimed again.
-	channel.ForEach(
-		ctx, failedCreateClaimSessionsObs,
-		rs.deleteExpiredSessionTreesFn(sharedtypes.GetClaimWindowCloseHeight),
-	)
+	// Delete failed session trees so they don't get claimed again.
+	channel.ForEach(ctx, failedCreateClaimSessionsObs, rs.deleteSessionTrees)
 
 	// Map eitherClaimedSessions to a new observable of []relayer.SessionTree
 	// which is notified when the corresponding claims creation succeeded.
@@ -101,7 +98,7 @@ func (rs *relayerSessionsManager) mapWaitForEarliestCreateClaimsHeight(
 // earliest block height, allowed by the protocol, at which claims can be created
 // for a session with the given sessionEndHeight. It is calculated relative to
 // sessionEndHeight using onchain governance parameters and randomized input.
-// It IS A BLOCKING function.
+// IT IS A BLOCKING FUNCTION.
 func (rs *relayerSessionsManager) waitForEarliestCreateClaimsHeight(
 	ctx context.Context,
 	sessionTrees []relayer.SessionTree,

--- a/pkg/relayer/session/claim.go
+++ b/pkg/relayer/session/claim.go
@@ -104,9 +104,16 @@ func (rs *relayerSessionsManager) waitForEarliestCreateClaimsHeight(
 	sessionTrees []relayer.SessionTree,
 	failedCreateClaimsSessionsCh chan<- []relayer.SessionTree,
 ) []relayer.SessionTree {
+	// Check if sessionTrees is empty to prevent index out of bounds errors
+	if len(sessionTrees) == 0 {
+		rs.logger.Warn().Msg("received empty sessionTrees array")
+		return nil
+	}
+
 	// Given the sessionTrees are grouped by their sessionEndHeight, we can use the
 	// first one from the group to calculate the earliest height for claim creation.
 	sessionEndHeight := sessionTrees[0].GetSessionHeader().GetSessionEndBlockHeight()
+	supplierOperatorAddr := sessionTrees[0].GetSupplierOperatorAddress()
 
 	logger := rs.logger.With("session_end_height", sessionEndHeight)
 
@@ -142,7 +149,6 @@ func (rs *relayerSessionsManager) waitForEarliestCreateClaimsHeight(
 	logger.Info().Msg("observed earliest claim commit height offset seed block height")
 
 	// Get the earliest claim commit height for this supplier.
-	supplierOperatorAddr := sessionTrees[0].GetSupplierOperatorAddress()
 	earliestSupplierClaimsCommitHeight := sharedtypes.GetEarliestSupplierClaimCommitHeight(
 		sharedParams,
 		sessionEndHeight,
@@ -201,6 +207,7 @@ func (rs *relayerSessionsManager) newMapClaimSessionsFn(
 		if len(sessionTrees) == 0 {
 			return either.Success(sessionTrees), false
 		}
+		sessionEndHeight := sessionTrees[0].GetSessionHeader().GetSessionEndBlockHeight()
 
 		// Filter out the session trees that the supplier operator can afford to claim.
 		claimableSessionTrees, err := rs.payableProofsSessionTrees(ctx, sessionTrees)
@@ -225,7 +232,6 @@ func (rs *relayerSessionsManager) newMapClaimSessionsFn(
 		// TODO_REFACTOR(@red-0ne): Pass a richer type to the function instead of []SessionTrees to:
 		// - Avoid making assumptions about shared properties
 		// - Eliminate constant queries for sharedParams
-		sessionEndHeight := sessionTrees[0].GetSessionHeader().GetSessionEndBlockHeight()
 		sharedParams, err := rs.sharedQueryClient.GetParams(ctx)
 		if err != nil {
 			failedCreateClaimsSessionsPublishCh <- sessionTrees
@@ -272,6 +278,11 @@ func (rs *relayerSessionsManager) payableProofsSessionTrees(
 	ctx context.Context,
 	sessionTrees []relayer.SessionTree,
 ) ([]relayer.SessionTree, error) {
+	// Check if sessionTrees is empty to prevent index out of bounds errors
+	if len(sessionTrees) == 0 {
+		return sessionTrees, nil
+	}
+
 	supplierOperatorAddress := sessionTrees[0].GetSupplierOperatorAddress()
 	logger := rs.logger.With(
 		"supplier_operator_address", supplierOperatorAddress,

--- a/pkg/relayer/session/persistence.go
+++ b/pkg/relayer/session/persistence.go
@@ -155,7 +155,7 @@ func (rs *relayerSessionsManager) loadSessionTreeMap(ctx context.Context, height
 
 		// Scenarios 2: The claim window is still open.
 		// The session has still a chance to reach settlement by creating the claim and submitting the proof.
-		sessionTree, treeErr := importSessionTree(sessionSMT, claim, rs.storesDirectory, rs.logger)
+		sessionTree, treeErr := importSessionTree(sessionSMT, claim, rs.storesDirectory, sessionLogger)
 		if treeErr != nil {
 			sessionLogger.Error().Err(treeErr).Msg("failed to import session tree")
 			continue
@@ -180,6 +180,9 @@ func (rs *relayerSessionsManager) loadSessionTreeMap(ctx context.Context, height
 // - The full persisted session tree on-disk key/value store
 // - The session tree metadata entry from the in-memory store
 func (rs *relayerSessionsManager) deletePersistedSessionTree(sessionSMT *prooftypes.SessionSMT) error {
+	rs.sessionsTreesMu.Lock()
+	defer rs.sessionsTreesMu.Unlock()
+
 	supplierOperatorAddress := sessionSMT.SupplierOperatorAddress
 	sessionId := sessionSMT.SessionHeader.SessionId
 	sessionEndHeight := sessionSMT.SessionHeader.SessionEndBlockHeight
@@ -254,6 +257,9 @@ func (rs *relayerSessionsManager) persistSessionMetadata(sessionTree relayer.Ses
 // supplierOperatorAddress->blockHeight->sessionId->sessionTree.
 // Return true if the session was inserted, false if it already exists.
 func (rs *relayerSessionsManager) insertSessionTree(sessionTree relayer.SessionTree) bool {
+	rs.sessionsTreesMu.Lock()
+	defer rs.sessionsTreesMu.Unlock()
+
 	supplierOperatorAddress := sessionTree.GetSupplierOperatorAddress()
 	sessionId := sessionTree.GetSessionHeader().SessionId
 	sessionEndHeight := sessionTree.GetSessionHeader().SessionEndBlockHeight
@@ -296,6 +302,9 @@ func (rs *relayerSessionsManager) insertSessionTree(sessionTree relayer.SessionT
 // proveClaimedSessions processes the claimed sessions and sends them to the
 // relayer for proof submission without going through the whole pipeline.
 func (rs *relayerSessionsManager) proveClaimedSessions(ctx context.Context) {
+	rs.sessionsTreesMu.Lock()
+	defer rs.sessionsTreesMu.Unlock()
+
 	// Iterate over all supplier clients so we can submit proofs for all claimed sessions.
 	for supplierOperatorAddress, supplierClient := range rs.supplierClients.SupplierClients {
 		// TODO_TECHDEBT(@bryanchriswhite): Close the channel when all the sessions have been processed.

--- a/pkg/relayer/session/proof.go
+++ b/pkg/relayer/session/proof.go
@@ -80,6 +80,7 @@ func (rs *relayerSessionsManager) waitForEarliestSubmitProofsHeightAndGeneratePr
 ) []relayer.SessionTree {
 	// Given the sessionTrees are grouped by their sessionEndHeight, we can use the
 	// first one from the group to calculate the earliest height for proof submission.
+	// TODO_IN_THIS_PR: Look for all 'sessionTrees[0]' and add a guard in place to ensure no index out of bounds errors.
 	sessionEndHeight := sessionTrees[0].GetSessionHeader().GetSessionEndBlockHeight()
 
 	logger := rs.logger.With("session_end_height", sessionEndHeight)

--- a/pkg/relayer/session/proof.go
+++ b/pkg/relayer/session/proof.go
@@ -47,11 +47,8 @@ func (rs *relayerSessionsManager) submitProofs(
 
 	logging.LogErrors(ctx, filter.EitherError(ctx, eitherProvenSessionsObs))
 
-	// Delete expired session trees so they don't get proven again.
-	channel.ForEach(
-		ctx, failedSubmitProofsSessionsObs,
-		rs.deleteExpiredSessionTreesFn(sharedtypes.GetProofWindowCloseHeight),
-	)
+	// Delete failed session trees so they don't get proven again.
+	channel.ForEach(ctx, failedSubmitProofsSessionsObs, rs.deleteSessionTrees)
 }
 
 // mapWaitForEarliestSubmitProofsHeight is intended to be used as a MapFn. It

--- a/pkg/relayer/session/session.go
+++ b/pkg/relayer/session/session.go
@@ -41,6 +41,8 @@ type relayerSessionsManager struct {
 	// 2. Ensure the mutex is used everywhere it's needed and is not used everywhere it's not
 	// 3. Cleanup comments and techdebt in this package.
 
+	// TODO_IN_THIS_PR: Identify all functions accessing and mutating 'rs.sessionTrees` and lock the mutex in there
+
 	// sessionTrees is a SessionsTreesMap (see type alias above).
 	//
 	// - The block height index is used to know when the sessions contained in the entry should be closed.

--- a/pkg/relayer/session/session_persistence_test.go
+++ b/pkg/relayer/session/session_persistence_test.go
@@ -250,6 +250,9 @@ func (s *SessionPersistenceTestSuite) TestRestartAfterClaimSubmitted() {
 
 	// Calculate when the claim window opens for this session
 	claimWindowOpenHeight := sharedtypes.GetClaimWindowOpenHeight(&s.sharedParams, sessionEndHeight)
+	claimWindowCloseHeight := sharedtypes.GetClaimWindowCloseHeight(&s.sharedParams, sessionEndHeight)
+	fmt.Println("claimWindowOpenHeight", claimWindowOpenHeight)
+	fmt.Println("claimWindowCloseHeight", claimWindowCloseHeight)
 	// Move to the block where the claim window opens (which should trigger claim creation)
 	s.advanceToBlock(claimWindowOpenHeight)
 

--- a/pkg/relayer/session/sessiontree.go
+++ b/pkg/relayer/session/sessiontree.go
@@ -128,6 +128,8 @@ func importSessionTree(
 ) (relayer.SessionTree, error) {
 	sessionId := sessionSMT.SessionHeader.SessionId
 	supplierOperatorAddress := sessionSMT.SupplierOperatorAddress
+	applicationAddress := sessionSMT.SessionHeader.ApplicationAddress
+	serviceId := sessionSMT.SessionHeader.ServiceId
 	smtRoot := sessionSMT.SmtRoot
 	storePath := filepath.Join(storesDirectory, supplierOperatorAddress, sessionId)
 
@@ -147,8 +149,10 @@ func importSessionTree(
 	}
 
 	logger = logger.With(
-		"session_id", sessionId,
+		"service_id", serviceId,
+		"application_address", applicationAddress,
 		"supplier_operator_address", supplierOperatorAddress,
+		"session_id", sessionId,
 	)
 
 	// SCENARIO 1: Session has been claimed
@@ -157,10 +161,7 @@ func importSessionTree(
 	if claim != nil {
 		sessionTree.claimedRoot = claim.RootHash
 		sessionTree.isClaiming = true
-		logger.Info().Msgf(
-			"imported session tree with committed onchain claim - root hash: %x",
-			claim.RootHash,
-		)
+		logger.Info().Msg("imported a session tree WITH A PREVIOUSLY COMMITTED onchain claim")
 		return sessionTree, nil
 	}
 
@@ -182,7 +183,7 @@ func importSessionTree(
 	sessionTree.claimedRoot = nil  // explicitly set for posterity
 	sessionTree.isClaiming = false // explicitly set for posterity
 
-	logger.Info().Msg("the imported session tree with no committed onchain claim")
+	logger.Info().Msg("imported a session tree WITHOUT A PREVIOUSLY COMMITTED onchain claim")
 
 	return sessionTree, nil
 }

--- a/x/shared/types/session.go
+++ b/x/shared/types/session.go
@@ -102,7 +102,7 @@ func GetProofWindowCloseHeight(sharedParams *Params, queryHeight int64) int64 {
 // TODO_TECHDEBT(@red-0ne): Having claim distribution windows was
 // a requirement that was never determined to be necessary, but implemented regardless.
 // We are keeping around the functions but TBD whether it is deemed necessary. The results
-// of #711 are tengentially related to this requirement, after which the functions,
+// of #711 are tangentially related to this requirement, after which the functions,
 // helpers, comments and docs for claim distribution can either be repurposed or deleted.
 func GetEarliestSupplierClaimCommitHeight(
 	sharedParams *Params,
@@ -129,7 +129,7 @@ func GetEarliestSupplierClaimCommitHeight(
 // TODO_TECHDEBT(@red-0ne): Having proof distribution windows was
 // a requirement that was never determined to be necessary, but implemented regardless.
 // We are keeping around the functions but TBD whether it is deemed necessary. The results
-// of #711 are tengentially related to this requirement, after which the functions,
+// of #711 are tangentially related to this requirement, after which the functions,
 // helpers, comments and docs for claim distribution can either be repurposed or deleted.
 func GetEarliestSupplierProofCommitHeight(
 	sharedParams *Params,


### PR DESCRIPTION
Original: #1480 
```bash
go test --tags=test -v -count=1  ./pkg/relayer/session/... -run TestSessionPersistence/TestRestartAfterClaimSubmitted
```
```text
{"level":"info","method":"RSM.deleteExpiredSessionTreesFn","supplier_operator_address":"pokt1l5zzacp6n5kunukrzl3v388kk5e24wwrqr86wd","message":"no session trees found for the supplier operator address"}
{"level":"debug","session_id":"sessionId","application":"","supplier_operator_address":"pokt1l5zzacp6n5kunukrzl3v388kk5e24wwrqr86wd","message":"added relay to session tree"}
claimWindowOpenHeight 12
claimWindowCloseHeight 16
{"level":"debug","method":"RSM.deleteSessionTrees","message":"no session trees to delete"}
{"level":"debug","method":"RSM.deleteSessionTrees","message":"no session trees to delete"}
{"level":"debug","method":"RSM.deleteSessionTrees","message":"no session trees to delete"}
{"level":"debug","method":"RSM.deleteSessionTrees","message":"no session trees to delete"}
{"level":"info","session_end_height":10,"claim_window_open_height":12,"message":"waiting & blocking until the earliest claim commit height offset seed block height"}
{"level":"debug","method":"RSM.deleteSessionTrees","message":"no session trees to delete"}
{"level":"debug","method":"RSM.deleteSessionTrees","message":"no session trees to delete"}
{"level":"debug","method":"RSM.deleteSessionTrees","message":"no session trees to delete"}
{"level":"debug","method":"RSM.deleteSessionTrees","message":"no session trees to delete"}
{"level":"debug","method":"RSM.deleteSessionTrees","message":"no session trees to delete"}
{"level":"debug","method":"RSM.deleteSessionTrees","message":"no session trees to delete"}
{"level":"debug","method":"RSM.deleteSessionTrees","message":"no session trees to delete"}
{"level":"info","session_end_height":10,"claim_window_open_height":12,"claim_window_open_block_hash":"0000000000000000000000000000000000000000000000000000000000000000","message":"observed earliest claim commit height offset seed block height"}
{"level":"info","session_end_height":10,"claim_window_open_height":12,"claim_window_open_block_hash":"0000000000000000000000000000000000000000000000000000000000000000","earliest_claim_commit_height":12,"message":"waiting & blocking until the earliest claim commit height for this supplier"}
{"level":"info","session_end_height":10,"claim_window_open_height":12,"claim_window_open_block_hash":"0000000000000000000000000000000000000000000000000000000000000000","earliest_claim_commit_height":12,"message":"observed earliest claim commit height 12"}
{"level":"info","session_end_height":10,"proof_window_open_height":16,"message":"waiting & blocking until the proof window open height"}
{"level":"warn","session_end_height":10,"proof_window_open_height":16,"message":"failed to observe earliest proof commit height offset seed block height"}
{"level":"info","method":"RSM.deleteSessionTrees","supplier_operator_address":"pokt1l5zzacp6n5kunukrzl3v388kk5e24wwrqr86wd","session_id":"sessionId","message":"deleting session tree"}
{"level":"info","store_path":"/var/folders/th/667_sx1j13343j4_k93ppf380000gn/T/TestSessionPersistence_TestRestartAfterClaimSubmitted_smt_kvstore917941092/pokt1l5zzacp6n5kunukrzl3v388kk5e24wwrqr86wd/sessionId","session_id":"sessionId","supplier_operator_address":"pokt1l5zzacp6n5kunukrzl3v388kk5e24wwrqr86wd","claim_root":"8821fca71eae22170811eb9ca3ddce4e309bcf7dfa1c05e37a1ee838022de0c600000000000000020000000000000001","message":"KVStore is already stopped"}
{"level":"debug","method":"RSM.deleteSessionTrees","supplier_operator_address":"pokt1l5zzacp6n5kunukrzl3v388kk5e24wwrqr86wd","message":"deleted 1 session trees from relayerSessions"}
{"level":"debug","method":"RSM.Stop","session_id":"sessionId","supplier_operator_address":"pokt1l5zzacp6n5kunukrzl3v388kk5e24wwrqr86wd","message":"Successfully stored session tree on disk"}
{"level":"info","message":"Successfully cleared 1 session trees from memory"}
2025/06/12 22:02:42 [JOB 1] WAL file /var/folders/th/667_sx1j13343j4_k93ppf380000gn/T/TestSessionPersistence_TestRestartAfterClaimSubmitted_smt_kvstore917941092/sessions_metadata/000002.log with log number 000002 stopped reading at offset: 392; replayed 2 keys in 2 batches
{"level":"info","method":"populateSessionTreeMap","height":13,"message":"about to load 1 persisted sessions into memory"}
{"level":"error","method":"populateSessionTreeMap","height":13,"session_id":"sessionId","supplier_operator_address":"pokt1l5zzacp6n5kunukrzl3v388kk5e24wwrqr86wd","session_end_height":10,"claim_window_close":16,"proof_window_close":20,"current_height":13,"error":"stat /var/folders/th/667_sx1j13343j4_k93ppf380000gn/T/TestSessionPersistence_TestRestartAfterClaimSubmitted_smt_kvstore917941092/pokt1l5zzacp6n5kunukrzl3v388kk5e24wwrqr86wd/sessionId: no such file or directory","message":"session tree store path does not exist: \"/var/folders/th/667_sx1j13343j4_k93ppf380000gn/T/TestSessionPersistence_TestRestartAfterClaimSubmitted_smt_kvstore917941092/pokt1l5zzacp6n5kunukrzl3v388kk5e24wwrqr86wd/sessionId\""}
{"level":"error","method":"populateSessionTreeMap","height":13,"session_id":"sessionId","supplier_operator_address":"pokt1l5zzacp6n5kunukrzl3v388kk5e24wwrqr86wd","session_end_height":10,"claim_window_close":16,"proof_window_close":20,"current_height":13,"error":"stat /var/folders/th/667_sx1j13343j4_k93ppf380000gn/T/TestSessionPersistence_TestRestartAfterClaimSubmitted_smt_kvstore917941092/pokt1l5zzacp6n5kunukrzl3v388kk5e24wwrqr86wd/sessionId: no such file or directory","message":"failed to import session tree"}
{"level":"info","method":"RSM.deleteExpiredSessionTreesFn","supplier_operator_address":"pokt1l5zzacp6n5kunukrzl3v388kk5e24wwrqr86wd","message":"no session trees found for the supplier operator address"}
    session_persistence_test.go:383:
        	Error Trace:	/Users/olshansky/workspace/pocket/poktroll/pkg/relayer/session/session_persistence_test.go:383
        	            				/Users/olshansky/workspace/pocket/poktroll/pkg/relayer/session/session_persistence_test.go:283
        	Error:      	Should be true
        	Test:       	TestSessionPersistence/TestRestartAfterClaimSubmitted
{"level":"info","message":"Successfully cleared 0 session trees from memory"}
--- FAIL: TestSessionPersistence (0.62s)
    --- FAIL: TestSessionPersistence/TestRestartAfterClaimSubmitted (0.62s)
FAIL
FAIL	github.com/pokt-network/poktroll/pkg/relayer/session	1.515s
FAIL
```