### PR TITLE
[WIP][Test Bug] Fix E2E Tests post `mint_equals_burn_claim_distribution` addition

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,8 +11,8 @@ accounts:
   - name: pnf
     mnemonic: "crumble shrimp south strategy speed kick green topic stool seminar track stand rhythm almost bubble pet knock steel pull flag weekend country major blade"
     coins:
-      - 6900000000042upokt
-      - 6900000000042mact
+      - 690000000000042upokt
+      - 6900000000000042mact
   - name: validator1
     mnemonic: "creek path rule retire evolve vehicle bargain champion roof whisper prize endorse unknown anchor fashion energy club sauce elder parent cotton old affair visa"
     coins:

--- a/e2e/tests/0_tokenomics.feature
+++ b/e2e/tests/0_tokenomics.feature
@@ -86,6 +86,23 @@ Feature: Tokenomics Namespace
             | proof_submission_fee         | 1000000                                                          | coin  |
         And all "proof" module params should be updated
 
+        # Configure tokenomics parameters for distributed settlement
+        And the "tokenomics" module parameters are set as follows
+            | name                                             | value | type  |
+            | dao_reward_address                               | pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw | string |
+            | mint_allocation_percentages.dao                  | 0.1   | float |
+            | mint_allocation_percentages.proposer             | 0.05  | float |
+            | mint_allocation_percentages.supplier             | 0.7   | float |
+            | mint_allocation_percentages.source_owner         | 0.15  | float |
+            | mint_allocation_percentages.application          | 0.0   | float |
+            | global_inflation_per_claim                       | 0     | float |
+            | mint_equals_burn_claim_distribution.dao          | 0.0   | float |
+            | mint_equals_burn_claim_distribution.proposer     | 0.0   | float |
+            | mint_equals_burn_claim_distribution.supplier     | 1.0   | float |
+            | mint_equals_burn_claim_distribution.source_owner | 0.0   | float |
+            | mint_equals_burn_claim_distribution.application  | 0.0   | float |
+        And all "tokenomics" module params should be updated
+
         # Configure shared parameters
         And the "shared" module parameters are set as follows
             | compute_units_to_tokens_multiplier | 42                                                         | int64 |


### PR DESCRIPTION
This commit broke E2E tests: https://github.com/pokt-network/poktroll/commit/8270157958ff15fcba809e880d2531393c06c7d1

Two leading reasons:
1. Changes to `config.yaml`
2. Introduction of `mint_equals_burn_claim_distribution`

The quick self-explanatory changes below already resulted in resolving some of the issues but it is not a fullproof solution yet.

This is a reference/handoff document