### PR TITLE
Make the telegram bot release be a manual trigger

### DIFF
--- a/.github/workflows/notify-telegram-groups.yml
+++ b/.github/workflows/notify-telegram-groups.yml
@@ -76,65 +76,65 @@ jobs:
             -d text="$MESSAGE" \
             -d parse_mode="Markdown"
 
-          # Send to BitGet <> Pocket Network (POKT)
-          echo "Sending to BitGet <> Pocket Network (POKT) ($CHAT_2)"
-          curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
-            -d chat_id="$CHAT_2" \
-            -d text="$MESSAGE" \
-            -d parse_mode="Markdown"
+          # # Send to BitGet <> Pocket Network (POKT)
+          # echo "Sending to BitGet <> Pocket Network (POKT) ($CHAT_2)"
+          # curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
+          #   -d chat_id="$CHAT_2" \
+          #   -d text="$MESSAGE" \
+          #   -d parse_mode="Markdown"
 
-          # Send to ByBit <> POKT
-          echo "Sending to ByBit <> POKT ($CHAT_3)"
-          curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
-            -d chat_id="$CHAT_3" \
-            -d text="$MESSAGE" \
-            -d parse_mode="Markdown"
+          # # Send to ByBit <> POKT
+          # echo "Sending to ByBit <> POKT ($CHAT_3)"
+          # curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
+          #   -d chat_id="$CHAT_3" \
+          #   -d text="$MESSAGE" \
+          #   -d parse_mode="Markdown"
 
-          # Send to CoinEx <> POKT
-          echo "Sending to CoinEx <> POKT ($CHAT_4)"
-          curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
-            -d chat_id="$CHAT_4" \
-            -d text="$MESSAGE" \
-            -d parse_mode="Markdown"
+          # # Send to CoinEx <> POKT
+          # echo "Sending to CoinEx <> POKT ($CHAT_4)"
+          # curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
+          #   -d chat_id="$CHAT_4" \
+          #   -d text="$MESSAGE" \
+          #   -d parse_mode="Markdown"
 
-          # Send to Mr. Yang <> Grove / POKT
-          echo "Sending to Mr. Yang <> Grove / POKT ($CHAT_5)"
-          curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
-            -d chat_id="$CHAT_5" \
-            -d text="$MESSAGE" \
-            -d parse_mode="Markdown"
+          # # Send to Mr. Yang <> Grove / POKT
+          # echo "Sending to Mr. Yang <> Grove / POKT ($CHAT_5)"
+          # curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
+          #   -d chat_id="$CHAT_5" \
+          #   -d text="$MESSAGE" \
+          #   -d parse_mode="Markdown"
 
-          # Send to MEXC <> POKT
-          echo "Sending to MEXC <> POKT ($CHAT_6)"
-          curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
-            -d chat_id="$CHAT_6" \
-            -d text="$MESSAGE" \
-            -d parse_mode="Markdown"
+          # # Send to MEXC <> POKT
+          # echo "Sending to MEXC <> POKT ($CHAT_6)"
+          # curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
+          #   -d chat_id="$CHAT_6" \
+          #   -d text="$MESSAGE" \
+          #   -d parse_mode="Markdown"
 
-          # Send to OKX <> Pocket Network
-          echo "Sending to OKX <> Pocket Network ($CHAT_7)"
-          curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
-            -d chat_id="$CHAT_7" \
-            -d text="$MESSAGE" \
-            -d parse_mode="Markdown"
+          # # Send to OKX <> Pocket Network
+          # echo "Sending to OKX <> Pocket Network ($CHAT_7)"
+          # curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
+          #   -d chat_id="$CHAT_7" \
+          #   -d text="$MESSAGE" \
+          #   -d parse_mode="Markdown"
 
-          # Send to OrangeX <> Grove (POKT)
-          echo "Sending to OrangeX <> Grove (POKT) ($CHAT_8)"
-          curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
-            -d chat_id="$CHAT_8" \
-            -d text="$MESSAGE" \
-            -d parse_mode="Markdown"
+          # # Send to OrangeX <> Grove (POKT)
+          # echo "Sending to OrangeX <> Grove (POKT) ($CHAT_8)"
+          # curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
+          #   -d chat_id="$CHAT_8" \
+          #   -d text="$MESSAGE" \
+          #   -d parse_mode="Markdown"
 
-          # Send to POKT & Gate.io
-          echo "Sending to POKT & Gate.io ($CHAT_9)"
-          curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
-            -d chat_id="$CHAT_9" \
-            -d text="$MESSAGE" \
-            -d parse_mode="Markdown"
+          # # Send to POKT & Gate.io
+          # echo "Sending to POKT & Gate.io ($CHAT_9)"
+          # curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
+          #   -d chat_id="$CHAT_9" \
+          #   -d text="$MESSAGE" \
+          #   -d parse_mode="Markdown"
 
-          # Send to POKT Network | AscendEX
-          echo "Sending to POKT Network | AscendEX ($CHAT_10)"
-          curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
-            -d chat_id="$CHAT_10" \
-            -d text="$MESSAGE" \
-            -d parse_mode="Markdown"
+          # # Send to POKT Network | AscendEX
+          # echo "Sending to POKT Network | AscendEX ($CHAT_10)"
+          # curl -s -X POST https://api.telegram.org/bot7267336172:AAEYaEeY0i7DfbL7SsRjPf09N67mvLo8WC4/sendMessage \
+          #   -d chat_id="$CHAT_10" \
+          #   -d text="$MESSAGE" \
+          #   -d parse_mode="Markdown"


### PR DESCRIPTION
- Update the telegram release bot to be manually triggered rather than automatic
- Avoids spamming all groups on edits (intentional or accidental)
- Workflow can be triggered here: https://github.com/pokt-network/poktroll/actions/workflows/notify-telegram-groups.yml