### PR TITLE
[Upgrade] Add v0.1.24 upgrade handler

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -114,6 +114,14 @@ var allUpgrades = []upgrades.Upgrade{
 	// - Tokenomics enhancements (non-chain halting claim settlement)
 	// - Service parameter updates and governance parameter adjustments
 	upgrades.Upgrade_0_1_23,
+
+	// v0.1.24 - upgrade to:
+	// - Supplier query enhancements (dehydrated flag for list-suppliers)
+	// - Supplier downstaking fixes (funds go to owner address)
+	// - Session parameter updates (numSuppliersPerSession increased to 50)
+	// - CLI improvements (count flag for relay command)
+	// - Telegram bot exchange list updates
+	upgrades.Upgrade_0_1_24,
 }
 
 // setUpgrades sets upgrade handlers for all upgrades and executes KVStore migration if an upgrade plan file exists.

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -113,7 +113,7 @@ var allUpgrades = []upgrades.Upgrade{
 	// - RelayMiner improvements (replaced EventsQueryClient with CometBFT client)
 	// - Tokenomics enhancements (non-chain halting claim settlement)
 	// - Service parameter updates and governance parameter adjustments
-	upgrades.Upgrade_0_1_23,
+	// upgrades.Upgrade_0_1_23,
 
 	// v0.1.24 - upgrade to:
 	// - Supplier query enhancements (dehydrated flag for list-suppliers)

--- a/app/upgrades/v0.1.24.go
+++ b/app/upgrades/v0.1.24.go
@@ -1,0 +1,45 @@
+package upgrades
+
+import (
+	"context"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/pokt-network/poktroll/app/keepers"
+)
+
+const (
+	Upgrade_0_1_24_PlanName = "v0.1.24"
+)
+
+// Upgrade_0_1_24 handles the upgrade to release `v0.1.24`.
+// This upgrade includes:
+// - Supplier query enhancements (dehydrated flag for list-suppliers)
+// - Supplier downstaking fixes (funds go to owner address)
+// - Session parameter updates (numSuppliersPerSession increased to 50)
+// - CLI improvements (count flag for relay command)
+// - Telegram bot exchange list updates
+var Upgrade_0_1_24 = Upgrade{
+	PlanName: Upgrade_0_1_24_PlanName,
+	// No KVStore migrations in this upgrade.
+	StoreUpgrades: storetypes.StoreUpgrades{},
+
+	// Upgrade Handler
+	CreateUpgradeHandler: func(
+		mm *module.Manager,
+		keepers *keepers.Keepers,
+		configurator module.Configurator,
+	) upgradetypes.UpgradeHandler {
+		// Add new parameters by:
+		// 1. Inspecting the diff between v0.1.23..v0.1.24
+		// 2. Manually inspect changes in ignite's config.yml
+		// 3. Update the upgrade handler here accordingly
+		// Ref: https://github.com/pokt-network/poktroll/compare/v0.1.23..v0.1.24
+
+		return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+			return vm, nil
+		}
+	},
+}


### PR DESCRIPTION
## Summary

Add upgrade handler for v0.1.24 release

### Primary Changes:
- Add `v0.1.24.go` upgrade handler file with upgrade logic
- Register `Upgrade_0_1_24` in `allUpgrades` slice for upgrade execution
- Include upgrade comments documenting the changes in this release

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Other (specify) upgrade

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
