### PR TITLE
upgrade: Prepare upgrade plan for v0.1.26

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -127,7 +127,11 @@ var allUpgrades = []upgrades.Upgrade{
 	// - Reduced SMST / onchain proof size by persisting payload-dehydrated relay responses
 	// - Reduced event related state bloat by removing unnecessary settlement results from events
 	// - Updated Morse account recovery allowlist
-	upgrades.Upgrade_0_1_25,
+	// upgrades.Upgrade_0_1_25,
+
+	// v0.1.26 - upgrade to:
+	// - Implement backward compatible relay response signature verification to enable smooth protocol upgrades
+	upgrades.Upgrade_0_1_26,
 }
 
 // setUpgrades sets upgrade handlers for all upgrades and executes KVStore migration if an upgrade plan file exists.

--- a/app/upgrades/v0.1.26.go
+++ b/app/upgrades/v0.1.26.go
@@ -1,0 +1,41 @@
+package upgrades
+
+import (
+	"context"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/pokt-network/poktroll/app/keepers"
+)
+
+const (
+	Upgrade_0_1_26_PlanName = "v0.1.26"
+)
+
+// Upgrade_0_1_26 handles the upgrade to release `v0.1.26`.
+// This upgrade adds:
+// - Implement backward compatible relay response signature verification to enable smooth protocol upgrades
+var Upgrade_0_1_26 = Upgrade{
+	PlanName: Upgrade_0_1_26_PlanName,
+	// No KVStore migrations in this upgrade.
+	StoreUpgrades: storetypes.StoreUpgrades{},
+
+	// Upgrade Handler
+	CreateUpgradeHandler: func(
+		mm *module.Manager,
+		keepers *keepers.Keepers,
+		configurator module.Configurator,
+	) upgradetypes.UpgradeHandler {
+		// Add new parameters by:
+		// 1. Inspecting the diff between v0.1.25..v0.1.26
+		// 2. Manually inspect changes in ignite's config.yml
+		// 3. Update the upgrade handler here accordingly
+		// Ref: https://github.com/pokt-network/poktroll/compare/v0.1.25..v0.1.26
+
+		return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+			return vm, nil
+		}
+	},
+}


### PR DESCRIPTION
## Summary

Prepare upgrade plan for v0.1.26 with backward compatible relay response signature verification

### Primary Changes:
- Add `Upgrade_0_1_26` handler in `app/upgrades/v0.1.26.go`
- Update upgrade registry to include v0.1.26 upgrade

## Issue:

Protocol upgrade to enable smooth transitions with backward compatible relay response signature verification

## Type of change

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs