### PR TITLE
[RM] Handle `io.ReadAll` memory issue.

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -15,6 +15,10 @@ RUN groupadd -g 1025 pocket && useradd -u 1025 -g pocket -m -s /sbin/nologin poc
 COPY --chown=pocket:pocket release_binaries/pocket_linux_$TARGETARCH /bin/pocketd
 COPY --chown=pocket:pocket tmp/cosmovisor-linux-$TARGETARCH /bin/cosmovisor
 
+# Set Go GC tuning defaults for production memory behavior
+ENV GODEBUG="madvdontneed=1"
+ENV GOGC="50"
+
 USER pocket
 
 ENTRYPOINT ["pocketd"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -15,8 +15,13 @@ RUN groupadd -g 1025 pocket && useradd -u 1025 -g pocket -m -s /sbin/nologin poc
 COPY --chown=pocket:pocket release_binaries/pocket_linux_$TARGETARCH /bin/pocketd
 COPY --chown=pocket:pocket tmp/cosmovisor-linux-$TARGETARCH /bin/cosmovisor
 
-# Set Go GC tuning defaults for production memory behavior
+# Use MADV_DONTNEED to aggressively return freed memory to the OS
+# This helps reduce RSS and is more transparent in container environments
 ENV GODEBUG="madvdontneed=1"
+
+# Lower GC target percentage (default is 100)
+# Triggers GC when heap grows 50% since last collection
+# Helps control memory growth in production environments
 ENV GOGC="50"
 
 USER pocket

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/go-kit/kit v0.13.0
 	github.com/gogo/status v1.1.0
 	github.com/golang/mock v1.6.0
-	github.com/golang/protobuf v1.5.4
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0

--- a/pkg/polylog/polyzero/logger.go
+++ b/pkg/polylog/polyzero/logger.go
@@ -31,7 +31,7 @@ func NewLogger(
 ) polylog.Logger {
 	ze := &zerologLogger{
 		level:  zerolog.DebugLevel,
-		Logger: zerolog.New(os.Stderr),
+		Logger: zerolog.New(os.Stderr).With().Timestamp().Logger(),
 	}
 
 	for _, opt := range opts {

--- a/pkg/polylog/polyzero/logger.go
+++ b/pkg/polylog/polyzero/logger.go
@@ -31,7 +31,7 @@ func NewLogger(
 ) polylog.Logger {
 	ze := &zerologLogger{
 		level:  zerolog.DebugLevel,
-		Logger: zerolog.New(os.Stderr).With().Timestamp().Logger(),
+		Logger: zerolog.New(os.Stderr),
 	}
 
 	for _, opt := range opts {

--- a/pkg/polylog/polyzero/options.go
+++ b/pkg/polylog/polyzero/options.go
@@ -2,6 +2,7 @@ package polyzero
 
 import (
 	"io"
+	"os"
 
 	"github.com/rs/zerolog"
 
@@ -30,6 +31,14 @@ func WithLevel(level polylog.Level) polylog.LoggerOption {
 func WithTimestampKey(key string) polylog.LoggerOption {
 	return func(_ polylog.Logger) {
 		zerolog.TimestampFieldName = key
+	}
+}
+
+// WithTimestamp configures the logger to include a timestamp field using zerolog's built-in Timestamp().
+func WithTimestamp() polylog.LoggerOption {
+	return func(logger polylog.Logger) {
+		// Fallback to os.Stderr, as in NewLogger, since zerolog.Logger does not expose Writer().
+		logger.(*zerologLogger).Logger = zerolog.New(os.Stderr).With().Timestamp().Logger()
 	}
 }
 

--- a/pkg/relayer/cmd/cmd_relay.go
+++ b/pkg/relayer/cmd/cmd_relay.go
@@ -138,6 +138,7 @@ func runRelay(cmd *cobra.Command, args []string) error {
 	loggerOpts := []polylog.LoggerOption{
 		polyzero.WithLevel(polyzero.ParseLevel(flagLogLevel)),
 		polyzero.WithOutput(os.Stderr),
+		polyzero.WithTimestamp(),
 	}
 
 	// Construct logger and associate with command context

--- a/pkg/relayer/proxy/http_utils.go
+++ b/pkg/relayer/proxy/http_utils.go
@@ -1,0 +1,108 @@
+package proxy
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/pokt-network/poktroll/pkg/polylog"
+	"google.golang.org/protobuf/proto"
+
+	sdktypes "github.com/pokt-network/shannon-sdk/types"
+)
+
+// TODO(@jorgecuesta) Move this into `config.yaml` as a default AND/OR per service this is important avoid anyone could blow a RM due to bigger payload attack.
+// DefaultMaxBodySize - Defines max request/response body to be handled
+const DefaultMaxBodySize = 20 * 1024 * 1024 // 20MB
+
+// bodyBufPool - Pool with 8MB slices, efficient for most realistic body sizes
+var bodyBufPool = sync.Pool{
+	New: func() any {
+		return make([]byte, 0, 8*1024*1024) // 2MB pre allocated
+	},
+}
+
+// CloseRequestBody safely closes an io.ReadCloser, logging a warning if it's nil or an error if closing fails.
+func CloseRequestBody(logger polylog.Logger, body io.ReadCloser) {
+	if body == nil {
+		logger.Warn().Msg("⚠️ SHOULD NEVER HAPPEN ⚠️ Attempting to close request body when it is nil.")
+		return
+	}
+	e := body.Close()
+	if e != nil {
+		logger.Error().Err(e).Msg("❌ failed to close the request body")
+	}
+}
+
+// SafeReadBody reads the full body from the reader with a max size limit.
+// It closes the reader automatically and reuses memory from a buffer pool.
+func SafeReadBody(body io.ReadCloser, maxSize int64, logger polylog.Logger) ([]byte, error) {
+	defer CloseRequestBody(logger, body)
+
+	if maxSize <= 0 {
+		maxSize = DefaultMaxBodySize
+	}
+
+	// LimitReader to cap how much we read
+	limited := io.LimitReader(body, maxSize+1)
+
+	// Get a buffer from the pool and wrap in bytes.Buffer
+	poolBuf := bodyBufPool.Get().([]byte)
+	defer bodyBufPool.Put(poolBuf[:0]) // Reset before returning to the pool
+
+	buf := bytes.NewBuffer(poolBuf[:0])
+	n, err := buf.ReadFrom(limited)
+	if err != nil {
+		return nil, err
+	}
+	if n > maxSize {
+		e := fmt.Errorf("body larger than max size: %d > %d", n, maxSize)
+		logger.Error().Err(e).Msg("❌ Request/Response body larger than max size.")
+		return nil, e
+	}
+
+	return buf.Bytes(), nil
+}
+
+// NOTE: I move this from Shannon-SDK because it was not closing body properly and also using the io.ReadAll
+// SerializeHTTPResponse take an http.Response object and serializes it into a byte
+// slice that can be embedded into another struct, such as RelayResponse.Payload.
+func SerializeHTTPResponse(
+	response *http.Response,
+	logger polylog.Logger,
+) (poktHTTPResponse *sdktypes.POKTHTTPResponse, poktHTTPResponseBz []byte, err error) {
+	responseBodyBz, err := SafeReadBody(response.Body, DefaultMaxBodySize, logger)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer CloseRequestBody(logger, response.Body)
+
+	headers := map[string]*sdktypes.Header{}
+	// http.Header is a map of header keys to a list of values. We need to get
+	// the http.Header.Values(key) to get all the values of a key.
+	// We have to avoid using http.Header.Get(key) because it only returns the
+	// first value of the key.
+	for key := range response.Header {
+		headerValues := response.Header.Values(key)
+		headers[key] = &sdktypes.Header{
+			Key:    key,
+			Values: headerValues,
+		}
+	}
+
+	poktHTTPResponse = &sdktypes.POKTHTTPResponse{
+		StatusCode: uint32(response.StatusCode),
+		Header:     headers,
+		BodyBz:     responseBodyBz,
+	}
+
+	// Use deterministic marshaling to ensure that the serialized response is
+	// byte-for-byte equal when comparing the serialized response.
+	opts := proto.MarshalOptions{Deterministic: true}
+
+	poktHTTPResponseBz, err = opts.Marshal(poktHTTPResponse)
+
+	return poktHTTPResponse, poktHTTPResponseBz, err
+}

--- a/pkg/relayer/proxy/http_utils.go
+++ b/pkg/relayer/proxy/http_utils.go
@@ -7,102 +7,142 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/pokt-network/poktroll/pkg/polylog"
+	sdktypes "github.com/pokt-network/shannon-sdk/types"
 	"google.golang.org/protobuf/proto"
 
-	sdktypes "github.com/pokt-network/shannon-sdk/types"
+	"github.com/pokt-network/poktroll/pkg/polylog"
 )
 
-// TODO(@jorgecuesta) Move this into `config.yaml` as a default AND/OR per service this is important avoid anyone could blow a RM due to bigger payload attack.
-// DefaultMaxBodySize - Defines max request/response body to be handled
-const DefaultMaxBodySize = 20 * 1024 * 1024 // 20MB
+const (
+	// TODO_IMPROVE: Make this a RelayMiner config parameter
+	// TODO_IMPROVE: Make this configurable on a per-service basis
+	defaultMaxBodySize = 20 * 1024 * 1024 // 20MB max request/response body size
 
-// bodyBufPool - Pool with 8MB slices, efficient for most realistic body sizes
+	// Buffer pool allocation size - 8MB should handle most realistic body sizes efficiently
+	bufferPoolSize = 8 * 1024 * 1024 // 8MB
+)
+
+// bodyBufPool provides reusable *bytes.Buffer to reduce memory allocations
+// when reading HTTP request/response bodies
 var bodyBufPool = sync.Pool{
 	New: func() any {
-		return make([]byte, 0, 8*1024*1024) // 2MB pre allocated
+		buf := bytes.NewBuffer(make([]byte, 0, bufferPoolSize))
+		return buf
 	},
 }
 
-// CloseRequestBody safely closes an io.ReadCloser, logging a warning if it's nil or an error if closing fails.
+// CloseRequestBody safely closes an io.ReadCloser with proper error handling and logging.
+// It gracefully handles nil readers and logs any errors encountered during closure.
 func CloseRequestBody(logger polylog.Logger, body io.ReadCloser) {
 	if body == nil {
-		logger.Warn().Msg("⚠️ SHOULD NEVER HAPPEN ⚠️ Attempting to close request body when it is nil.")
+		logger.Warn().Msg("⚠️  SHOULD NEVER HAPPEN ⚠️  Attempting to close nil request body")
 		return
 	}
-	e := body.Close()
-	if e != nil {
-		logger.Error().Err(e).Msg("❌ failed to close the request body")
+
+	if err := body.Close(); err != nil {
+		logger.Error().Err(err).Msg("❌ Failed to close request body")
 	}
 }
 
-// SafeReadBody reads the full body from the reader with a max size limit.
-// It closes the reader automatically and reuses memory from a buffer pool.
-func SafeReadBody(body io.ReadCloser, maxSize int64, logger polylog.Logger) ([]byte, error) {
+// SafeReadBody reads the complete body from an io.ReadCloser with size limits and memory pooling.
+// It automatically closes the reader, enforces maximum size constraints, and reuses buffers
+// from a shared pool to minimize memory allocations.
+//
+// Parameters:
+//   - body: The io.ReadCloser to read from (will be closed automatically)
+//   - maxSize: Maximum allowed body size in bytes (uses defaultMaxBodySize if <= 0)
+//   - logger: Logger for error reporting
+//
+// Returns the complete body as a byte slice or an error if reading fails or size limit is exceeded.
+func SafeReadBody(logger polylog.Logger, body io.ReadCloser, maxSize int64) ([]byte, error) {
 	defer CloseRequestBody(logger, body)
 
 	if maxSize <= 0 {
-		maxSize = DefaultMaxBodySize
+		logger.Warn().Msgf("SHOULD NOT HAPPEN: Max body size is less than or equal to 0, using default max body size of %d", defaultMaxBodySize)
+		maxSize = defaultMaxBodySize
 	}
 
-	// LimitReader to cap how much we read
-	limited := io.LimitReader(body, maxSize+1)
+	// Create a limited reader that will read at most maxSize+1 bytes
+	// The +1 allows us to detect when the body exceeds the limit
+	limitedReader := io.LimitReader(body, maxSize+1)
 
-	// Get a buffer from the pool and wrap in bytes.Buffer
-	poolBuf := bodyBufPool.Get().([]byte)
-	defer bodyBufPool.Put(poolBuf[:0]) // Reset before returning to the pool
+	// Get a reusable *bytes.Buffer from the pool
+	buf := bodyBufPool.Get().(*bytes.Buffer)
+	buf.Reset() // Always reset before use
+	defer bodyBufPool.Put(buf)
 
-	buf := bytes.NewBuffer(poolBuf[:0])
-	n, err := buf.ReadFrom(limited)
+	bytesRead, err := buf.ReadFrom(limitedReader)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("❌ failed to read request body: %w", err)
 	}
-	if n > maxSize {
-		e := fmt.Errorf("body larger than max size: %d > %d", n, maxSize)
-		logger.Error().Err(e).Msg("❌ Request/Response body larger than max size.")
-		return nil, e
+
+	// Check if the body exceeded our size limit
+	if bytesRead > maxSize {
+		err := fmt.Errorf("❌ request body size exceeds maximum allowed body: %d bytes read > %d bytes limit", bytesRead, maxSize)
+		logger.Error().Err(err).Msg("❌ Request/response body too large")
+		return nil, err
 	}
 
 	return buf.Bytes(), nil
 }
 
-// NOTE: I move this from Shannon-SDK because it was not closing body properly and also using the io.ReadAll
-// SerializeHTTPResponse take an http.Response object and serializes it into a byte
-// slice that can be embedded into another struct, such as RelayResponse.Payload.
+// TODO_TECHDEBT: Move this function back to the Shannon SDK. It was moved:
+// 1. To ensure proper body closure
+// 2. To avoid using io.ReadAll which doesn't implement size limits.
+// 3. To iterate faster
+//
+// SerializeHTTPResponse converts an http.Response into a protobuf-serialized byte slice.
+//
+// The function:
+//   - Safely reads the response body with size limits
+//   - Preserves all HTTP headers (including multiple values per header key)
+//   - Uses deterministic protobuf marshaling for consistent serialization
+//   - Properly closes the response body
+//
+// Parameters:
+//   - response: The HTTP response to serialize
+//   - logger: Logger for error reporting
+//
+// Returns:
+//   - poktHTTPResponse: The structured response object
+//   - poktHTTPResponseBz: The serialized response as bytes
+//   - err: Any error encountered during processing
 func SerializeHTTPResponse(
-	response *http.Response,
 	logger polylog.Logger,
+	response *http.Response,
 ) (poktHTTPResponse *sdktypes.POKTHTTPResponse, poktHTTPResponseBz []byte, err error) {
-	responseBodyBz, err := SafeReadBody(response.Body, DefaultMaxBodySize, logger)
+	// Read the response body with size limits
+	responseBodyBz, err := SafeReadBody(logger, response.Body, defaultMaxBodySize)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("❌ failed to read response body: %w", err)
 	}
-	defer CloseRequestBody(logger, response.Body)
 
-	headers := map[string]*sdktypes.Header{}
-	// http.Header is a map of header keys to a list of values. We need to get
-	// the http.Header.Values(key) to get all the values of a key.
-	// We have to avoid using http.Header.Get(key) because it only returns the
-	// first value of the key.
-	for key := range response.Header {
-		headerValues := response.Header.Values(key)
-		headers[key] = &sdktypes.Header{
-			Key:    key,
+	// Convert HTTP headers to the POKT header format
+	// Note: We use Values() instead of Get() to preserve all header values,
+	// since HTTP allows multiple values for the same header key
+	headers := make(map[string]*sdktypes.Header, len(response.Header))
+	for headerKey := range response.Header {
+		headerValues := response.Header.Values(headerKey)
+		headers[headerKey] = &sdktypes.Header{
+			Key:    headerKey,
 			Values: headerValues,
 		}
 	}
 
+	// Create the POKT HTTP response structure
 	poktHTTPResponse = &sdktypes.POKTHTTPResponse{
 		StatusCode: uint32(response.StatusCode),
 		Header:     headers,
 		BodyBz:     responseBodyBz,
 	}
 
-	// Use deterministic marshaling to ensure that the serialized response is
-	// byte-for-byte equal when comparing the serialized response.
-	opts := proto.MarshalOptions{Deterministic: true}
+	// Use deterministic marshaling to ensure consistent byte-for-byte serialization
+	// This is crucial for consensus mechanisms that rely on deterministic hashing
+	marshalOpts := proto.MarshalOptions{Deterministic: true}
+	poktHTTPResponseBz, err = marshalOpts.Marshal(poktHTTPResponse)
+	if err != nil {
+		return nil, nil, fmt.Errorf("❌ failed to marshal POKT HTTP response: %w", err)
+	}
 
-	poktHTTPResponseBz, err = opts.Marshal(poktHTTPResponse)
-
-	return poktHTTPResponse, poktHTTPResponseBz, err
+	return poktHTTPResponse, poktHTTPResponseBz, nil
 }

--- a/pkg/relayer/proxy/relay_builders.go
+++ b/pkg/relayer/proxy/relay_builders.go
@@ -10,7 +10,7 @@ import (
 // newRelayRequest builds a RelayRequest from an http.Request.
 func (sync *relayMinerHTTPServer) newRelayRequest(request *http.Request) (*types.RelayRequest, error) {
 	// Replace DefaultMaxBodySize with config options
-	requestBody, err := SafeReadBody(request.Body, DefaultMaxBodySize, sync.logger)
+	requestBody, err := SafeReadBody(sync.logger, request.Body, defaultMaxBodySize)
 	if err != nil {
 		return nil, ErrRelayerProxyInternalError.Wrap(err.Error())
 	}

--- a/pkg/relayer/proxy/relay_builders.go
+++ b/pkg/relayer/proxy/relay_builders.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"io"
 	"net/http"
 
 	"github.com/pokt-network/poktroll/x/service/types"
@@ -10,7 +9,8 @@ import (
 
 // newRelayRequest builds a RelayRequest from an http.Request.
 func (sync *relayMinerHTTPServer) newRelayRequest(request *http.Request) (*types.RelayRequest, error) {
-	requestBody, err := io.ReadAll(request.Body)
+	// Replace DefaultMaxBodySize with config options
+	requestBody, err := SafeReadBody(request.Body, DefaultMaxBodySize, sync.logger)
 	if err != nil {
 		return nil, ErrRelayerProxyInternalError.Wrap(err.Error())
 	}

--- a/pkg/relayer/proxy/sync.go
+++ b/pkg/relayer/proxy/sync.go
@@ -218,7 +218,7 @@ func (server *relayMinerHTTPServer) serveSyncRequest(
 
 	// Serialize the service response to be sent back to the client.
 	// This will include the status code, headers, and body.
-	_, responseBz, err := SerializeHTTPResponse(httpResponse, logger)
+	_, responseBz, err := SerializeHTTPResponse(logger, httpResponse)
 	if err != nil {
 		return relayRequest, err
 	}

--- a/pkg/relayer/proxy/sync.go
+++ b/pkg/relayer/proxy/sync.go
@@ -4,30 +4,16 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	io "io"
 	"net/http"
 	"slices"
 	"strings"
 	"time"
-
-	sdktypes "github.com/pokt-network/shannon-sdk/types"
 
 	"github.com/pokt-network/poktroll/pkg/polylog"
 	"github.com/pokt-network/poktroll/pkg/relayer"
 	"github.com/pokt-network/poktroll/pkg/relayer/config"
 	"github.com/pokt-network/poktroll/x/service/types"
 )
-
-func closeRequestBody(logger polylog.Logger, body io.ReadCloser) {
-	if body == nil {
-		logger.Warn().Msg("⚠️ SHOULD NEVER HAPPEN ⚠️ Attempting to close request body when it is nil.")
-		return
-	}
-	e := body.Close()
-	if e != nil {
-		logger.Error().Err(e).Msg("❌ failed to close the request body")
-	}
-}
 
 // serveSyncRequest serves a synchronous relay request by forwarding the request
 // to the service's backend URL and returning the response to the client.
@@ -54,7 +40,7 @@ func (server *relayMinerHTTPServer) serveSyncRequest(
 		logger.Warn().Err(err).Msg("failed creating relay request")
 		return relayRequest, err
 	}
-	defer closeRequestBody(logger, request.Body)
+	defer CloseRequestBody(logger, request.Body)
 
 	if err = relayRequest.ValidateBasic(); err != nil {
 		logger.Warn().Err(err).Msg("failed validating relay request")
@@ -190,7 +176,7 @@ func (server *relayMinerHTTPServer) serveSyncRequest(
 		logger.Error().Err(err).Msg("failed to build the service backend request")
 		return relayRequest, ErrRelayerProxyInternalError.Wrapf("failed to build the service backend request: %v", err)
 	}
-	defer closeRequestBody(logger, httpRequest.Body)
+	defer CloseRequestBody(logger, httpRequest.Body)
 
 	// Configure the HTTP client to use the appropriate transport based on the
 	// backend URL scheme.
@@ -214,7 +200,7 @@ func (server *relayMinerHTTPServer) serveSyncRequest(
 		relayer.CaptureServiceDuration(serviceId, serviceCallStartTime, statusCode)
 		return relayRequest, ErrRelayerProxyInternalError.Wrap(err.Error())
 	}
-	defer closeRequestBody(logger, httpResponse.Body)
+	defer CloseRequestBody(logger, httpResponse.Body)
 	// Capture the service call request duration metric.
 	relayer.CaptureServiceDuration(serviceId, serviceCallStartTime, httpResponse.StatusCode)
 	// If the backend service returns a 5xx error, we consider it an internal error
@@ -232,7 +218,7 @@ func (server *relayMinerHTTPServer) serveSyncRequest(
 
 	// Serialize the service response to be sent back to the client.
 	// This will include the status code, headers, and body.
-	_, responseBz, err := sdktypes.SerializeHTTPResponse(httpResponse)
+	_, responseBz, err := SerializeHTTPResponse(httpResponse, logger)
 	if err != nil {
 		return relayRequest, err
 	}


### PR DESCRIPTION
## Summary

Fix memory issues that was spiking due to the usage of `io.ReadAll` base on `pprof` reports of `heap`

### Primary Changes:

- Introduce Go GC tuning defaults in Dockerfile for production memory optimization.
- Refactor request body handling to use pooled buffers and size limits for improved memory management.
- Centralize body closing logic in `CloseRequestBody` to enhance consistency and error handling.
- Replace `io.ReadAll` with `SafeReadBody` for capped, streamlined payload reads.
- Add `SerializeHTTPResponse` implementation for deterministic response serialization.

### Secondary Changes:

- Enable timestamping in logger initialization for improved log tracing.

## Issue

- High Memory usage on load (actively receiving relays)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [x] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [x] 'TODO's, configurations and other docs
