### PR TITLE
[Telegram] Add Korbit channel to broadcast workflow

### DIFF
--- a/.github/workflows/telegram-send-message.yml
+++ b/.github/workflows/telegram-send-message.yml
@@ -56,6 +56,8 @@ jobs:
           CHAT_15="-1002653157934"
           # KuCoin <> POKT
           CHAT_16="-775612675"
+          # Korbit <> POKT
+          CHAT_17="-1002811115444"
 
           # Get the message and parse mode from the workflow inputs
           MESSAGE="${{ inputs.message }}"
@@ -98,4 +100,5 @@ jobs:
             send_message "$CHAT_14" "HTX <> POKT"
             send_message "$CHAT_15" "POKT <> Upbit"
             send_message "$CHAT_16" "KuCoin <> POKT"
+            send_message "$CHAT_17" "Korbit <> POKT"
           fi


### PR DESCRIPTION
Adds missing Korbit <> POKT channel (ID: -1002811115444) to the telegram-send-message.yml workflow to ensure broadcast messages reach the Korbit partnership channel.

🤖 Generated with [Claude Code](https://claude.ai/code)