### PR TITLE
[RelayMiner] Enhance Signal Handling and Event Subscription Reliability

### DIFF
--- a/cmd/faucet/serve.go
+++ b/cmd/faucet/serve.go
@@ -109,7 +109,7 @@ func runServe(cmd *cobra.Command, _ []string) error {
 	cmd.SetContext(cmdContext)
 
 	// Register a signal handler to gracefully shut down the server.
-	signals.GoOnExitSignal(func() {
+	signals.GoOnExitSignal(logger.Logger, func() {
 		logger.Logger.Info().Msg("Shutting down...")
 		cmdCancel()
 	})

--- a/cmd/signals/exit.go
+++ b/cmd/signals/exit.go
@@ -6,11 +6,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/pokt-network/poktroll/pkg/polylog"
 	"github.com/spf13/cobra"
+
+	"github.com/pokt-network/poktroll/pkg/polylog"
 )
 
-const shutdownTimeout = 30 * time.Second
+const shutDownTimeout = 30 * time.Second
 
 // ExitCode is a global variable that is intended to be used by CLI commands to
 // hold the current exit code and subsequently used in ExitWithCodeIfNonZero.
@@ -60,8 +61,8 @@ func GoOnExitSignal(logger polylog.Logger, onInterrupt func()) {
 			logger.Warn().Msgf("⚠️ Received another signal %s during shutdown, 🗡️ exiting immediately.", sig)
 			// Exit immediately if another signal is received during shutdown
 			os.Exit(130) // UNIX convention, use 128 + 2 to indicate a double interrupt (SIGINT)
-		case <-time.After(shutdownTimeout):
-			logger.Warn().Msgf("⌛ Graceful shutdown timed out after %s, 🗡️ exiting immediately.", shutdownTimeout)
+		case <-time.After(shutDownTimeout):
+			logger.Warn().Msgf("⌛ Graceful shutdown timed out after %s, 🗡️ exiting immediately.", shutDownTimeout)
 			os.Exit(1) // Exit immediately if the shutdown takes too long
 		}
 	}()

--- a/cmd/signals/exit.go
+++ b/cmd/signals/exit.go
@@ -4,9 +4,13 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
+	"github.com/pokt-network/poktroll/pkg/polylog"
 	"github.com/spf13/cobra"
 )
+
+const shutdownTimeout = 30 * time.Second
 
 // ExitCode is a global variable that is intended to be used by CLI commands to
 // hold the current exit code and subsequently used in ExitWithCodeIfNonZero.
