### PR TITLE
[Feature] Streaming Support for SSE and NDJSON (used for LLMs)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/go-kit/kit v0.13.0
 	github.com/gogo/status v1.1.0
 	github.com/golang/mock v1.6.0
-	github.com/golang/protobuf v1.5.4
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/go-kit/kit v0.13.0
 	github.com/gogo/status v1.1.0
 	github.com/golang/mock v1.6.0
-	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/golang/protobuf v1.5.4
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0

--- a/pkg/relayer/proxy/http_stream.go
+++ b/pkg/relayer/proxy/http_stream.go
@@ -1,0 +1,148 @@
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/pokt-network/poktroll/pkg/polylog"
+	"github.com/pokt-network/poktroll/x/service/types"
+	sdktypes "github.com/pokt-network/shannon-sdk/types"
+	"google.golang.org/protobuf/proto"
+)
+
+// Target streaming types
+var httpStreamingTypes = []string{
+	"text/event-stream",
+	"application/x-ndjson",
+}
+
+var streamDelimitter = "||POKT_STREAM||"
+
+// Custom split function for POKT events.
+// The POKT streams contains a signature and the body of the request to the
+// backend, so we need a custom delimiter for streaming responses.
+// This functions is a custom delimiter for the Stream functionality
+func ScanEvents(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+
+	// Look for the POKT_STREAM delimiter
+	if i := strings.Index(string(data), streamDelimitter); i >= 0 {
+		// Return chunk without the delimiter
+		return i + len(streamDelimitter), data[0:i], nil
+	}
+
+	// If we're at EOF, return whatever we have
+	if atEOF {
+		return len(data), data, nil
+	}
+
+	// Request more data
+	return 0, nil, nil
+}
+
+// This function looks for the supported streams.
+// We should be able to handle any cunked stream, but we have limited this
+// to the content types specified in the variable `httpStreamingTypes`
+//
+// Returns:
+//   - boolean whether the backend response should be streamed or not
+func IsStreamingResponse(response *http.Response) (isStreaming bool) {
+	// Check if this is a streaming response
+	contentType := response.Header.Get("Content-Type")
+	for _, streamType := range httpStreamingTypes {
+		if strings.Contains(strings.ToLower(contentType), streamType) {
+			isStreaming = true
+		}
+	}
+
+	return
+}
+
+// Handles the streaming backend responses.
+// This function takes a streaming body and:
+// - Reads each chunk
+// - Converts the chunk into a POKT HTTP response structure
+// - Signs each chunk
+// - Writes and flush to the requesting app
+//
+// This will handle any stream where the delimiter is a newline (`\n`)
+func (server *relayMinerHTTPServer) HandleHttpStream(response *http.Response,
+	writer http.ResponseWriter,
+	meta types.RelayRequestMetadata,
+	logger polylog.Logger) (relayResponse *types.RelayResponse, responseSize float64, err error) {
+
+	// Set headers
+	writer.Header().Set("Connection", "close")
+	// Copy the response back to the original request
+	for k, v := range response.Header {
+		writer.Header()[k] = v
+	}
+	writer.WriteHeader(response.StatusCode)
+
+	// Instance the flusher
+	flusher, ok := writer.(http.Flusher)
+	if !ok {
+		logger.Error().Msg("Streaming not supported.")
+		return nil, 0, fmt.Errorf("❌ failed to open stream request")
+	} else {
+		// Create scanner with default delimiter (\n)
+		scanner := bufio.NewScanner(response.Body)
+		// Scan for chunks
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			// Add back the newline that we stripped at Scan
+			line = append(line, '\n')
+
+			// logger.Debug().
+			// 	Int("lineSize", len(line)).
+			// 	// Str("line", string(line)).
+			// 	Msg("Recieved stream chunk.")
+
+			// Create the POKT HTTP response structure
+			poktHTTPResponse := &sdktypes.POKTHTTPResponse{
+				StatusCode: uint32(http.StatusOK),
+				Header:     make(map[string]*sdktypes.Header, 0),
+				BodyBz:     line,
+			}
+			// Deterministic marshaling of response
+			marshalOpts := proto.MarshalOptions{Deterministic: true}
+			poktHTTPResponseBz, err := marshalOpts.Marshal(poktHTTPResponse)
+			if err != nil {
+				return nil, 0, fmt.Errorf("❌ failed to marshal POKT HTTP response: %w", err)
+			}
+
+			// Sign response
+			relayResponse, err = server.newRelayResponse(poktHTTPResponseBz, meta.SessionHeader, meta.SupplierOperatorAddress)
+			if err != nil {
+				return nil, 0, err
+			}
+			// Marshal response
+			signedLine, err := relayResponse.Marshal()
+			if err != nil {
+				return nil, 0, err
+			}
+
+			// track size, the sum of all chunks
+			responseSize += float64(relayResponse.Size())
+
+			// Append custom delimiter (used by app to detect POKT streaming)
+			signedLine = append(signedLine, []byte(streamDelimitter)...)
+
+			// Write to client
+			writer.Write(signedLine)
+
+			// Flush to ensure the stream goes asap to the app
+			flusher.Flush()
+
+			// logger.Debug().
+			// 	Int("responseSize", relayResponse.Size()).
+			// 	Msg("Stream chunk relayed.")
+		}
+	}
+
+	return
+}

