### PR TITLE
[CometBFT] Use Pocket's fork temporarily

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -514,4 +514,4 @@ tool (
 	google.golang.org/protobuf/cmd/protoc-gen-go
 )
 
-replace github.com/cometbft/cometbft => github.com/pokt-network/cometbft v0.38.18-0.20250807224318-70d09a916833
+replace github.com/cometbft/cometbft => github.com/pokt-network/cometbft v0.38.17-0.20250808222235-91d271231811

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,11 @@ replace nhooyr.io/websocket => github.com/coder/websocket v1.8.6
 // replace broken goleveldb
 replace github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 
+// TODO_HACK(@olshansk): Replace CometBFT with Pocket's fork to avoid blocking RPC queries on heavy EndBlockers.
+// Ref: https://github.com/pokt-network/cometbft/issues/3
+replace github.com/cometbft/cometbft => github.com/pokt-network/cometbft v0.38.17-0.20250808222235-91d271231811
+
+
 require (
 	cosmossdk.io/api v0.9.2
 	cosmossdk.io/client/v2 v2.0.0-beta.8
@@ -513,5 +518,3 @@ tool (
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc
 	google.golang.org/protobuf/cmd/protoc-gen-go
 )
-
-replace github.com/cometbft/cometbft => github.com/pokt-network/cometbft v0.38.17-0.20250808222235-91d271231811

--- a/go.sum
+++ b/go.sum
@@ -1283,8 +1283,8 @@ github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pokt-network/cometbft v0.38.18-0.20250807224318-70d09a916833 h1:IzgpotHDzPZiF4qPilhOKdTjUNGpP89Cx/Zt6umCHyQ=
-github.com/pokt-network/cometbft v0.38.18-0.20250807224318-70d09a916833/go.mod h1:5l0SkgeLRXi6bBfQuevXjKqML1jjfJJlvI1Ulp02/o4=
+github.com/pokt-network/cometbft v0.38.17-0.20250808222235-91d271231811 h1:WpmIfpDCXSJVCZ1zm7S6nJI3HjNjkhxCFeV9PuSR/ks=
+github.com/pokt-network/cometbft v0.38.17-0.20250808222235-91d271231811/go.mod h1:5l0SkgeLRXi6bBfQuevXjKqML1jjfJJlvI1Ulp02/o4=
 github.com/pokt-network/ring-go v0.1.0 h1:hF7mDR4VVCIqqDAsrloP8azM9y1mprc99YgnTjKSSwk=
 github.com/pokt-network/ring-go v0.1.0/go.mod h1:8NHPH7H3EwrPX3XHfpyRI6bz4gApkE3+fd0XZRbMWP0=
 github.com/pokt-network/shannon-sdk v0.0.0-20250704180202-e527d4172770 h1:ztJnRBnkdNCSkRi6yT7ATQ1mw/i28JQKzhLoUXXHkzw=


### PR DESCRIPTION
_tl;dr Workaround to prevent slow EndBlockers from blocking RPC queries_

Temporarily use Pocket's fork of CometBFT as a hacky workaround related to mutexes.

Ref: https://github.com/pokt-network/cometbft/pull/2
Next steps: https://github.com/pokt-network/cometbft/issues/3