@@ -22,17 +26,43 @@ func ExitWithCodeIfNonZero(_ *cobra.Command, _ []string) {
 
 // GoOnExitSignal calls the given callback when the process receives an interrupt or terminate signal.
 // It sets up a goroutine that listens for OS signals and invokes the callback
-func GoOnExitSignal(onInterrupt func()) {
+func GoOnExitSignal(logger polylog.Logger, onInterrupt func()) {
 	go func() {
 		// Set up sigCh to receive when this process receives an interrupt or
 		// terminate signal.
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+		// Use a buffered channel with large capacity to prevent signal loss
+		sigCh := make(chan os.Signal, 5)
+
+		// Register the signals we want to listen for.
+		// DEV_NOTE: SIGKILL cannot be trapped, so we don't listen for it.
+		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGABRT)
 
 		// Block until we receive an interrupt or kill signal (OS-agnostic)
-		<-sigCh
+		sig := <-sigCh
+		logger.Info().Msgf("🔚 Received signal %s, starting graceful shutdown...", sig)
 
-		// Call the onInterrupt callback.
-		onInterrupt()
+		// Create a channel to track shutdown completion
+		done := make(chan struct{})
+
+		// Start the graceful shutdown in a goroutine
+		go func() {
+			// Call the onInterrupt callback.
+			onInterrupt()
+			close(done)
+		}()
+
+		// Wait for either completion or another signal or timeout
+		select {
+		case <-done:
+			logger.Info().Msg("✅ Graceful shutdown completed successfully.")
+			return
+		case sig := <-sigCh:
+			logger.Warn().Msgf("⚠️ Received another signal %s during shutdown, 🗡️ exiting immediately.", sig)
+			// Exit immediately if another signal is received during shutdown
+			os.Exit(130) // UNIX convention, use 128 + 2 to indicate a double interrupt (SIGINT)
+		case <-time.After(shutdownTimeout):
+			logger.Warn().Msgf("⌛ Graceful shutdown timed out after %s, 🗡️ exiting immediately.", shutdownTimeout)
+			os.Exit(1) // Exit immediately if the shutdown takes too long
+		}
 	}()
 }

--- a/e2e/tests/init_test.go
+++ b/e2e/tests/init_test.go
@@ -187,9 +187,10 @@ func (s *suite) Before() {
 	flagSet := testclient.NewLocalnetFlagSet(s)
 	clientCtx := testclient.NewLocalnetClientCtx(s, flagSet)
 	s.proofQueryClient = prooftypes.NewQueryClient(clientCtx)
+	logger := polylog.Ctx(s.ctx)
 
 	s.deps = depinject.Supply(
-		events.NewEventsQueryClient(testclient.CometLocalWebsocketURL),
+		events.NewEventsQueryClient(testclient.CometLocalWebsocketURL, events.WithLogger(logger)),
 		polylog.Ctx(s.ctx),
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/go-kit/kit v0.13.0
 	github.com/gogo/status v1.1.0
 	github.com/golang/mock v1.6.0
-	github.com/golang/protobuf v1.5.4
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0

--- a/load-testing/tests/relays_stress_test.go
+++ b/load-testing/tests/relays_stress_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pokt-network/poktroll/pkg/client"
 	"github.com/pokt-network/poktroll/pkg/observable"
 	"github.com/pokt-network/poktroll/pkg/observable/channel"
+	"github.com/pokt-network/poktroll/pkg/polylog"
 	"github.com/pokt-network/poktroll/testutil/testclient"
 	"github.com/pokt-network/poktroll/testutil/testclient/testtx"
 	apptypes "github.com/pokt-network/poktroll/x/application/types"
@@ -263,7 +264,7 @@ func (s *relaysSuite) LocalnetIsRunning() {
 	// Cancel the context if this process is interrupted or exits.
 	// Delete the keyring entries for the application accounts since they are
 	// not persisted across test runs.
-	signals.GoOnExitSignal(func() {
+	signals.GoOnExitSignal(polylog.Ctx(s.ctx), func() {
 		for _, app := range append(s.activeApplications, s.preparedApplications...) {
 			accAddress := sdk.MustAccAddressFromBech32(app.address)
 

--- a/pkg/client/events/query_client.go
+++ b/pkg/client/events/query_client.go
@@ -288,8 +288,9 @@ func (eqc *eventsQueryClient) goPublishEventsBz(evtConn *eventsBytesInfo) {
 	// websocket connection is isClosed and/or returns an error.
 	for {
 		eventBz, err := evtConn.conn.Receive()
+		// Prevent late messages from being published to the closed eventsBzPublishCh.
+		// This is done by checking the isClosed flag before publishing the eventBz.
 		if evtConn.isClosed.Load() {
-			// If the context is done, we should stop reading messages.
 			return
 		}
 

--- a/pkg/client/events/query_client_test.go
+++ b/pkg/client/events/query_client_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pokt-network/poktroll/pkg/client/events/websocket"
 	"github.com/pokt-network/poktroll/pkg/either"
 	"github.com/pokt-network/poktroll/pkg/observable"
+	"github.com/pokt-network/poktroll/pkg/polylog"
 	"github.com/pokt-network/poktroll/testutil/mockclient"
 	"github.com/pokt-network/poktroll/testutil/testchannel"
 	"github.com/pokt-network/poktroll/testutil/testclient/testeventsquery"
@@ -48,7 +49,8 @@ func TestEventsQueryClient_Subscribe_Succeeds(t *testing.T) {
 
 	// Set up events query client.
 	dialerOpt := events.WithDialer(dialerMock)
-	queryClient := events.NewEventsQueryClient("", dialerOpt)
+	loggerOpt := events.WithLogger(polylog.Ctx(rootCtx))
+	queryClient := events.NewEventsQueryClient("", dialerOpt, loggerOpt)
 	t.Cleanup(queryClient.Close)
 
 	for queryIdx := 0; queryIdx < queryLimit; queryIdx++ {
@@ -173,7 +175,8 @@ func TestEventsQueryClient_Subscribe_Close(t *testing.T) {
 		MinTimes(handleEventsLimit)
 
 	dialerOpt := events.WithDialer(dialerMock)
-	queryClient := events.NewEventsQueryClient("", dialerOpt)
+	loggerOpt := events.WithLogger(polylog.Ctx(ctx))
+	queryClient := events.NewEventsQueryClient("", dialerOpt, loggerOpt)
 
 	// set up query observer
 	eventsObservable, err := queryClient.EventsBytes(ctx, testQuery(0))
@@ -206,7 +209,8 @@ func TestEventsQueryClient_Subscribe_DialError(t *testing.T) {
 	dialerMock := testeventsquery.NewOneTimeMockDialer(t, eitherErrDial)
 
 	dialerOpt := events.WithDialer(dialerMock)
-	queryClient := events.NewEventsQueryClient("", dialerOpt)
+	loggerOpt := events.WithLogger(polylog.Ctx(ctx))
+	queryClient := events.NewEventsQueryClient("", dialerOpt, loggerOpt)
 	eventsObservable, err := queryClient.EventsBytes(ctx, testQuery(0))
 	require.Nil(t, eventsObservable)
 	require.True(t, errors.Is(err, events.ErrEventsDial))
@@ -221,7 +225,8 @@ func TestEventsQueryClient_Subscribe_RequestError(t *testing.T) {
 		Times(1)
 
 	dialerOpt := events.WithDialer(dialerMock)
-	queryClient := events.NewEventsQueryClient("url_ignored", dialerOpt)
+	loggerOpt := events.WithLogger(polylog.Ctx(ctx))
+	queryClient := events.NewEventsQueryClient("url_ignored", dialerOpt, loggerOpt)
 	eventsObservable, err := queryClient.EventsBytes(ctx, testQuery(0))
 	require.Nil(t, eventsObservable)
 	require.True(t, errors.Is(err, events.ErrEventsSubscribe))
@@ -264,7 +269,8 @@ func TestEventsQueryClient_Subscribe_ReceiveError(t *testing.T) {
 		MinTimes(handleEventLimit)
 
 	dialerOpt := events.WithDialer(dialerMock)
-	queryClient := events.NewEventsQueryClient("", dialerOpt)
+	loggerOpt := events.WithLogger(polylog.Ctx(ctx))
+	queryClient := events.NewEventsQueryClient("", dialerOpt, loggerOpt)
 
 	// set up query observer
 	eventsObservable, err := queryClient.EventsBytes(ctx, testQuery(0))

--- a/pkg/client/events/replay_client.go
+++ b/pkg/client/events/replay_client.go
@@ -27,18 +27,16 @@ const (
 	// eventsBytesRetryDelay is the delay between retry attempts when the events
 	// bytes observable returns an error.
 	eventsBytesRetryDelay = time.Second
-
-	// replayObsCacheBufferSize is the replay buffer size of the
-	// replayObsCache replay observable which is used to cache the replay
-	// observable that is notified of new events.
-	// It, replayObsCache, is updated with a new "active" observable when a new
-	// events query subscription is created, for example, after a non-persistent
-	// connection error.
-	replayObsCacheBufferSize = 1
 )
 
 // Enforce the EventsReplayClient interface is implemented by the replayClient type.
 var _ client.EventsReplayClient[any] = (*replayClient[any])(nil)
+
+// Define connection state for tracking and logging transitions
+type connState struct {
+	status    string
+	timestamp time.Time
+}
 
 // NewEventsFn is a function that takes a byte slice and returns a new instance
 // of the generic type T.
@@ -67,21 +65,6 @@ type replayClient[T any] struct {
 	// replayed to new observers.
 	// NB: This is not the buffer size of the replayObsCache
 	replayObsBufferSize int
-	// replayObsCache is a replay observable with a buffer size of 1, which
-	// holds the "active latest replay observable" which is notified when new
-	// events are received by the events query client subscription created in
-	// goPublishEvents. This observable (and the one it emits) closes when the
-	// events bytes observable returns an error and is updated with a new
-	// "active" observable after a new events query subscription is created.
-	//
-	// TODO_TECHDEBT(@bryanchriswhite): Look into making this a regular observable as
-	// we may no longer depend on it being replayable.
-	replayObsCache observable.ReplayObservable[observable.ReplayObservable[T]]
-	// replayObsCachePublishCh is the publish channel for replayObsCache.
-	// It's used to set and subsequently update replayObsCache the events replay
-	// observable;
-	// For example when the connection is re-established after erroring.
-	replayObsCachePublishCh chan<- observable.ReplayObservable[T]
 	// eventTypeObs is the replay observable for the generic type T.
 	eventTypeObs observable.ReplayObservable[T]
 	// replayClientCancelCtx is the function to cancel the context of the replay client.
@@ -91,6 +74,8 @@ type replayClient[T any] struct {
 	// in the event that it encounters an error or its connection is interrupted.
 	// If connRetryLimit is < 0, it will retry indefinitely.
 	connRetryLimit int
+	// Track connection state transitions
+	currentState *connState
 }
 
 // NewEventsReplayClient creates a new EventsReplayClient from the given
@@ -125,17 +110,6 @@ func NewEventsReplayClient[T any](
 		opt(rClient)
 	}
 
-	// TODO_TECHDEBT(@bryanchriswhite): Look into making this a regular observable as
-	// we may no longer depend on it being replayable.
-	replayObsCache, replayObsCachePublishCh := channel.NewReplayObservable[observable.ReplayObservable[T]](
-		ctx,
-		// Buffer size of 1 as the cache only needs to hold the latest
-		// active replay observable.
-		replayObsCacheBufferSize,
-	)
-	rClient.replayObsCache = replayObsCache
-	rClient.replayObsCachePublishCh = replayObsCachePublishCh
-
 	// Inject dependencies
 	if err := depinject.Inject(deps, &rClient.eventsClient, &rClient.logger); err != nil {
 		return nil, err
@@ -148,6 +122,12 @@ func NewEventsReplayClient[T any](
 		ctx,
 		rClient.replayObsBufferSize,
 	)
+
+	// Initialize connection state tracking
+	rClient.currentState = &connState{
+		status:    "initial",
+		timestamp: time.Now(),
+	}
 
 	// Concurrently publish events to the observable emitted by replayObsCache.
 	go rClient.goPublishEvents(ctx, replayEventTypeObsPublishCh)
@@ -195,6 +175,10 @@ func (rClient *replayClient[T]) Close() {
 func (rClient *replayClient[T]) goPublishEvents(ctx context.Context, publishCh chan<- T) {
 	numRetries := 0
 
+	rClient.logger.Info().
+		Str("state", rClient.currentState.status).
+		Msgf("🚀 Starting event subscription for query: %s", rClient.queryString)
+
 	for {
 		// Check if retry limit has been exceeded
 		if numRetries > rClient.connRetryLimit {
@@ -210,8 +194,22 @@ func (rClient *replayClient[T]) goPublishEvents(ctx context.Context, publishCh c
 		select {
 		case <-ctx.Done():
 			// If the context is done, exit the loop and stop processing events.
+			rClient.logger.Info().Msgf(
+				"🛑 Context canceled. Stopping event subscription for query: %s",
+				rClient.queryString,
+			)
 			return
 		default:
+			// Log connection attempt state
+			if rClient.currentState.status != "connected" {
+				rClient.logger.Info().Msgf(
+					"🔄 Attempting to establish event subscription for query: %s (attempt %d/%d)",
+					rClient.queryString,
+					numRetries+1,
+					rClient.connRetryLimit,
+				)
+			}
+
 			// Create a cancellable context for this connection attempt
 			eventsBzCtx, cancelEventsBzObs := context.WithCancel(ctx)
 
@@ -219,6 +217,7 @@ func (rClient *replayClient[T]) goPublishEvents(ctx context.Context, publishCh c
 			// This will return an observable that emits either event bytes or an error
 			eventsBytesObs, err := rClient.eventsClient.EventsBytes(eventsBzCtx, rClient.queryString)
 			if err != nil {
+				rClient.updateState("failed")
 				rClient.logger.Error().Err(err).Msgf(
 					"🔌 Failed to establish websocket connection to blockchain node for event subscription '%s'. Retrying connection (%d/%d)",
 					rClient.queryString,
@@ -234,6 +233,13 @@ func (rClient *replayClient[T]) goPublishEvents(ctx context.Context, publishCh c
 				continue
 			}
 
+			// Connection successful and verified
+			rClient.updateState("connected")
+			rClient.logger.Info().Msgf(
+				"📶 Successfully established verified websocket connection to blockchain node for event subscription %q.",
+				rClient.queryString,
+			)
+
 			// Reset the retry counter since we successfully established a connection
 			numRetries = 0
 
@@ -245,12 +251,16 @@ func (rClient *replayClient[T]) goPublishEvents(ctx context.Context, publishCh c
 				// Extract event bytes or error from the Either type
 				eventBz, eitherErr := eitherEventBz.ValueOrError()
 				if eitherErr != nil {
+					rClient.updateState("disconnected")
 					rClient.logger.Error().Err(eitherErr).Msgf(
 						"📡 Lost connection to event stream for query: %s. Attempting to reconnect (%d/%d)",
 						rClient.queryString,
 						numRetries+1,
 						rClient.connRetryLimit,
 					)
+
+					// Make sure to properly clean up before attempting to reconnect
+					cancelEventsBzObs()
 
 					// Connection error occurred - exit event loop to retry
 					break
@@ -261,25 +271,31 @@ func (rClient *replayClient[T]) goPublishEvents(ctx context.Context, publishCh c
 				if err != nil {
 					if ErrEventsUnmarshalEvent.Is(err) {
 						// Event bytes were not the expected type - skip this message and continue
-						rClient.logger.Info().Msgf(
-							"ℹ️ Received blockchain event that doesn't match subscription filter for query: %s. Skipping event (this is expected)",
+						rClient.logger.Debug().Err(err).Msgf(
+							"❓️ Received blockchain event that doesn't match subscription filter for query: %s. Skipping event (this is expected)",
 							rClient.queryString,
 						)
 						continue
 					}
 
-					// Unexpected decoding error - exit event loop to retry
+					// Unexpected decoding error - log the specific error and decide whether to reconnect
+					rClient.updateState("decode_error")
 					rClient.logger.Error().Err(err).Msgf(
 						"⚠️ Failed to decode blockchain event data for query: %s. Reconnecting to refresh event stream (%d/%d)",
 						rClient.queryString,
 						numRetries+1,
 						rClient.connRetryLimit,
 					)
+
+					// Make sure to properly clean up before attempting to reconnect
+					cancelEventsBzObs()
+
+					// Exit the event loop to retry connection
 					break
 				}
 
 				// Successfully decoded event - publish it to the channel
-				rClient.logger.ProbabilisticDebugInfo(polylog.ProbabilisticDebugInfoProb).Msgf(
+				rClient.logger.Info().Msgf(
 					"📦 Publishing blockchain event for query: %s",
 					rClient.queryString,
 				)
@@ -291,7 +307,36 @@ func (rClient *replayClient[T]) goPublishEvents(ctx context.Context, publishCh c
 
 			// Increment retry counter and delay
 			numRetries++
+			rClient.updateState("waiting_retry")
+			rClient.logger.Info().Msgf(
+				"⏳ Waiting %s before attempting to reconnect for query: %s (attempt %d/%d)",
+				eventsBytesRetryDelay,
+				rClient.queryString,
+				numRetries,
+				rClient.connRetryLimit,
+			)
 			time.Sleep(eventsBytesRetryDelay)
 		}
+	}
+}
+
+// updateState updates and tracks connection state transitions
+func (rClient *replayClient[T]) updateState(newStatus string) {
+	prevStatus := rClient.currentState.status
+	duration := time.Since(rClient.currentState.timestamp).Round(time.Millisecond)
+
+	// Only log transitions between different states
+	if prevStatus != newStatus {
+		rClient.logger.Info().
+			Str("prev_state", prevStatus).
+			Str("new_state", newStatus).
+			Dur("duration_in_prev_state", duration).
+			Msgf("🔄 Connection state transition for query: %s", rClient.queryString)
+	}
+
+	// Update current state
+	rClient.currentState = &connState{
+		status:    newStatus,
+		timestamp: time.Now(),
 	}
 }

--- a/pkg/client/events/replay_client_integration_test.go
+++ b/pkg/client/events/replay_client_integration_test.go
@@ -105,7 +105,8 @@ func TestReplayClient_Remapping(t *testing.T) {
 
 	// Setup the events query client dependency
 	dialerOpt := events.WithDialer(dialerMock)
-	queryClient := events.NewEventsQueryClient("", dialerOpt)
+	loggerOpt := events.WithLogger(polylog.Ctx(ctx))
+	queryClient := events.NewEventsQueryClient("", dialerOpt, loggerOpt)
 
 	logger := polylog.Ctx(ctx)
 	deps := depinject.Supply(queryClient, logger)

--- a/pkg/client/events/websocket/state.go
+++ b/pkg/client/events/websocket/state.go
@@ -1,0 +1,41 @@
+package websocket
+
+import (
+	"time"
+)
+
+// ConnStateStatus represents the status of the underlying websocket connection
+type ConnStateStatus int
+
+const (
+	// ConnStateInitial represents the initial state of the underlying websocket connection
+	ConnStateInitial ConnStateStatus = iota
+	// ConnStateConnected represents a connected state
+	ConnStateConnected
+	// ConnStateDisconnected represents a disconnected state
+	ConnStateDisconnected
+	// ConnStateWaitingRetry represents a state where the client is waiting to retry connection
+	ConnStateWaitingRetry
+	// ConnStateFailed represents a failed connection state
+	ConnStateFailed
+	// ConnStateDecodeError represents a state where there was an error decoding events
+	ConnStateDecodeError
+)
+
+// String returns the string representation of ConnStateStatus
+func (s ConnStateStatus) String() string {
+	return [...]string{
+		"initial",
+		"connected",
+		"disconnected",
+		"waiting_retry",
+		"failed",
+		"decode_error",
+	}[s]
+}
+
+// Define connection state for tracking and logging transitions
+type ConnState struct {
+	Status    ConnStateStatus
+	Timestamp time.Time
+}

--- a/pkg/client/events/websocket/state.go
+++ b/pkg/client/events/websocket/state.go
@@ -4,12 +4,12 @@ import (
 	"time"
 )
 
-// ConnStateStatus represents the status of the underlying websocket connection
-type ConnStateStatus int
+// WebsocketConnectionState represents the status of the underlying websocket connection
+type WebsocketConnectionState int
 
 const (
 	// ConnStateInitial represents the initial state of the underlying websocket connection
-	ConnStateInitial ConnStateStatus = iota
+	ConnStateInitial WebsocketConnectionState = iota
 	// ConnStateConnected represents a connected state
 	ConnStateConnected
 	// ConnStateDisconnected represents a disconnected state
@@ -23,7 +23,7 @@ const (
 )
 
 // String returns the string representation of ConnStateStatus
-func (s ConnStateStatus) String() string {
+func (s WebsocketConnectionState) String() string {
 	return [...]string{
 		"initial",
 		"connected",
@@ -35,7 +35,7 @@ func (s ConnStateStatus) String() string {
 }
 
 // Define connection state for tracking and logging transitions
-type ConnState struct {
-	Status    ConnStateStatus
+type WebsocketConnState struct {
+	Status    WebsocketConnectionState
 	Timestamp time.Time
 }

--- a/pkg/relayer/cmd/cmd_start.go
+++ b/pkg/relayer/cmd/cmd_start.go
@@ -93,7 +93,7 @@ func runRelayer(cmd *cobra.Command, _ []string) error {
 	cmd.SetContext(ctx)
 
 	// Handle interrupt/kill signals asynchronously
-	signals.GoOnExitSignal(cancelCtx)
+	signals.GoOnExitSignal(logger, cancelCtx)
 
 	// Read relay miner config file
 	configContent, err := os.ReadFile(flagRelayMinerConfig)

--- a/pkg/relayer/session/claim.go
+++ b/pkg/relayer/session/claim.go
@@ -32,7 +32,7 @@ import (
 // 1. Choose a reasonable (empirically observed) p90 of claim & proof sizes across most chains
 // 2. TODO_FUTURE: Compute the gas cost dynamically based on the size of the branch being proven.
 // TODO_TECHDEBT(@olshansk): Temporarily setting this to 1uPOKT to see more claims & proofs on chain
-var ClaimAndProofGasCost = sdktypes.NewInt64Coin(pocket.DenomuPOKT, 1)
+var ClaimAndProofGasCost = sdktypes.NewInt64Coin(pocket.DenomuPOKT, 2)
 
 // createClaims maps over the sessionsToClaimObs observable. For each claim batch, it:
 // 1. Calculates the earliest block height at which it is safe to CreateClaims

--- a/pkg/relayer/session/claim.go
+++ b/pkg/relayer/session/claim.go
@@ -26,12 +26,13 @@ import (
 // - Value may change as network parameters change
 // - This value is a function of the claim & proof message sizes
 //
-// TODO(@bryanchriswhite, #1507): ClaimAndProofGasCost value should be a function of
+// TODO_IMPORTANT(#1507): ClaimAndProofGasCost value should be a function of
 // the biggest Relay (in num of bytes) and tx_size_cost_per_byte auth module param.
 // There should be a two step approach to this:
-// 1. Choose a reasonable (emperically observed) p90 of claim & proof sizes across most chains
+// 1. Choose a reasonable (empirically observed) p90 of claim & proof sizes across most chains
 // 2. TODO_FUTURE: Compute the gas cost dynamically based on the size of the branch being proven.
-var ClaimAndProofGasCost = sdktypes.NewInt64Coin(pocket.DenomuPOKT, 10_000)
+// TODO_TECHDEBT(@olshansk): Temporarily setting this to 1uPOKT to see more claims & proofs on chain
+var ClaimAndProofGasCost = sdktypes.NewInt64Coin(pocket.DenomuPOKT, 1)
 
 // createClaims maps over the sessionsToClaimObs observable. For each claim batch, it:
 // 1. Calculates the earliest block height at which it is safe to CreateClaims

--- a/pkg/relayer/session/session_test.go
+++ b/pkg/relayer/session/session_test.go
@@ -154,14 +154,14 @@ func TestRelayerSessionsManager_InsufficientBalanceForProofSubmission(t *testing
 
 	lowCUPRService := sharedtypes.Service{
 		Id:                   "lowCUPRService",
-		ComputeUnitsPerRelay: 10000,
+		ComputeUnitsPerRelay: 1,
 	}
 	testqueryclients.AddToExistingServices(t, lowCUPRService)
 	testqueryclients.SetServiceRelayDifficultyTargetHash(t, lowCUPRService.Id, protocol.BaseRelayDifficultyHashBz)
 
 	highCUPRService := sharedtypes.Service{
 		Id:                   "highCUPRService",
-		ComputeUnitsPerRelay: 20000,
+		ComputeUnitsPerRelay: 2,
 	}
 	testqueryclients.AddToExistingServices(t, highCUPRService)
 	testqueryclients.SetServiceRelayDifficultyTargetHash(t, highCUPRService.Id, protocol.BaseRelayDifficultyHashBz)

--- a/testutil/testclient/testblock/client.go
+++ b/testutil/testclient/testblock/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pokt-network/poktroll/pkg/client/block"
 	"github.com/pokt-network/poktroll/pkg/observable"
 	"github.com/pokt-network/poktroll/pkg/observable/channel"
+	"github.com/pokt-network/poktroll/pkg/polylog"
 	"github.com/pokt-network/poktroll/testutil/mockclient"
 	"github.com/pokt-network/poktroll/testutil/testclient"
 	"github.com/pokt-network/poktroll/testutil/testclient/testeventsquery"
@@ -30,7 +31,7 @@ func NewLocalnetClient(ctx context.Context, t *testing.T) client.BlockClient {
 	cometClient, err := sdkclient.NewClientFromNode(testclient.CometLocalTCPURL)
 	require.NoError(t, err)
 
-	deps := depinject.Supply(queryClient, cometClient)
+	deps := depinject.Supply(queryClient, cometClient, polylog.Ctx(ctx))
 	bClient, err := block.NewBlockClient(ctx, deps)
 	require.NoError(t, err)
 

--- a/testutil/testclient/testblock/client.go
+++ b/testutil/testclient/testblock/client.go
@@ -31,7 +31,7 @@ func NewLocalnetClient(ctx context.Context, t *testing.T) client.BlockClient {
 	cometClient, err := sdkclient.NewClientFromNode(testclient.CometLocalTCPURL)
 	require.NoError(t, err)
 
-	deps := depinject.Supply(queryClient, cometClient, polylog.Ctx(ctx))
+	deps := depinject.Supply(polylog.Ctx(ctx), queryClient, cometClient)
 	bClient, err := block.NewBlockClient(ctx, deps)
 	require.NoError(t, err)
 

--- a/testutil/testclient/testblock/client.go
+++ b/testutil/testclient/testblock/client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pokt-network/poktroll/pkg/client"
 	"github.com/pokt-network/poktroll/pkg/client/block"
+	"github.com/pokt-network/poktroll/pkg/client/events"
 	"github.com/pokt-network/poktroll/pkg/observable"
 	"github.com/pokt-network/poktroll/pkg/observable/channel"
 	"github.com/pokt-network/poktroll/pkg/polylog"
@@ -25,7 +26,8 @@ import (
 func NewLocalnetClient(ctx context.Context, t *testing.T) client.BlockClient {
 	t.Helper()
 
-	queryClient := testeventsquery.NewLocalnetClient(t)
+	loggerOpt := events.WithLogger(polylog.Ctx(ctx))
+	queryClient := testeventsquery.NewLocalnetClient(t, loggerOpt)
 	require.NotNil(t, queryClient)
 
 	cometClient, err := sdkclient.NewClientFromNode(testclient.CometLocalTCPURL)


### PR DESCRIPTION
## Summary

Improve signal handling with graceful shutdowns and enhance event subscription resilience with connection state tracking.

### Primary Changes:
- Enhanced `GoOnExitSignal` with graceful shutdown support, timeout handling, and multiple signal trapping
- Refactored `EventsQueryClient` to improve connection management and resource cleanup
- Added connection state tracking to `EventsReplayClient` with improved logging for debugging

### Secondary changes:
- Updated logging with emoji indicators for better visual distinction between message types
- Fixed resource leaks by ensuring proper cleanup of websocket connections
- Updated caller code to use the new `GoOnExitSignal` signature

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [x] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
