### PR TITLE
feat: Add session lifetime caching

### DIFF
--- a/pkg/client/query/cache/options.go
+++ b/pkg/client/query/cache/options.go
@@ -7,7 +7,11 @@ import (
 
 	"github.com/pokt-network/poktroll/pkg/client"
 	"github.com/pokt-network/poktroll/pkg/observable/channel"
+	"github.com/pokt-network/poktroll/pkg/polylog"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
 )
+
+const DefaultSessionCountForCacheClear = 1
 
 // Cache is an interface that defines the common methods for a cache object.
 type Cache interface {
@@ -16,7 +20,7 @@ type Cache interface {
 
 // CacheOption is a function type for the option functions that can customize
 // the cache behavior.
-type CacheOption[C Cache] func(context.Context, depinject.Config, C) error
+type CacheOption func(context.Context, depinject.Config, Cache) error
 
 // WithNewBlockCacheClearing is a cache option that clears the cache every time
 // a new block is observed.
@@ -35,4 +39,57 @@ func WithNewBlockCacheClearing[C Cache](ctx context.Context, deps depinject.Conf
 	)
 
 	return nil
+}
+
+// WithNewNthSessionCacheClearingFn is a cache option that clears the cache at the start
+// of every nth session, where n is defined by sessionCountForCacheClear.
+func WithNewNthSessionCacheClearingFn(sessionCountForCacheClear uint) func(context.Context, depinject.Config, Cache) error {
+	return func(ctx context.Context, deps depinject.Config, cache Cache) error {
+		var blockClient client.BlockClient
+		var sharedClient client.ParamsCache[sharedtypes.Params]
+		var logger polylog.Logger
+		if err := depinject.Inject(deps, &blockClient, &sharedClient, &logger); err != nil {
+			return err
+		}
+
+		// isInitialClearing is used to avoid logging the first cache clear attempt
+		// when the cache is first initialized.
+		// This is to prevent log spam during the initial setup.
+		isInitialClearing := true
+
+		channel.ForEach(
+			ctx,
+			blockClient.CommittedBlocksSequence(ctx),
+			func(ctx context.Context, block client.Block) {
+				sharedParams, found := sharedClient.Get()
+				if !found {
+					if !isInitialClearing {
+						logger.Warn().Msg("ℹ️ Shared params not found in cache, skipping cache clearing")
+						isInitialClearing = false
+					}
+					return
+				}
+
+				currentHeight := block.Height()
+				currentSessionStartHeight := sharedtypes.GetSessionStartHeight(&sharedParams, currentHeight)
+				currentSessionNumber := sharedtypes.GetSessionNumber(&sharedParams, currentHeight)
+
+				isAtSessionStart := currentHeight == currentSessionStartHeight
+				isCacheClearableSession := currentSessionNumber%int64(sessionCountForCacheClear) == 0
+				if isAtSessionStart && isCacheClearableSession {
+					logger.Info().Msgf(
+						"🧹 Clearing cache at session number %d (start: %d)\n",
+						currentSessionNumber, currentSessionStartHeight,
+					)
+					cache.Clear()
+				}
+			},
+		)
+
+		return nil
+	}
+}
+
+func WithDefaultNewNthSessionCacheClearingFn() func(context.Context, depinject.Config, Cache) error {
+	return WithNewNthSessionCacheClearingFn(DefaultSessionCountForCacheClear)
 }

--- a/pkg/deps/config/suppliers.go
+++ b/pkg/deps/config/suppliers.go
@@ -13,7 +13,6 @@ import (
 	cosmostx "github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/spf13/cobra"
 
-	"github.com/pokt-network/poktroll/pkg/cache"
 	"github.com/pokt-network/poktroll/pkg/cache/memory"
 	"github.com/pokt-network/poktroll/pkg/client"
 	"github.com/pokt-network/poktroll/pkg/client/block"
@@ -518,7 +517,7 @@ func newSupplyTxClientsFn(
 
 // NewSupplyKeyValueCacheFn returns a function which constructs a KeyValueCache of type T.
 // It take a list of cache options that can be used to configure the cache.
-func NewSupplyKeyValueCacheFn[T any](opts ...querycache.CacheOption[cache.KeyValueCache[T]]) SupplierFn {
+func NewSupplyKeyValueCacheFn[T any](opts ...querycache.CacheOption) SupplierFn {
 	return func(
 		ctx context.Context,
 		deps depinject.Config,
@@ -541,6 +540,8 @@ func NewSupplyKeyValueCacheFn[T any](opts ...querycache.CacheOption[cache.KeyVal
 			return nil, err
 		}
 
+		deps = depinject.Configs(deps, depinject.Supply(kvCache))
+
 		// Apply the query cache options
 		for _, opt := range opts {
 			if err := opt(ctx, deps, kvCache); err != nil {
@@ -548,13 +549,13 @@ func NewSupplyKeyValueCacheFn[T any](opts ...querycache.CacheOption[cache.KeyVal
 			}
 		}
 
-		return depinject.Configs(deps, depinject.Supply(kvCache)), nil
+		return deps, nil
 	}
 }
 
 // NewSupplyParamsCacheFn returns a function which constructs a ParamsCache of type T.
 // It take a list of cache options that can be used to configure the cache.
-func NewSupplyParamsCacheFn[T any](opts ...querycache.CacheOption[client.ParamsCache[T]]) SupplierFn {
+func NewSupplyParamsCacheFn[T any](opts ...querycache.CacheOption) SupplierFn {
 	return func(
 		ctx context.Context,
 		deps depinject.Config,
@@ -579,6 +580,8 @@ func NewSupplyParamsCacheFn[T any](opts ...querycache.CacheOption[client.ParamsC
 			return nil, err
 		}
 
+		deps = depinject.Configs(deps, depinject.Supply(paramsCache))
+
 		// Apply the query cache options
 		for _, opt := range opts {
 			if err := opt(ctx, deps, paramsCache); err != nil {
@@ -586,7 +589,7 @@ func NewSupplyParamsCacheFn[T any](opts ...querycache.CacheOption[client.ParamsC
 			}
 		}
 
-		return depinject.Configs(deps, depinject.Supply(paramsCache)), nil
+		return deps, nil
 	}
 }
 


### PR DESCRIPTION
## Summary

Implement cache clearing based on session lifetimes instead of every block to improve performance and reduce unnecessary overhead.

### Primary Changes:
- Add `WithNewNthSessionCacheClearingFn` cache option to clear caches at session boundaries
- Update RelayMiner dependencies to use session-based cache clearing instead of block-based
- Add `DefaultSessionCountForCacheClear` constant for configurable cache clearing frequency

### Secondary changes:
- Refactor `CacheOption` type signature to use generic `Cache` interface
- Update dependency injection pattern for cache options
- Add comprehensive logging for cache clearing operations
- Update cache clearing for different data types based on their update frequency

## Issue:

Performance optimization - reduce cache clearing frequency from every block to every session to minimize unnecessary overhead while maintaining data consistency.

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs