### PR TITLE
feat: Add chain info retrieval functionality to client

### DIFF
--- a/pkg/client/interface.go
+++ b/pkg/client/interface.go
@@ -29,6 +29,7 @@ import (
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/hashicorp/go-version"
 	"google.golang.org/grpc"
 
 	"github.com/pokt-network/poktroll/pkg/either"
@@ -191,6 +192,8 @@ type BlockClient interface {
 	// Close unsubscribes all observers of the committed block sequence
 	// observable and closes the events query client.
 	Close()
+	// GetChainVersion returns the current chain version.
+	GetChainVersion() *version.Version
 }
 
 // TxClientOption defines a function type that modifies the TxClient.

--- a/pkg/relayer/miner/miner.go
+++ b/pkg/relayer/miner/miner.go
@@ -8,6 +8,7 @@ import (
 	"cosmossdk.io/depinject"
 
 	"github.com/pokt-network/poktroll/pkg/client"
+	"github.com/pokt-network/poktroll/pkg/client/block"
 	"github.com/pokt-network/poktroll/pkg/crypto/protocol"
 	"github.com/pokt-network/poktroll/pkg/either"
 	"github.com/pokt-network/poktroll/pkg/observable"
@@ -27,6 +28,7 @@ type miner struct {
 	// serviceQueryClient is used to query for the relay difficulty target hash of a service.
 	// relay_difficulty is the target hash which a relay hash must be less than to be volume/reward applicable.
 	serviceQueryClient client.ServiceQueryClient
+	blockClient        client.BlockClient
 	relayMeter         relayer.RelayMeter
 }
 
@@ -44,7 +46,7 @@ func NewMiner(
 ) (*miner, error) {
 	mnr := &miner{}
 
-	if err := depinject.Inject(deps, &mnr.serviceQueryClient, &mnr.relayMeter); err != nil {
+	if err := depinject.Inject(deps, &mnr.serviceQueryClient, &mnr.relayMeter, &mnr.blockClient); err != nil {
 		return nil, err
 	}
 
@@ -88,10 +90,18 @@ func (mnr *miner) mapMineDehydratedRelay(
 	ctx context.Context,
 	relay *servicetypes.Relay,
 ) (_ either.Either[*relayer.MinedRelay], skip bool) {
-	// Set the response payload to nil to reduce the size of SMST & onchain proofs.
-	// DEV_NOTE: This MUST be done in order to support onchain response signature
-	// verification, without including the entire response payload in the SMST/proof.
-	relay.Res.Payload = nil
+	// Compare the chain version with the signingPayloadHashVersion.
+	// - If the chain version is greater than or equal to the signingPayloadHashVersion,
+	//   compute the payload hash and include it in the RelayResponse.
+	// - If the chain version is less than the signingPayloadHashVersion, remain backward
+	//   compatible with older versions of the Network that expect payload only RelayResponses.
+	chainVersion := mnr.blockClient.GetChainVersion()
+	if chainVersion.GreaterThanOrEqual(block.SigningPayloadHashVersion) {
+		// Set the response payload to nil to reduce the size of SMST & onchain proofs.
+		// DEV_NOTE: This MUST be done in order to support onchain response signature
+		// verification, without including the entire response payload in the SMST/proof.
+		relay.Res.Payload = nil
+	}
 
 	// Marshal and hash the whole relay to measure difficulty.
 	relayBz, err := relay.Marshal()

--- a/pkg/relayer/proxy/relay_builders.go
+++ b/pkg/relayer/proxy/relay_builders.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"net/http"
 
+	"github.com/pokt-network/poktroll/pkg/client/block"
 	"github.com/pokt-network/poktroll/x/service/types"
 	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
 )
@@ -40,11 +41,19 @@ func (sync *relayMinerHTTPServer) newRelayResponse(
 		Payload: responseBz,
 	}
 
-	// Compute hash of the response payload for proof verification.
-	// This hash will be stored in the RelayResponse and used during proof validation
-	// to verify the integrity of the response without requiring the full payload.
-	if err := relayResponse.UpdatePayloadHash(); err != nil {
-		return nil, err
+	// Compare the chain version with the signingPayloadHashVersion.
+	// - If the chain version is greater than or equal to the signingPayloadHashVersion,
+	//   compute the payload hash and include it in the RelayResponse.
+	// - If the chain version is less than the signingPayloadHashVersion, remain backward
+	//   compatible with older versions of the Network that expect payload only RelayResponses.
+	chainVersion := sync.blockClient.GetChainVersion()
+	if chainVersion.GreaterThanOrEqual(block.SigningPayloadHashVersion) {
+		// Compute hash of the response payload for proof verification.
+		// This hash will be stored in the RelayResponse and used during proof validation
+		// to verify the integrity of the response without requiring the full payload.
+		if err := relayResponse.UpdatePayloadHash(); err != nil {
+			return nil, err
+		}
 	}
 
 	// Sign the relay response and add the signature to the relay response metadata


### PR DESCRIPTION
## Summary

Add chain version retrieval functionality to block client with backward compatibility for relay response signing

### Primary Changes:
- Added `GetChainVersion()` method to `BlockClient` interface for retrieving current chain version
- Implemented chain version tracking in `blockReplayClient` with automatic updates on each new block
- Added version-based conditional logic for `RelayResponse` payload hash computation in miner and proxy
- Introduced `SigningPayloadHashVersion` constant to control backward compatibility behavior

### Secondary changes:
- Added mutex protection for concurrent access to chain version data
- Integrated `cometClient` dependency injection for ABCI info queries
- Added proper context cancellation for ongoing version queries
- Enhanced error handling and logging for chain version operations

## Issue:

Implements backward compatible relay response signatures to support both old and new chain versions during network upgrades

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs