### PR TITLE
[Docs] fix path config link

### DIFF
--- a/docusaurus/docs/3_protocol/actors/4_path_gateway.md
+++ b/docusaurus/docs/3_protocol/actors/4_path_gateway.md
@@ -21,4 +21,4 @@ or custom software that implements the same functionality.
 ## Configuration
 
 Configurations and additional documentation related to operating a `PATH Gateway`
-can be found at [path_gateway.md](https://path.grove.city/operate).
+can be found at [path_gateway.md](https://path.grove.city/configs/config_intro).

--- a/docusaurus/docs/3_protocol/actors/4_path_gateway.md
+++ b/docusaurus/docs/3_protocol/actors/4_path_gateway.md
@@ -21,4 +21,4 @@ or custom software that implements the same functionality.
 ## Configuration
 
 Configurations and additional documentation related to operating a `PATH Gateway`
-can be found at [path_gateway.md](https://path.grove.city/configs/config_intro).
+can be found at [path_gateway.md](https://path.grove.city/category/path-configurations).


### PR DESCRIPTION
## Summary

Update PATH Gateway configuration documentation link to point to operate section

### Primary Changes:

- Updated PATH Gateway configuration link from `https://path.grove.city/configs/config_intro` to `https://path.grove.city/operate`

### Secondary Changes:

- N/A

## Issue

- N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [x] Documentation
- [ ] Other (specify)

## QoS Checklist

### E2E Validation & Tests

- [ ] `make path_up`
- [ ] `make test_e2e_evm_shannon`

### Observability

- [ ] 1. `make path_up`
- [ ] 2. Run the following E2E test: `make test_request__shannon_relay_util_100`
- [ ] 3. View results in LocalNet's [PATH Relay Grafana Dashboard](http://localhost:3003/d/relays/path-service-requests)

## Sanity Checklist

- [ ] I have updated the GitHub Issue `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs, I have run `make docusaurus_start`
- [ ] For code, I have run `make test_all`
- [ ] For configurations, I have updated the documentation
- [ ] I added `TODO`s where applicable