### PR TITLE
[Params] Update session, proof and shared params to prevent excessive MainNet chain bloat

### DIFF
--- a/tools/scripts/params/bulk_params_beta/proof_params.json
+++ b/tools/scripts/params/bulk_params_beta/proof_params.json
@@ -5,10 +5,10 @@
         "@type": "/pocket.proof.MsgUpdateParams",
         "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
         "params": {
-          "proof_request_probability": 0.2,
+          "proof_request_probability": 0.01,
           "proof_requirement_threshold": {
             "denom": "upokt",
-            "amount": "1"
+            "amount": "100"
           },
           "proof_missing_penalty": {
             "denom": "upokt",

--- a/tools/scripts/params/bulk_params_beta/session_params.json
+++ b/tools/scripts/params/bulk_params_beta/session_params.json
@@ -5,7 +5,7 @@
         "@type": "/pocket.session.MsgUpdateParams",
         "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
         "params": {
-          "num_suppliers_per_session": "50"
+          "num_suppliers_per_session": "20"
         }
       }
     ]

--- a/tools/scripts/params/bulk_params_beta/shared_params.json
+++ b/tools/scripts/params/bulk_params_beta/shared_params.json
@@ -5,13 +5,13 @@
         "@type": "/pocket.shared.MsgUpdateParams",
         "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
         "params": {
-          "num_blocks_per_session": "10",
+          "num_blocks_per_session": "50",
           "grace_period_end_offset_blocks": "1",
           "claim_window_open_offset_blocks": "1",
           "claim_window_close_offset_blocks": "4",
           "proof_window_close_offset_blocks": "4",
-          "supplier_unbonding_period_sessions": "2016",
-          "application_unbonding_period_sessions": "2",
+          "supplier_unbonding_period_sessions": "403",
+          "application_unbonding_period_sessions": "1",
           "compute_units_to_tokens_multiplier": "33482",
           "gateway_unbonding_period_sessions": "1",
           "compute_unit_cost_granularity": "1000000"

--- a/tools/scripts/params/bulk_params_main/proof_params.json
+++ b/tools/scripts/params/bulk_params_main/proof_params.json
@@ -5,10 +5,10 @@
         "@type": "/pocket.proof.MsgUpdateParams",
         "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
         "params": {
-          "proof_request_probability": 0.2,
+          "proof_request_probability": 0.01,
           "proof_requirement_threshold": {
             "denom": "upokt",
-            "amount": "1"
+            "amount": "100"
           },
           "proof_missing_penalty": {
             "denom": "upokt",

--- a/tools/scripts/params/bulk_params_main/session_params.json
+++ b/tools/scripts/params/bulk_params_main/session_params.json
@@ -5,7 +5,7 @@
         "@type": "/pocket.session.MsgUpdateParams",
         "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
         "params": {
-          "num_suppliers_per_session": "50"
+          "num_suppliers_per_session": "20"
         }
       }
     ]

--- a/tools/scripts/params/bulk_params_main/shared_params.json
+++ b/tools/scripts/params/bulk_params_main/shared_params.json
@@ -5,13 +5,13 @@
         "@type": "/pocket.shared.MsgUpdateParams",
         "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
         "params": {
-          "num_blocks_per_session": "10",
+          "num_blocks_per_session": "50",
           "grace_period_end_offset_blocks": "1",
           "claim_window_open_offset_blocks": "1",
           "claim_window_close_offset_blocks": "4",
           "proof_window_close_offset_blocks": "4",
-          "supplier_unbonding_period_sessions": "2016",
-          "application_unbonding_period_sessions": "2",
+          "supplier_unbonding_period_sessions": "403",
+          "application_unbonding_period_sessions": "1",
           "compute_units_to_tokens_multiplier": "33482",
           "gateway_unbonding_period_sessions": "1",
           "compute_unit_cost_granularity": "1000000"

--- a/tools/scripts/params/gov_params.sh
+++ b/tools/scripts/params/gov_params.sh
@@ -26,7 +26,16 @@
 # 5. Export all module parameters to individual files in a directory
 # 6. Provide instructions for submitting transactions
 
-set -e
+# set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
 
 # Available modules list
 AVAILABLE_MODULES=(
@@ -256,7 +265,6 @@ fi
 # Function to query and display parameters for a single module
 query_module_params() {
     local module=$1
-    local show_header=${2:-true}
 
     # Build the query command
     local query_cmd="pocketd query $module params --home=$HOME_DIR"
@@ -266,13 +274,11 @@ query_module_params() {
     query_cmd="$query_cmd -o json"
     echo $query_cmd
 
-    if [ "$show_header" = true ]; then
-        echo "========================================="
-        echo "Module: $module ($(get_module_description "$module"))"
-        echo "Environment: $ENVIRONMENT"
-        echo "Network: $NETWORK"
-        echo "========================================="
-    fi
+    echo "========================================="
+    echo "Module: $module ($(get_module_description "$module"))"
+    echo -e "Environment: ${CYAN}$ENVIRONMENT${NC}"
+    echo -e "Network: ${CYAN}$NETWORK${NC}"
+    echo "========================================="
 
     # Query parameters
     local params_output
@@ -281,9 +287,6 @@ query_module_params() {
 
     if [ $query_exit_code -ne 0 ] || [ -z "$params_output" ]; then
         echo "❌ Failed to query parameters for module '$module'"
-        if [ "$show_header" = true ]; then
-            echo "   This module may not exist or may not have queryable parameters"
-        fi
         return 1
     fi
 
@@ -317,7 +320,7 @@ query_all_modules() {
 
     for module in "${AVAILABLE_MODULES[@]}"; do
         echo "🔍 Checking module: $module..."
-        if query_module_params "$module" false; then
+        if query_module_params "$module"; then
             successful_modules+=("$module")
         else
             failed_modules+=("$module")
@@ -525,9 +528,9 @@ case $COMMAND in
 
     echo "========================================="
     echo "Querying current $MODULE_NAME parameters"
-    echo "Environment: $ENVIRONMENT"
-    echo "Network: $NETWORK"
-    echo "Command: $QUERY_CMD"
+    echo -e "Environment: ${CYAN}$ENVIRONMENT${NC}"
+    echo -e "Network: ${CYAN}$NETWORK${NC}"
+    echo -e "Command: ${CYAN}$QUERY_CMD${NC}"
     echo "========================================="
     echo ""
 
@@ -569,8 +572,8 @@ case $COMMAND in
 EOF
 
     echo "========================================="
-    echo "Transaction template created: $OUTPUT_FILE_UPDATE"
-    echo "Message type used: $MESSAGE_TYPE"
+    echo -e "Transaction template created: ${CYAN}$OUTPUT_FILE_UPDATE${NC}"
+    echo -e "Message type used: ${CYAN}$MESSAGE_TYPE${NC}"
     echo "========================================="
     echo ""
 
@@ -608,10 +611,10 @@ EOF
     echo ""
     echo "To submit your parameter update transaction, run:"
     echo ""
-    echo "  pocketd tx authz exec $OUTPUT_FILE_UPDATE --from=$FROM_KEY --keyring-backend=test --chain-id=$CHAIN_ID $NODE --yes --home=$HOME_DIR --gas=auto --fees=10upokt"
+    echo -e "${CYAN}pocketd tx authz exec $OUTPUT_FILE_UPDATE --from=$FROM_KEY --keyring-backend=test --chain-id=$CHAIN_ID $NODE --yes --home=$HOME_DIR --gas=auto --fees=10upokt${NC}"
     echo ""
-    echo "Template file location: $OUTPUT_FILE_UPDATE"
-    echo "Message type used: $MESSAGE_TYPE"
+    echo -e "Template file location: ${CYAN}$OUTPUT_FILE_UPDATE${NC}"
+    echo -e "Message type used: ${CYAN}$MESSAGE_TYPE${NC}"
     echo ""
     echo "⚠️  IMPORTANT: Review your changes carefully before submitting!"
     echo "⚠️  Parameter updates affect the entire network and cannot be easily reverted."

--- a/tools/scripts/params/gov_params.sh
+++ b/tools/scripts/params/gov_params.sh
@@ -608,7 +608,7 @@ EOF
     echo ""
     echo "To submit your parameter update transaction, run:"
     echo ""
-    echo "  pocketd tx authz exec $OUTPUT_FILE_UPDATE --from=$FROM_KEY --keyring-backend=test --chain-id=$CHAIN_ID $NODE --yes --home=$HOME_DIR --fees=200upokt"
+    echo "  pocketd tx authz exec $OUTPUT_FILE_UPDATE --from=$FROM_KEY --keyring-backend=test --chain-id=$CHAIN_ID $NODE --yes --home=$HOME_DIR --gas=auto --fees=10upokt"
     echo ""
     echo "Template file location: $OUTPUT_FILE_UPDATE"
     echo "Message type used: $MESSAGE_TYPE"


### PR DESCRIPTION
Make the following param changes on BetaNet & MainNet:
- `proof_request_probability`: `0.2` -> `0.01` (%)
- `proof_requirement_threshold` `1` -> `100` (uPOKT)
- `num_suppliers_per_session`: `50` -> `20` (count)
- `num_blocks_per_session`: `50` -

**Why is this necessary?**
- Shannon is still in "phase 1" of stabilization of getting back to normalcy
- We need to 🩹 a temporary solution to prevent excessive growth while we resolve an amalgamation of different issues
- These param changes will buy us time and do not affect the mint/burn economy

Refs:
- Related issue: https://github.com/pokt-network/poktroll/issues/1497
- Internal discussion thread: https://discord.com/channels/824324475256438814/1386776430037438544

If we do not change it now, then:
- MainNet block size today: 5GB
- Projected in 1 week: 50GB

<img width="1013" alt="Screenshot_2025-06-23_at_3 49 24_PM" src="https://github.com/user-attachments/assets/9ffc47a1-e16e-4ae0-b979-ac8c1fbaaff9" />
