### PR TITLE
[SUPPLIER][APPLICATION][PARAMS] Increasing CUTTM on Beta and Mainnet by 10x

### DIFF
--- a/tools/scripts/params/bulk_params_beta/shared_params.json
+++ b/tools/scripts/params/bulk_params_beta/shared_params.json
@@ -13,7 +13,7 @@
           "proof_window_close_offset_blocks": "10",
           "supplier_unbonding_period_sessions": "57",
           "application_unbonding_period_sessions": "1",
-          "compute_units_to_tokens_multiplier": "33482",
+          "compute_units_to_tokens_multiplier": "334820",
           "gateway_unbonding_period_sessions": "1",
           "compute_unit_cost_granularity": "1000000"
         }

--- a/tools/scripts/params/bulk_params_main/shared_params.json
+++ b/tools/scripts/params/bulk_params_main/shared_params.json
@@ -13,7 +13,7 @@
           "proof_window_close_offset_blocks": "10",
           "supplier_unbonding_period_sessions": "57",
           "application_unbonding_period_sessions": "1",
-          "compute_units_to_tokens_multiplier": "33482",
+          "compute_units_to_tokens_multiplier": "334820",
           "gateway_unbonding_period_sessions": "1",
           "compute_unit_cost_granularity": "1000000"
         }


### PR DESCRIPTION
## Summary

Increases CUTTM by 10x on both Beta and Mainnet

### Primary Changes:

- Increase `shared.compute_units_to_tokens_multiplier` from `33482` -> `334820` on Beta Testnet
- Increase `shared.compute_units_to_tokens_multiplier` from `33482` -> `334820` on Mainnet

## Issue

- Stopgap solution for #1607 

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [x] Other (specify): Params

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
