### PR TITLE
[DOCS][SERVICE] Adding danger for Grove employees on mainnet service creation

### DIFF
--- a/docusaurus/docs/1_operate/1_cheat_sheets/1_service_cheatsheet.md
+++ b/docusaurus/docs/1_operate/1_cheat_sheets/1_service_cheatsheet.md
@@ -48,6 +48,12 @@ Service IDs are limited to `42` chars and descriptions are limited to `169` char
 
 ### 1. Add a Service
 
+:::danger Grove Employees Service Creation
+
+If you are a Grove Employee, you **ABSOLUTELY MUST** create all Mainnet Services using the Grove Master Gateway: `pokt1lf0kekv9zcv9v3wy4v6jx2wh7v4665s8e0sl9s` 
+
+:::
+
 Use the `add-service` command to create a new service like so:
 
 ```bash


### PR DESCRIPTION
## Summary

Adds stark warning for Grove employees creating Mainnet services

### Primary Changes:

- Adds warning to use specific address when creating services on mainnet

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [x] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
