### PR TITLE
[Logs] Reduce IOPS generated due to log writes

### DIFF
--- a/pkg/polylog/polyzero/options.go
+++ b/pkg/polylog/polyzero/options.go
@@ -2,7 +2,6 @@ package polyzero
 
 import (
 	"io"
-	"os"
 
 	"github.com/rs/zerolog"
 
@@ -37,8 +36,8 @@ func WithTimestampKey(key string) polylog.LoggerOption {
 // WithTimestamp configures the logger to include a timestamp field using zerolog's built-in Timestamp().
 func WithTimestamp() polylog.LoggerOption {
 	return func(logger polylog.Logger) {
-		// Fallback to os.Stderr, as in NewLogger, since zerolog.Logger does not expose Writer().
-		logger.(*zerologLogger).Logger = zerolog.New(os.Stderr).With().Timestamp().Logger()
+		zl := logger.(*zerologLogger)
+		zl.Logger = zl.Logger.With().Timestamp().Logger()
 	}
 }
 


### PR DESCRIPTION
## Summary

Reduce logs stress to the server. Since all of them are going to disk on containerized environments because it is using `os.Stderr`

### Primary Changes:

- Refactor `WithTimestamp` to reuse existing logger
- Add buffered logging with periodic flushing to reduce IOPS. 

## Issue

- High IOPS

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [x] 'TODO's, configurations and other docs