--- a/pkg/relayer/proxy/sync.go
+++ b/pkg/relayer/proxy/sync.go
@@ -215,44 +215,67 @@ func (server *relayMinerHTTPServer) serveSyncRequest(
 		)
 	}
 
-	// Serialize the service response to be sent back to the client.
-	// This will include the status code, headers, and body.
-	_, responseBz, err := SerializeHTTPResponse(logger, httpResponse)
-	if err != nil {
-		return relayRequest, err
+	// Check if the response is a stream
+	streamThis := IsStreamingResponse(httpResponse)
+	// Create empty relay response
+	var relayResponse *types.RelayResponse
+	var responseSize float64
+	if streamThis {
+		logger.Debug().Msg("Handling streaming request.")
+
+		// Process and assign the relay response
+		relayResponse, responseSize, err = server.HandleHttpStream(httpResponse, writer, meta, logger)
+		if err != nil {
+			return relayRequest, err
+		}
+
+	} else {
+		logger.Debug().Msg("Handling normal request.")
+
+		// Serialize the service response to be sent back to the client.
+		// This will include the status code, headers, and body.
+		_, responseBz, err := SerializeHTTPResponse(logger, httpResponse)
+		if err != nil {
+			return relayRequest, err
+		}
+
+		logger.Debug().
+			Str("relay_request_session_header", meta.SessionHeader.String()).
+			Msg("building relay response protobuf from service response")
+
+		// Build the relay response using the original service's response.
+		// Use relayRequest.Meta.SessionHeader on the relayResponse session header since it
+		// was verified to be valid and has to be the same as the relayResponse session header.
+		relayResponse, err = server.newRelayResponse(responseBz, meta.SessionHeader, meta.SupplierOperatorAddress)
+		if err != nil {
+			// The client should not have knowledge about the RelayMiner's issues with
+			// building the relay response. Reply with an internal error so that the
+			// original error is not exposed to the client.
+			return relayRequest, ErrRelayerProxyInternalError.Wrap(err.Error())
+		}
+
+		// Send the relay response to the client.
+		if err = server.sendRelayResponse(relayResponse, writer); err != nil {
+			// If the originHost cannot be parsed, reply with an internal error so that
+			// the original error is not exposed to the client.
+			clientError := ErrRelayerProxyInternalError.Wrap(err.Error())
+			logger.Warn().Err(err).Msg("failed sending relay response")
+			return relayRequest, clientError
+		}
+
+		// Set response size
+		responseSize = float64(relayResponse.Size())
+
 	}
 
-	logger.Debug().
-		Str("relay_request_session_header", meta.SessionHeader.String()).
-		Msg("building relay response protobuf from service response")
-
-	// Build the relay response using the original service's response.
-	// Use relayRequest.Meta.SessionHeader on the relayResponse session header since it
-	// was verified to be valid and has to be the same as the relayResponse session header.
-	relayResponse, err := server.newRelayResponse(responseBz, meta.SessionHeader, meta.SupplierOperatorAddress)
-	if err != nil {
-		// The client should not have knowledge about the RelayMiner's issues with
-		// building the relay response. Reply with an internal error so that the
-		// original error is not exposed to the client.
-		return relayRequest, ErrRelayerProxyInternalError.Wrap(err.Error())
-	}
-
+	// Create the relay response
 	relay := &types.Relay{Req: relayRequest, Res: relayResponse}
-
-	// Send the relay response to the client.
-	if err = server.sendRelayResponse(relay.Res, writer); err != nil {
-		// If the originHost cannot be parsed, reply with an internal error so that
-		// the original error is not exposed to the client.
-		clientError := ErrRelayerProxyInternalError.Wrap(err.Error())
-		logger.Warn().Err(err).Msg("failed sending relay response")
-		return relayRequest, clientError
-	}
 
 	logger.ProbabilisticDebugInfo(polylog.ProbabilisticDebugInfoProb).Msg("relay request served successfully")
 
 	relayer.RelaysSuccessTotal.With("service_id", serviceId).Add(1)
 
-	relayer.RelayResponseSizeBytes.With("service_id", serviceId).Observe(float64(relay.Res.Size()))
+	relayer.RelayResponseSizeBytes.With("service_id", serviceId).Observe(responseSize)
 
 	// Verify relay reward eligibility a SECOND time AFTER completing the backend request.
 	//

--- a/pkg/relayer/proxy/sync.go
+++ b/pkg/relayer/proxy/sync.go
@@ -216,11 +216,11 @@ func (server *relayMinerHTTPServer) serveSyncRequest(
 	}
 
 	// Check if the response is a stream
-	streamThis := IsStreamingResponse(httpResponse)
+	isStream := IsStreamingResponse(httpResponse)
 	// Create empty relay response
 	var relayResponse *types.RelayResponse
 	var responseSize float64
-	if streamThis {
+	if isStream {
 		logger.Debug().Msg("Handling streaming request.")
 
 		// Process and assign the relay response
@@ -228,7 +228,6 @@ func (server *relayMinerHTTPServer) serveSyncRequest(
 		if err != nil {
 			return relayRequest, err
 		}
-
 	} else {
 		logger.Debug().Msg("Handling normal request.")
 


### PR DESCRIPTION
## Summary

Added streaming support for contentypes:
- "text/event-stream" (https://en.wikipedia.org/wiki/Server-sent_events)
- "application/x-ndjson" (https://docs.mulesoft.com/dataweave/latest/dataweave-formats-ndjson)

These are streams delimited by newlines (`\n`) that can be supported by Pocket Network without any change to the verification and accounting logic.

The first one, `text/event-stream`, is the one used by streaming LLM responses (OpenAI format) and is a functionality that we need asap.

### Primary Changes:

- Added new file `http_stream.go` that implements streaming responses of the mentioned types.
- Added a custom delimiter for the Pocket Network streamed responses, necessary to avoid collision with arbitrary payloads and supplier signature.
- Modified `sync.go` to check for the backend response headers and implement either this streaming protocol or respond normally (read full response first and then relay)

### Secondary Changes:

- Modified the order of some checks in the `serveSyncRequest()` function, to keep code more tidy.
- Modified `processStreamRequest` to provide an example on how to support streaming responses by an app.
- Modified `processStreamRequest` to make code more modular and re-use functions between normal and streamed response.

### Checks:

I tested this in beta-testnet, against a vLLM enpoint, using this custom RM and the `pocketd relayminer relay` command:

```bash
pocketd relayminer relay \
    --app=pokt1wvn4a8kj4mfnq0cjakadskxwr2zkev35psjxh9 \
    --supplier=pokt19a3t4yunp0dlpfjrp7qwnzwlrzd5fzs2gjaaaj \
    --node=https://shannon-testnet-grove-rpc.beta.poktroll.com  \
    --grpc-addr=shannon-testnet-grove-grpc.beta.poktroll.com:443 \
    --grpc-insecure=false \
    --payload='{"messages": [{"role": "user", "content": "Tell me how to properly eat a Choripan."}],"max_tokens":200, "model":"pocket_network", "stream":true}' \
    --supplier-public-endpoint-override=http://localhost:8545/v1/chat/completions \
    --network=beta
```

response:

```bash
{"level":"warn","time":"2025-06-24T16:40:29-03:00","message":"⚠️ Using override endpoint URL: http://localhost:8546/v1/chat/completions"}
{"level":"info","time":"2025-06-24T16:40:29-03:00","message":"✅ JSON-RPC request payload serialized."}
{"level":"info","time":"2025-06-24T16:40:29-03:00","message":"✅ Relay request built."}
{"level":"info","time":"2025-06-24T16:40:29-03:00","message":"✅ Retrieved private key for app pokt1wvn4a8kj4mfnq0cjakadskxwr2zkev35psjxh9"}
{"level":"info","time":"2025-06-24T16:40:29-03:00","message":"✅ Relay request signed."}
{"level":"info","time":"2025-06-24T16:40:29-03:00","message":"✅ Relay request marshaled."}
{"level":"info","time":"2025-06-24T16:40:29-03:00","message":"✅ Endpoint URL parsed: http://localhost:8546/v1/chat/completions"}
{"level":"info","time":"2025-06-24T16:40:30-03:00","message":"🔍 Content-Type: text/event-stream; charset=utf-8"}
{"level":"info","time":"2025-06-24T16:40:30-03:00","message":"🌊 Handling streaming response with status:"}
{"level":"info","time":"2025-06-24T16:40:30-03:00","message":"📦 Read chunk of length 449"}
{"level":"info","time":"2025-06-24T16:40:30-03:00","message":"✅ Deserialized response body as JSON map: map[choices:[map[delta:map[content: role:assistant] finish_reason:<nil> index:0 logprobs:<nil>]] created:1.75079403e+09 id:chat-2b20014c1d124d1da32d6a71139ea77e model:pocket_network object:chat.completion.chunk]"}
{"level":"info","time":"2025-06-24T16:40:30-03:00","message":"📦 Read chunk of length 213"}
{"level":"info","time":"2025-06-24T16:40:30-03:00","message":"📦 Read chunk of length 432"}
{"level":"info","time":"2025-06-24T16:40:30-03:00","message":"✅ Deserialized response body as JSON map: map[choices:[map[delta:map[content:Ch] finish_reason:<nil> index:0 logprobs:<nil>]] created:1.75079403e+09 id:chat-2b20014c1d124d1da32d6a71139ea77e model:pocket_network object:chat.completion.chunk]"}
{"level":"info","time":"2025-06-24T16:40:30-03:00","message":"📦 Read chunk of length 213"}
{"level":"info","time":"2025-06-24T16:40:30-03:00","message":"📦 Read chunk of length 432"}
{"level":"info","time":"2025-06-24T16:40:31-03:00","message":"✅ Deserialized response body as JSON map: map[choices:[map[delta:map[content:or] finish_reason:<nil> index:0 logprobs:<nil>]] created:1.75079403e+09 id:chat-2b20014c1d124d1da32d6a71139ea77e model:pocket_network object:chat.completion.chunk]"}
{"level":"info","time":"2025-06-24T16:40:31-03:00","message":"📦 Read chunk of length 213"}
{"level":"info","time":"2025-06-24T16:40:31-03:00","message":"📦 Read chunk of length 432"}
{"level":"info","time":"2025-06-24T16:40:31-03:00","message":"✅ Deserialized response body as JSON map: map[choices:[map[delta:map[content:ip] finish_reason:<nil> index:0 logprobs:<nil>]] created:1.75079403e+09 id:chat-2b20014c1d124d1da32d6a71139ea77e model:pocket_network object:chat.completion.chunk]"}
{"level":"info","time":"2025-06-24T16:40:31-03:00","message":"📦 Read chunk of length 213"}
{"level":"info","time":"2025-06-24T16:40:31-03:00","message":"📦 Read chunk of length 432"}
{"level":"info","time":"2025-06-24T16:40:31-03:00","message":"✅ Deserialized response body as JSON map: map[choices:[map[delta:map[content:an] finish_reason:<nil> index:0 logprobs:<nil>]] created:1.75079403e+09 id:chat-2b20014c1d124d1da32d6a71139ea77e model:pocket_network object:chat.completion.chunk]"}
{"level":"info","time":"2025-06-24T16:40:31-03:00","message":"📦 Read chunk of length 213"}
{"level":"info","time":"2025-06-24T16:40:31-03:00","message":"📦 Read chunk of length 433"}
{"level":"info","time":"2025-06-24T16:40:32-03:00","message":"✅ Deserialized response body as JSON map: map[choices:[map[delta:map[content: is] finish_reason:<nil> index:0 logprobs:<nil>]] created:1.75079403e+09 id:chat-2b20014c1d124d1da32d6a71139ea77e model:pocket_network object:chat.completion.chunk]"}
...
```
## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
