### PR TITLE
bug fix

### DIFF
--- a/pkg/relayer/header_utils.go
+++ b/pkg/relayer/header_utils.go
@@ -14,11 +14,9 @@ func ForwardPocketHeaders(header *http.Header, meta types.RelayRequestMetadata) 
 	// Supplier identification
 	header.Set("Pocket-Supplier", meta.SupplierOperatorAddress)
 
-	// Service identification
-	header.Set("Pocket-Service", meta.SessionHeader.ServiceId)
-
-	// Application identification (if available)
+	// Application and service identification (if available)
 	if meta.SessionHeader != nil {
+		header.Set("Pocket-Service", meta.SessionHeader.ServiceId)
 		header.Set("Pocket-Session-Id", meta.SessionHeader.SessionId)
 		header.Set("Pocket-Application", meta.SessionHeader.ApplicationAddress)
 		header.Set("Pocket-Session-Start-Height", fmt.Sprintf("%d", meta.SessionHeader.SessionStartBlockHeight))


### PR DESCRIPTION
## Summary

Fixed small bug in `nil` check of `meta.SessionHeader` before populating the `ForwardPocketHeaders` on the RelayMiner.

## Issue

#1684 

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

