### PR TITLE
Update Morse bulk to handle output address node and skip already claimed accounts.

### DIFF
--- a/x/migration/module/cmd/claim_morse_account_bulk.go
+++ b/x/migration/module/cmd/claim_morse_account_bulk.go
@@ -436,6 +436,13 @@ func readMorseAccountsPrivateKeysFile(
 			continue
 		}
 
+		if res.MorseClaimableAccount.MorseOutputAddress != "" {
+			// Ignore already-claimed Morse accounts during the bulk supplier migration.
+			// This is intentional behaviour assuming a human error of not removing a key from the input-file that has already been claimed.
+			logger.Logger.Warn().Msgf("Skipping accounts with morse address (%s) because it has staked balance: %v, please use `pocketd tx migration claim-supplier` instead", morseAddressStr, res.MorseClaimableAccount)
+			continue
+		}
+
 		// Morse account is in the snapshot and not yet claimed.
 		// Add it to migration list.
 		morseAccounts = append(morseAccounts, MorseAccountInfo{

--- a/x/migration/module/cmd/claim_morse_supplier_bulk.go
+++ b/x/migration/module/cmd/claim_morse_supplier_bulk.go
@@ -312,13 +312,9 @@ func runClaimSuppliers(cmd *cobra.Command, _ []string) error {
 				Str("morse_output_address", claimableMorseNode.MorseOutputAddress).
 				Msg("Checking MorseOutputAddress exists as MorseClaimableAccount and is already migrated.")
 			// Non-custodial: load and cache MorseClaimableAccount for output address
-			claimableMorseAccount, outputAddressIsNode, morseAccountError := queryMorseClaimableAccount(ctx, clientCtx, morseOutputAddress)
+			claimableMorseAccount, _, morseAccountError := queryMorseClaimableAccount(ctx, clientCtx, morseOutputAddress)
 			if morseAccountError != nil {
 				return morseAccountError
-			}
-			if outputAddressIsNode {
-				// TODO_TECHDEBT(@olshansky): Re-evaluate if/how this can happen and tackle it separately.
-				return fmt.Errorf("the bulk claim tool does not have support for non-custodial nodes when the morse output address '%s' is a node", morseOutputAddress)
 			}
 
 			if !claimableMorseAccount.IsClaimed() {


### PR DESCRIPTION
## Summary

Update Morse bulk claim logic to handle non-custodial node cases and skip already-claimed accounts.

## Issue

- `claim-suppliers` was not allowing to claim when the output address was a node
- `claim-accounts` was exiting earlier when an account was a node.

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
