### PR TITLE
[Upgrade] Adding v0.1.21.go upgrade handler

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -98,7 +98,12 @@ var allUpgrades = []upgrades.Upgrade{
 	// v0.1.20 - upgrade to:
 	// - Add zero-balance/stake `MorseClaimableAccount`s for Morse owner accounts that are non-custodial and had no corresponding `MorseAuthAccount`
 	// - Update the Morse account recovery allowlist with exchange allowlist updates and invalid addresses
-	upgrades.Upgrade_0_1_20,
+	// upgrades.Upgrade_0_1_20,
+
+	// v0.1.21 - upgrade to:
+	// - Update the Morse account recovery allowlist with exchange allowlist updates and invalid addresses
+	// - Slim down excessively sized proof module events:
+	upgrades.Upgrade_0_1_21,
 }
 
 // setUpgrades sets upgrade handlers for all upgrades and executes KVStore migration if an upgrade plan file exists.

--- a/app/upgrades/v0.1.21.go
+++ b/app/upgrades/v0.1.21.go
@@ -1,0 +1,47 @@
+package upgrades
+
+import (
+	"context"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/pokt-network/poktroll/app/keepers"
+)
+
+const (
+	Upgrade_0_1_21_PlanName = "v0.1.21"
+)
+
+// Upgrade_0_1_21 handles the upgrade to release `v0.1.21`.
+// This upgrade adds:
+//  1. Update the recovery allowlist to include the additional accounts
+//  2. Slim down excessively sized proof module events:
+//     - Changes multiple event protobuf types.
+//     - Nodes syncing from genesis will run distinct binaries and swap them at the respective onchain upgrade heights—no state migration required.
+//     - WILL impact offchain observers who consume/operate on historical data.
+//     - Proper protobuf type (pkg-level) versioning is required to mitigate this.
+//     - See: https://github.com/pokt-network/poktroll/issues/1517.
+var Upgrade_0_1_21 = Upgrade{
+	PlanName: Upgrade_0_1_21_PlanName,
+	// No KVStore migrations in this upgrade.
+	StoreUpgrades: storetypes.StoreUpgrades{},
+
+	// Upgrade Handler
+	CreateUpgradeHandler: func(
+		mm *module.Manager,
+		keepers *keepers.Keepers,
+		configurator module.Configurator,
+	) upgradetypes.UpgradeHandler {
+		// Add new parameters by:
+		// 1. Inspecting the diff between v0.1.20..v0.1.21
+		// 2. Manually inspect changes in ignite's config.yml
+		// 3. Update the upgrade handler here accordingly
+		// Ref: https://github.com/pokt-network/poktroll/compare/v0.1.20..v0.1.21
+
+		return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+			return vm, nil
+		}
+	},
+}

--- a/app/upgrades/v0.1.21.go
+++ b/app/upgrades/v0.1.21.go
@@ -34,10 +34,6 @@ var Upgrade_0_1_21 = Upgrade{
 		keepers *keepers.Keepers,
 		configurator module.Configurator,
 	) upgradetypes.UpgradeHandler {
-		// Add new parameters by:
-		// 1. Inspecting the diff between v0.1.20..v0.1.21
-		// 2. Manually inspect changes in ignite's config.yml
-		// 3. Update the upgrade handler here accordingly
 		// Ref: https://github.com/pokt-network/poktroll/compare/v0.1.20..v0.1.21
 
 		return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {

--- a/app/upgrades/vNEXT.go
+++ b/app/upgrades/vNEXT.go
@@ -1,27 +1,3 @@
-// vNEXT_Template.go - Canonical Upgrade Template
-//
-// ────────────────────────────────────────────────────────────────
-// TEMPLATE PURPOSE:
-//   - This file is the canonical TEMPLATE for all future onchain upgrade files in the poktroll repo.
-//   - DO NOT add upgrade-specific logic or changes to this file.
-//   - YOU SHOULD NEVER NEED TO CHANGE THIS FILE
-//
-// USAGE INSTRUCTIONS:
-//  1. To start a new upgrade cycle, rename vNEXT.go to the target version (e.g., v0.1.14.go) and update all identifiers accordingly:
-//     cp ./app/upgrades/vNEXT.go ./app/upgrades/v0.1.14.go
-//  2. Then, copy this file to vNEXT.go:
-//     cp ./app/upgrades/vNEXT_Template.go ./app/upgrades/vNEXT.go
-//  3. Look for the word "Template" in `vNEXT.go` and replace it with an empty string.
-//  4. Make all upgrade-specific changes in vNEXT.go only.
-//  5. To reset, restore, or start a new upgrade cycle, repeat fromstep 1.
-//  6. Update the last entry in the `allUpgrades` slice in `app/upgrades.go` to point to the new upgrade version variable.
-//
-// vNEXT_Template.go should NEVER be modified for upgrade-specific logic.
-// Only update this file to improve the template itself.
-//
-//	See also: https://github.com/pokt-network/poktroll/compare/vPREV..vNEXT
-//
-// ────────────────────────────────────────────────────────────────
 package upgrades
 
 import (
@@ -43,13 +19,7 @@ const (
 
 // Upgrade_NEXT handles the upgrade to release `vNEXT`.
 // This upgrade adds:
-//  1. Update the recovery allowlist to include the additional accounts
-//  2. Slim down excessively sized proof module events:
-//     - Changes multiple event protobuf types.
-//     - Nodes syncing from genesis will run distinct binaries and swap them at the respective onchain upgrade heights—no state migration required.
-//     - WILL impact offchain observers who consume/operate on historical data.
-//     - Proper protobuf type (pkg-level) versioning is required to mitigate this.
-//     - See: https://github.com/pokt-network/poktroll/issues/1517.
+// - ...
 var Upgrade_NEXT = Upgrade{
 	PlanName: Upgrade_NEXT_PlanName,
 	// No KVStore migrations in this upgrade.

--- a/app/upgrades/vNEXT_Template.go
+++ b/app/upgrades/vNEXT_Template.go
@@ -13,7 +13,7 @@
 //     cp ./app/upgrades/vNEXT_Template.go ./app/upgrades/vNEXT.go
 //  3. Look for the word "Template" in `vNEXT.go` and replace it with an empty string.
 //  4. Make all upgrade-specific changes in vNEXT.go only.
-//  5. To reset, restore, or start a new upgrade cycle, repeat fromstep 1.
+//  5. To reset, restore, or start a new upgrade cycle, repeat from step 1.
 //  6. Update the last entry in the `allUpgrades` slice in `app/upgrades.go` to point to the new upgrade version variable.
 //
 // vNEXT_Template.go should NEVER be modified for upgrade-specific logic.


### PR DESCRIPTION
v0.1.21 - upgrade to:
 - Update the Morse account recovery allowlist with exchange allowlist updates and invalid addresses
 - Slim down excessively sized proof module events:

Refs:
- https://dev.poktroll.com/develop/upgrades/release_procedure

![Screenshot 2025-06-18 at 1 07 13 PM](https://github.com/user-attachments/assets/667eb81f-4551-46d0-a98c-c65b7715e1b5)