### PR TITLE
fix: encoding on missing MorseClaimableAccounts JSON

### DIFF
--- a/app/upgrades/v0.1.20.go
+++ b/app/upgrades/v0.1.20.go
@@ -25,18 +25,36 @@ const (
 var mainNetZeroBalanceMorseClaimableAccountsJSONBZ = []byte(`[
   {
     "morse_src_address": "0C3B325133D65B6136CD59511CC63F17EF992BE6",
-    "unstaked_balance": "0upokt",
-    "supplier_stake": "0upokt",
-    "application_stake": "0upokt",
+    "unstaked_balance": {
+      "amount": "0",
+      "denom": "upokt"
+    },
+    "supplier_stake": {
+      "amount": "0",
+      "denom": "upokt"
+    },
+    "application_stake": {
+      "amount": "0",
+      "denom": "upokt"
+    },
     "claimed_at_height": 0,
     "shannon_dest_address": "",
     "morse_output_address": ""
   },
   {
     "morse_src_address": "F022ED4E7CCBCE2ABE54E2E3E51B847247E12DDB",
-    "unstaked_balance": "0upokt",
-    "supplier_stake": "0upokt",
-    "application_stake": "0upokt",
+    "unstaked_balance": {
+      "amount": "0",
+      "denom": "upokt"
+    },
+    "supplier_stake": {
+      "amount": "0",
+      "denom": "upokt"
+    },
+    "application_stake": {
+      "amount": "0",
+      "denom": "upokt"
+    },
     "claimed_at_height": 0,
     "shannon_dest_address": "",
     "morse_output_address": ""
@@ -47,18 +65,36 @@ var mainNetZeroBalanceMorseClaimableAccountsJSONBZ = []byte(`[
 var testNetZeroBalanceMorseClaimableAccountsJSONBZ = []byte(`[
   {
     "morse_src_address": "1C66C4B5905CF32EE9ED9D806D6EE12E93D38C20",
-    "unstaked_balance": "0upokt",
-    "supplier_stake": "0upokt",
-    "application_stake": "0upokt",
+    "unstaked_balance": {
+      "amount": "0",
+      "denom": "upokt"
+    },
+    "supplier_stake": {
+      "amount": "0",
+      "denom": "upokt"
+    },
+    "application_stake": {
+      "amount": "0",
+      "denom": "upokt"
+    },
     "claimed_at_height": 0,
     "shannon_dest_address": "",
     "morse_output_address": ""
   },
   {
     "morse_src_address": "1FA385948BFF6856765A048BC9F1920354EF87FD",
-    "unstaked_balance": "0upokt",
-    "supplier_stake": "0upokt",
-    "application_stake": "0upokt",
+    "unstaked_balance": {
+      "amount": "0",
+      "denom": "upokt"
+    },
+    "supplier_stake": {
+      "amount": "0",
+      "denom": "upokt"
+    },
+    "application_stake": {
+      "amount": "0",
+      "denom": "upokt"
+    },
     "claimed_at_height": 0,
     "shannon_dest_address": "",
     "morse_output_address": ""

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/go-kit/kit v0.13.0
 	github.com/gogo/status v1.1.0
 	github.com/golang/mock v1.6.0
-	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/golang/protobuf v1.5.4
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0

--- a/tools/scripts/migration/collect_non_existent_morse_output_accounts.sh
+++ b/tools/scripts/migration/collect_non_existent_morse_output_accounts.sh
@@ -113,7 +113,7 @@ get_all_raw_morse_claimable_account_src_addresses() {
 # Generate a JSON array of zero-balance Morse claimable accounts for the given JSON array of Morse claimable accounts..
 #   $1 - JSON array of Morse claimable accounts
 zero_balance_morse_claimable_accounts_for_addresses_json() {
-  echo "$1" | jq -r '.|map({morse_src_address: ., unstaked_balance: "0upokt", supplier_stake: "0upokt", application_stake: "0upokt", claimed_at_height: 0, shannon_dest_address: "", morse_output_address: ""})'
+  echo "$1" | jq -r '.|map({morse_src_address: ., unstaked_balance: {amount: "0", denom: "upokt"}, supplier_stake: {amount: "0", denom: "upokt"}, application_stake: {amount: "0", denom: "upokt"}, claimed_at_height: 0, shannon_dest_address: "", morse_output_address: ""})'
 }
 
 # Generate a JSON array of missing Morse claimable accounts for the MainNet state export with the given MainNet height.


### PR DESCRIPTION
## Summary

Fixes the encoding of the missing `MorseClaimableAccount`s which are added in v0.1.20 upgrade.

## Issue

- N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
