### PR TITLE
[Upgrade] Add v0.1.28 upgrade plan

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -131,7 +131,7 @@ var allUpgrades = []upgrades.Upgrade{
 
 	// v0.1.26 - upgrade to:
 	// - Implement backward compatible relay response signature verification to enable smooth protocol upgrades
-	//upgrades.Upgrade_0_1_26,
+	// upgrades.Upgrade_0_1_26,
 
 	// v0.1.27 - upgrade to:
 	// - Updates to the Morse account recovery allowlist
@@ -139,7 +139,13 @@ var allUpgrades = []upgrades.Upgrade{
 	// - Reward distribution for the mint=burn TLM
 	// - Updates to the Morse account recovery allowlist
 	// - Sets all IBC parameters to enable IBC support
-	upgrades.Upgrade_0_1_27,
+	// upgrades.Upgrade_0_1_27,
+
+	// v0.1.28 - upgrade to:
+	// - Shared module param update: increased `ComputeUnitsPerRelayMax`.
+	// - Tokenomics updates: validator proper decoding fix; updated DAO address in mint_equals_burn_claim_distribution;
+	// - Recovery: updated Morse account recovery allowlist (multiple iterations, incl. 8 Aug 2025 update).
+	upgrades.Upgrade_0_1_28,
 }
 
 // setUpgrades sets upgrade handlers for all upgrades and executes KVStore migration if an upgrade plan file exists.

--- a/app/upgrades/v0.1.28.go
+++ b/app/upgrades/v0.1.28.go
@@ -1,0 +1,43 @@
+package upgrades
+
+import (
+	"context"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/pokt-network/poktroll/app/keepers"
+)
+
+const (
+	Upgrade_0_1_28_PlanName = "v0.1.28"
+)
+
+// Upgrade_0_1_28 handles the upgrade to release `v0.1.28`.
+// This upgrade adds/changes (diff: v0.1.27..v0.1.28 / current main):
+// - Shared module param update: increased `ComputeUnitsPerRelayMax`.
+// - Tokenomics updates: validator proper decoding fix; updated DAO address in mint_equals_burn_claim_distribution;
+// - Recovery: updated Morse account recovery allowlist (multiple iterations, incl. 8 Aug 2025 update).
+var Upgrade_0_1_28 = Upgrade{
+	PlanName: Upgrade_0_1_28_PlanName,
+	// No KVStore migrations in this upgrade.
+	StoreUpgrades: storetypes.StoreUpgrades{},
+
+	// Upgrade Handler
+	CreateUpgradeHandler: func(
+		mm *module.Manager,
+		keepers *keepers.Keepers,
+		configurator module.Configurator,
+	) upgradetypes.UpgradeHandler {
+		// Add new parameters by:
+		// 1. Inspecting the diff between v0.1.27..v0.1.28
+		// 2. Manually inspect changes in ignite's config.yml
+		// 3. Update the upgrade handler here accordingly
+		// Ref: https://github.com/pokt-network/poktroll/compare/v0.1.27..v0.1.28
+
+		return func(ctx context.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+			return vm, nil
+		}
+	},
+}


### PR DESCRIPTION
## Summary

Prepare v0.1.28 onchain upgrade

## Issue

N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
