### PR TITLE
Added pocket-knife to ecosystem tools

### DIFF
--- a/docusaurus/docs/2_explore/3_community/1_community.md
+++ b/docusaurus/docs/2_explore/3_community/1_community.md
@@ -62,7 +62,7 @@ Streamlines deployment on Kubernetes clusters
 
 [GitHub Repo](https://github.com/eddyzags/pocket-network-helm-chart)
 
-## [Pocket Knife](github.com/buildwithgrove/pocket-knife/)
+## [Pocket Knife](https://github.com/buildwithgrove/pocket-knife/)
 
 A developer-friendly wrapper around pocketd — your Swiss Army knife for fast, clean, and reliable Pocket Network operations.
 

--- a/docusaurus/docs/2_explore/3_community/1_community.md
+++ b/docusaurus/docs/2_explore/3_community/1_community.md
@@ -64,7 +64,7 @@ Streamlines deployment on Kubernetes clusters
 
 ## [Pocket Knife](https://github.com/buildwithgrove/pocket-knife/)
 
-A CLI wrapper for `pocketd` — streamlined for bulk operations.
+A python syntactic sugar wrapper for `pocketd` — streamlined for bulk operations.
 
 **Features**:
 

--- a/docusaurus/docs/2_explore/3_community/1_community.md
+++ b/docusaurus/docs/2_explore/3_community/1_community.md
@@ -64,7 +64,7 @@ Streamlines deployment on Kubernetes clusters
 
 ## [Pocket Knife](https://github.com/buildwithgrove/pocket-knife/)
 
-A developer-friendly wrapper around pocketd — your Swiss Army knife for fast, clean, and reliable Pocket Network operations.
+A CLI wrapper for `pocketd` — streamlined for bulk operations.
 
 **Features**:
 

--- a/docusaurus/docs/2_explore/3_community/1_community.md
+++ b/docusaurus/docs/2_explore/3_community/1_community.md
@@ -61,3 +61,16 @@ Streamlines deployment on Kubernetes clusters
 - HPA resource definition for relayminer (autoscaling)
 
 [GitHub Repo](https://github.com/eddyzags/pocket-network-helm-chart)
+
+## [Pocket Knife](github.com/buildwithgrove/pocket-knife/)
+
+A developer-friendly wrapper around pocketd — your Swiss Army knife for fast, clean, and reliable Pocket Network operations.
+
+**Features**:
+
+- Quickly find and export all node operator addresses owned by a wallet, with smart filtering, deduplication, and file output.
+- Analyze total holdings across liquid balances, app stakes, and node stakes from a single structured JSON input.
+- Batch unstake hundreds of operators with automatic gas estimation, transaction tracking, and error reporting.
+- and many more features!
+
+[GitHub Repo](https://github.com/buildwithgrove/pocket-knife)


### PR DESCRIPTION
This pull request adds a new section to the community documentation, introducing the `Pocket Knife` tool. The update highlights its purpose, features, and provides a link to its GitHub repository.

![Screenshot 2025-07-02 at 5 58 29 PM](https://github.com/user-attachments/assets/447eefa1-d022-4bd6-b851-11c93baf82a6)

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [x] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
