### PR TITLE
[RelayMiner] Avoid concurrent access to shared logger

### DIFF
--- a/pkg/relayer/session/session.go
+++ b/pkg/relayer/session/session.go
@@ -669,7 +669,9 @@ func (rs *relayerSessionsManager) deleteSessionTrees(
 	numSessionTreesDeleted := 0
 	for _, sessionTree := range sessionTrees {
 		sessionId := sessionTree.GetSessionHeader().GetSessionId()
-		logger.Info().Str("session_id", sessionId).Msg("🗑️ Deleting session tree - cleaning up outdated or unclaimable session")
+		// Create a new logger instance for each iteration to avoid concurrent access issues
+		sessionLogger := logger.With("session_id", sessionId)
+		sessionLogger.Info().Msg("🗑️ Deleting session tree - cleaning up outdated or unclaimable session")
 
 		// Remove the session tree from the relayerSessions.
 		rs.deleteSessionTree(sessionTree)

--- a/testutil/testrelayer/relays.go
+++ b/testutil/testrelayer/relays.go
@@ -212,14 +212,19 @@ func NewSignedRandRelay(
 	_, err := rand.Read(randBz) //nolint:staticcheck // Using rand.Read in tests as a deterministic pseudo-random source is okay.
 	require.NoError(t, err)
 
+	// Prepare an empty relay with the given req & res headers.
 	relay := NewEmptyRelay(reqHeader, resHeader, supplierOperatorAddr)
+	// Populate the relay request and response payloads with random data.
 	relay.Req.Payload = randBz
 	relay.Res.Payload = randBz
-	SignRelayRequest(ctx, t, relay, reqHeader.GetApplicationAddress(), keyRing, ringClient)
-	SignRelayResponse(ctx, t, relay, supplierOperatorKeyUid, supplierOperatorAddr, keyRing)
 
+	// Update the relay response with the payload hash
 	err = relay.Res.UpdatePayloadHash()
 	require.NoError(t, err)
+
+	// Sign both the request and response.
+	SignRelayRequest(ctx, t, relay, reqHeader.GetApplicationAddress(), keyRing, ringClient)
+	SignRelayResponse(ctx, t, relay, supplierOperatorKeyUid, supplierOperatorAddr, keyRing)
 
 	return relay
 }

--- a/testutil/testtree/tree.go
+++ b/testutil/testtree/tree.go
@@ -101,6 +101,14 @@ func FillSessionTree(
 			keyRing,
 			ringClient,
 		)
+
+		// TODO(v0.1.26): Remove this if structure once all actors (miners, validators, etc.)
+		// update to the version of the protocol that enforce the payload hash
+		// and a nil payload.
+		if len(relay.Res.PayloadHash) > 0 {
+			relay.Res.Payload = nil
+		}
+
 		relayBz, err := relay.Marshal()
 		require.NoError(t, err)
 


### PR DESCRIPTION
Fixing RelayMiner log panic reported by the community:

- **Root Cause**: Multiple goroutines tried to use the same logger.
- **Solution**: Create context-specific loggers.

Side change: fixing some broken tests on main.

<img width="1018" alt="Screenshot 2025-07-03 at 4 52 14 PM" src="https://github.com/user-attachments/assets/a676e296-7ad6-4f83-a3a0-a70545f59bb4" />
