### PR TITLE
feat: Add in-memory SMT storage option for RelayMiner

### DIFF
--- a/pkg/relayer/cmd/cmd_start.go
+++ b/pkg/relayer/cmd/cmd_start.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
 	"github.com/pokt-network/poktroll/pkg/relayer"
 	relayerconfig "github.com/pokt-network/poktroll/pkg/relayer/config"
+	"github.com/pokt-network/poktroll/pkg/relayer/session"
 )
 
 // startCmd returns the Cobra subcommand for running the relay miner.
@@ -142,6 +143,17 @@ Totals:
 	if err != nil {
 		fmt.Printf("Could not parse config file from: %s\n", flagRelayMinerConfig)
 		return err
+	}
+
+	if relayMinerConfig.SmtStorePath == session.MemoryStore {
+		fmt.Printf(`
+🚨🚨🚨🚨 WARNING: The SMT is configured to use in-memory storage (memory://)! 🚨🚨🚨
+-------------------------------------------------------------------------------------
+All session data will be LOST if the RelayMiner process is restarted.
+No session state will be persisted to disk.
+Any non-submitted Claim or Proof will be lost.
+-------------------------------------------------------------------------------------
+`)
 	}
 
 	// --- Log flag values ---


### PR DESCRIPTION
## Summary

Add support for in-memory SMT storage when `smt_store_path` is set to `memory://` for testing environments where persistence is not required.

### Primary Changes:
- Add `MemoryStore` constant (`memory://`) for in-memory SMT configuration
- Implement conditional persistence logic in session manager and session trees
- Add startup warning when using in-memory storage mode
- Skip disk-based operations (save/restore) for in-memory SMTs

### Secondary changes:
- Add helper method `persistedSMT()` to determine storage type
- Update session loading to skip restoration for in-memory stores
- Modify session cleanup to use `ClearAll()` for in-memory stores

## Issue:

Feature request to support in-memory SMT storage for development and testing environments where session persistence is not needed.

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs

🤖 Generated with [Claude Code](https://claude.ai/code)