### PR TITLE
[Governance] - Updated Params to match the ones in the forum 

### DIFF
--- a/tools/scripts/params/bulk_params_main/tokenomics_params.json
+++ b/tools/scripts/params/bulk_params_main/tokenomics_params.json
@@ -15,10 +15,10 @@
           },
           "global_inflation_per_claim": 0.000001,
           "mint_equals_burn_claim_distribution": {
-            "dao": 0.1,
-            "proposer": 0.05,
-            "supplier": 0.7,
-            "source_owner": 0.15,
+            "dao": 0.05,
+            "proposer": 0.14,
+            "supplier": 0.78,
+            "source_owner": 0.03,
             "application": 0
           }
         }


### PR DESCRIPTION
This pull request modifies the tokenomics parameters in the `tokenomics_params.json` file, specifically adjusting the distribution percentages for the `mint_equals_burn_claim_distribution` section.

Modifications based on this post: https://forum.pokt.network/t/protocol-economics-parameters-for-the-shannon-upgrade/5490

### Tokenomics parameter updates:
* Adjusted distribution percentages for `mint_equals_burn_claim_distribution`:
  - Reduced `dao` from 10% to 5%.
  - Increased `proposer` from 5% to 14%.
  - Increased `supplier` from 70% to 78%.
  - Reduced `source_owner` from 15% to 3%.