### PR TITLE
[RelayMiner][Bug] Create sessionSMT before tree deletion to ensure proper SMT root retrieval

### DIFF
--- a/pkg/relayer/session/session.go
+++ b/pkg/relayer/session/session.go
@@ -681,6 +681,10 @@ func (rs *relayerSessionsManager) deleteSessionTree(sessionTree relayer.SessionT
 		"supplier_operator_address", sessionTree.GetSupplierOperatorAddress(),
 	)
 
+	// IMPORTANT: Create sessionSMT BEFORE deleting the tree
+	// This ensures we retrieve the SMT root while the KVStore is still open.
+	sessionSMT := sessionSMTFromSessionTree(sessionTree)
+
 	// Delete the session tree from the KVStore and close the underlying store.
 	if err := sessionTree.Delete(); err != nil {
 		logger.Error().Err(err).Msg("❌️ Failed to delete session tree from kvstore. ❗Check disk permissions and kvstore integrity. ❗Session data may persist incorrectly.")
@@ -688,7 +692,6 @@ func (rs *relayerSessionsManager) deleteSessionTree(sessionTree relayer.SessionT
 
 	// Delete the persisted session tree metadata from the disk store.
 	// This is necessary to ensure that the session is not restored on the next startup.
-	sessionSMT := sessionSMTFromSessionTree(sessionTree)
 	if err := rs.deletePersistedSessionTree(sessionSMT); err != nil {
 		logger.Error().
 			Err(err).


### PR DESCRIPTION
## Summary

Fix session deletion bug by retrieving SMT root before closing the KVStore

### Primary Changes:
- Move `sessionSMT` creation before the `sessionTree.Delete()` call
- Ensure SMT root is retrieved while the KVStore is still open
- Add comments explaining the importance of the execution order

## Issue

<details>
<summary>`panic: d.nx != 0` (Click for full stack trace)</summary>

```
relayminer  | panic: d.nx != 0
relayminer  |
relayminer  | goroutine 9751 [running]:
relayminer  | crypto/internal/fips140/sha256.(*Digest).checkSum(0xc0069b7418)
relayminer  | /opt/hostedtoolcache/go/1.24.3/x64/src/crypto/internal/fips140/sha256/sha256.go:214 +0x194
relayminer  | crypto/internal/fips140/sha256.(*Digest).Sum(0xc00c418f80, {0x0, 0x0, 0x0})
relayminer  | /opt/hostedtoolcache/go/1.24.3/x64/src/crypto/internal/fips140/sha256/sha256.go:188 +0x7d
relayminer  | github.com/pokt-network/smt.(*trieHasher).digestData(0xc055580e60, {0xc007898c00?, 0xc02a3c6f80?, 0xc0069b7540?})
relayminer  | /home/runner/go/pkg/mod/github.com/pokt-network/smt@v0.13.0/hasher.go:105 +0x3e
relayminer  | github.com/pokt-network/smt.(*TrieSpec).digestSumNode(0xc055580e60, {0x50f6120?, 0xc02a3c6f80?})
relayminer  | /home/runner/go/pkg/mod/github.com/pokt-network/smt@v0.13.0/trie_spec.go:231 +0x17b
relayminer  | github.com/pokt-network/smt.(*TrieSpec).encodeSumNode(0xc055580e60, {0x50f6120?, 0xc029cd3ac0})
relayminer  | /home/runner/go/pkg/mod/github.com/pokt-network/smt@v0.13.0/trie_spec.go:199 +0xb0
relayminer  | github.com/pokt-network/smt.(*TrieSpec).digestSumNode(0xc055580e60, {0x50f6120?, 0xc029cd3ac0?})
relayminer  | /home/runner/go/pkg/mod/github.com/pokt-network/smt@v0.13.0/trie_spec.go:229 +0x150
relayminer  | github.com/pokt-network/smt.(*TrieSpec).encodeSumNode(0xc055580e60, {0x50f6120?, 0xc060617f00})
relayminer  | /home/runner/go/pkg/mod/github.com/pokt-network/smt@v0.13.0/trie_spec.go:200 +0xdc
relayminer  | github.com/pokt-network/smt.(*TrieSpec).digestSumNode(0xc055580e60, {0x50f6120?, 0xc060617f00?})
relayminer  | /home/runner/go/pkg/mod/github.com/pokt-network/smt@v0.13.0/trie_spec.go:229 +0x150
relayminer  | github.com/pokt-network/smt.(*TrieSpec).encodeSumNode(0xc055580e60, {0x50f6120?, 0xc03ce6a2c0})
relayminer  | /home/runner/go/pkg/mod/github.com/pokt-network/smt@v0.13.0/trie_spec.go:199 +0xb0
relayminer  | github.com/pokt-network/smt.(*TrieSpec).digestSumNode(0xc055580e60, {0x50f6120?, 0xc03ce6a2c0?})
relayminer  | /home/runner/go/pkg/mod/github.com/pokt-network/smt@v0.13.0/trie_spec.go:229 +0x150
relayminer  | github.com/pokt-network/smt.(*TrieSpec).encodeSumNode(0xc055580e60, {0x50f6120?, 0xc029e768c0})
relayminer  | /home/runner/go/pkg/mod/github.com/pokt-network/smt@v0.13.0/trie_spec.go:200 +0xdc
relayminer  | github.com/pokt-network/smt.(*TrieSpec).digestSumNode(0xc055580e60, {0x50f6120?, 0xc029e768c0?})
relayminer  | /home/runner/go/pkg/mod/github.com/pokt-network/smt@v0.13.0/trie_spec.go:229 +0x150
relayminer  | github.com/pokt-network/smt.(*TrieSpec).encodeSumNode(0xc055580e60, {0x50f6120?, 0xc03422c940})
relayminer  | /home/runner/go/pkg/mod/github.com/pokt-network/smt@v0.13.0/trie_spec.go:199 +0xb0
relayminer  | github.com/pokt-network/smt.(*TrieSpec).digestSumNode(0xc055580e60, {0x50f6120?, 0xc03422c940?})
relayminer  | /home/runner/go/pkg/mod/github.com/pokt-network/smt@v0.13.0/trie_spec.go:229 +0x150
relayminer  | github.com/pokt-network/smt.(*TrieSpec).digest(0x0?, {0x50f6120?, 0xc03422c940?})
relayminer  | /home/runner/go/pkg/mod/github.com/pokt-network/smt@v0.13.0/trie_spec.go:82 +0x25
relayminer  | github.com/pokt-network/smt.(*SMT).Root(...)
relayminer  | /home/runner/go/pkg/mod/github.com/pokt-network/smt@v0.13.0/smt.go:62
relayminer  | github.com/pokt-network/smt.(*SMST).Root(0x0?)
relayminer  | /home/runner/go/pkg/mod/github.com/pokt-network/smt@v0.13.0/smst.go:175 +0x25
relayminer  | github.com/pokt-network/poktroll/pkg/relayer/session.(*sessionTree).GetSMSTRoot(0x33d5ea0?)
relayminer  | /home/runner/work/poktroll/poktroll/pkg/relayer/session/sessiontree.go:327 +0x22
relayminer  | github.com/pokt-network/poktroll/pkg/relayer/session.sessionSMTFromSessionTree({0x514a2f8, 0xc031b54180})
relayminer  | /home/runner/work/poktroll/poktroll/pkg/relayer/session/session.go:742 +0x54
relayminer  | github.com/pokt-network/poktroll/pkg/relayer/session.(*relayerSessionsManager).deleteSessionTree(0xc002aa4cc0, {0x514a2f8, 0xc031b54180})
relayminer  | /home/runner/work/poktroll/poktroll/pkg/relayer/session/session.go:691 +0x2e5
relayminer  | github.com/pokt-network/poktroll/pkg/relayer/session.(*relayerSessionsManager).deleteSessionTrees(0xc002aa4cc0, {0x42c76c8?, 0xc003bd6e40?}, {0xc0010dc370, 0x1, 0x4477b9bf88d5fe57?})
relayminer  | /home/runner/work/poktroll/poktroll/pkg/relayer/session/session.go:660 +0x1fc
relayminer  | github.com/pokt-network/poktroll/pkg/relayer/session.(*relayerSessionsManager).supplierSessionsToClaim.(*relayerSessionsManager).deleteExpiredSessionTreesFn.func2({0x5122dc0, 0xc0010ba420}, {0x511fb40, 0xc00884b500})
relayminer  | /home/runner/work/poktroll/poktroll/pkg/relayer/session/session.go:634 +0x39b
relayminer  | github.com/pokt-network/poktroll/pkg/observable/channel.ForEach[...].func1({0x511fb40?, 0xc00884b500?})
relayminer  | /home/runner/work/poktroll/poktroll/pkg/observable/channel/map.go:103 +0x34
relayminer  | github.com/pokt-network/poktroll/pkg/observable/channel.goMapTransformNotification[...]({0x5122dc0?, 0xc0010ba420}, {0x510c890, 0xc0030e91a0?}, 0xc004235e90?, 0xc004235f08, 0xc0042e3b90)
relayminer  | /home/runner/work/poktroll/poktroll/pkg/observable/channel/map.go:125 +0x88
relayminer  | created by github.com/pokt-network/poktroll/pkg/observable/channel.Map[...] in goroutine 1
relayminer  | /home/runner/work/poktroll/poktroll/pkg/observable/channel/map.go:24 +0x18c
```

</details>

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [x] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
