### PR TITLE
[BETA][MAINNET][VALIDATORS][STAKING] Increase validator pool on Beta and Mainnet from 5 -> 6

### DIFF
--- a/tools/scripts/params/bulk_params_beta/staking_params.json
+++ b/tools/scripts/params/bulk_params_beta/staking_params.json
@@ -6,7 +6,7 @@
         "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
         "params": {
           "unbonding_time": "504h0m0s",
-          "max_validators": 5,
+          "max_validators": 6,
           "max_entries": 8,
           "historical_entries": 10000,
           "bond_denom": "upokt",

--- a/tools/scripts/params/bulk_params_main/staking_params.json
+++ b/tools/scripts/params/bulk_params_main/staking_params.json
@@ -6,7 +6,7 @@
         "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
         "params": {
           "unbonding_time": "504h0m0s",
-          "max_validators": 5,
+          "max_validators": 6,
           "max_entries": 8,
           "historical_entries": 10000,
           "bond_denom": "upokt",


### PR DESCRIPTION
## Summary

Increase validator pool on Beta and Mainnet from 5 -> 6

### Primary Changes:

- Mainnet `staking.max_validators` from 5 -> 6
- Beta TestNet `staking.max_validators` from 5 -> 6

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Other: Param update

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
