### PR TITLE
[RelayMiner] Ensure `in-memory` RelayMiner still submits proofs

### DIFF
--- a/docusaurus/docs/1_operate/3_configs/4_relayminer_config.md
+++ b/docusaurus/docs/1_operate/3_configs/4_relayminer_config.md
@@ -184,25 +184,18 @@ in a BadgerDB KV store data files.
 
 **In-memory storage options:**
 
-- `:memory:` - Uses SimpleMap (pure Go map) for in-memory storage. **Recommended** for production use due to reliability and simplicity.
+- `:memory:` - Uses SimpleMap (pure Go map) for in-memory storage. **Recommended**.
 - `:memory_pebble:` - Uses Pebble database with in-memory VFS. Experimental option with more overhead.
 
-:::warning In-memory session state loss
+:::warning TODO(#1734) Experimentation in flight
 
-In-memory storage enables relay miners to be significantly more performant, but it also means that
-the session state will be lost when the relay miner is restarted.
+**This update is as of 08/2025.**
 
-TODO(#1734): Ensure session state is persisted even when using in-memory mode
+In-memory storage enables relay miners to be significantly more performant. For this reason, `:memory:` is the recommended option.
 
-:::
+**Warning:** Prior to #1734, RelayMiner restarts will result in loss of session state.
 
-:::note Experimental dual in-memory support
-
-We're currently experimenting with two in-memory storage approaches. Eventually we will either:
-- Create a proper enum for storage types (disk, memory_simple, memory_pebble)
-- Remove support for one of them based on performance/reliability testing
-
-Current recommendation: Use `:memory:` (SimpleMap) for production as it's more reliable for ephemeral data.
+**Consideration**: Once experimentation is complete, there will either only be one in-memory storage option or a proper enum will be created (disk, memory_simple, memory_pebble).
 
 :::
 

--- a/docusaurus/docs/1_operate/3_configs/4_relayminer_config.md
+++ b/docusaurus/docs/1_operate/3_configs/4_relayminer_config.md
@@ -182,14 +182,27 @@ The relative or absolute path to the directory where the `RelayMiner` will store
 the `SparseMerkleTree` data on disk. This directory is used to persist the `SMT`
 in a BadgerDB KV store data files.
 
-`:memory:` can be used to store the `SMT` only in memory, without persisting it to disk.
+**In-memory storage options:**
+
+- `:memory:` - Uses SimpleMap (pure Go map) for in-memory storage. **Recommended** for production use due to reliability and simplicity.
+- `:memory_pebble:` - Uses Pebble database with in-memory VFS. Experimental option with more overhead.
 
 :::warning In-memory session state loss
 
-In-memory enables relay miners to be a lot more performant, but it also means that
+In-memory storage enables relay miners to be significantly more performant, but it also means that
 the session state will be lost when the relay miner is restarted.
 
 TODO(#1734): Ensure session state is persisted even when using in-memory mode
+
+:::
+
+:::note Experimental dual in-memory support
+
+We're currently experimenting with two in-memory storage approaches. Eventually we will either:
+- Create a proper enum for storage types (disk, memory_simple, memory_pebble)
+- Remove support for one of them based on performance/reliability testing
+
+Current recommendation: Use `:memory:` (SimpleMap) for production as it's more reliable for ephemeral data.
 
 :::
 

--- a/docusaurus/docs/1_operate/3_configs/5_websocket_support.md
+++ b/docusaurus/docs/1_operate/3_configs/5_websocket_support.md
@@ -51,11 +51,7 @@ Update your `relayminer_config.yaml` to add `WebSocket` support like so:
 ```yaml
 default_signing_key_names:
   - supplier
-# SMT store path options:
-# - ":memory:" - SimpleMap in-memory storage (recommended for performance)
-# - ":memory_pebble:" - Pebble in-memory storage (experimental)
-# - "/path/to/.pocket/smt" - Disk-based persistent storage
-smt_store_path: ":memory:"
+smt_store_path: ":memory:"  # OR /path/to/.pocket/smt
 pocket_node:
   query_node_rpc_url: https://<RPC_NODE>
   query_node_grpc_url: https://<GRPC_NODE>:443

--- a/docusaurus/docs/1_operate/3_configs/5_websocket_support.md
+++ b/docusaurus/docs/1_operate/3_configs/5_websocket_support.md
@@ -51,7 +51,11 @@ Update your `relayminer_config.yaml` to add `WebSocket` support like so:
 ```yaml
 default_signing_key_names:
   - supplier
-smt_store_path: ":memory:" # Options: ":memory:" (SimpleMap, recommended), ":memory_pebble:" (experimental), or /path/to/.pocket/smt
+# SMT store path options:
+# - ":memory:" - SimpleMap in-memory storage (recommended for performance)
+# - ":memory_pebble:" - Pebble in-memory storage (experimental)
+# - "/path/to/.pocket/smt" - Disk-based persistent storage
+smt_store_path: ":memory:"
 pocket_node:
   query_node_rpc_url: https://<RPC_NODE>
   query_node_grpc_url: https://<GRPC_NODE>:443

--- a/docusaurus/docs/1_operate/3_configs/5_websocket_support.md
+++ b/docusaurus/docs/1_operate/3_configs/5_websocket_support.md
@@ -51,7 +51,7 @@ Update your `relayminer_config.yaml` to add `WebSocket` support like so:
 ```yaml
 default_signing_key_names:
   - supplier
-smt_store_path: ":memory:" # /path/to/.pocket/smt
+smt_store_path: ":memory:" # Options: ":memory:" (SimpleMap, recommended), ":memory_pebble:" (experimental), or /path/to/.pocket/smt
 pocket_node:
   query_node_rpc_url: https://<RPC_NODE>
   query_node_grpc_url: https://<GRPC_NODE>:443

--- a/docusaurus/docs/4_develop/developer_guide/walkthrough.md
+++ b/docusaurus/docs/4_develop/developer_guide/walkthrough.md
@@ -435,7 +435,10 @@ The following is an example config to get you started:
 ```bash
 cat <<🚀 >> shannon_relayminer_config.yaml
 default_signing_key_names: [ "shannon_supplier" ]
-# Options: ":memory:" (fast, in-memory), ":memory_pebble:" (experimental), or disk path
+# SMT store path options:
+# - ":memory:" - SimpleMap in-memory storage (fast, recommended for development)
+# - ":memory_pebble:" - Pebble in-memory storage (experimental)  
+# - "$HOME/.pocket/smt" - Disk-based persistent storage
 smt_store_path: $HOME/.pocket/smt
 metrics:
   enabled: true

--- a/docusaurus/docs/4_develop/developer_guide/walkthrough.md
+++ b/docusaurus/docs/4_develop/developer_guide/walkthrough.md
@@ -435,6 +435,7 @@ The following is an example config to get you started:
 ```bash
 cat <<🚀 >> shannon_relayminer_config.yaml
 default_signing_key_names: [ "shannon_supplier" ]
+# Options: ":memory:" (fast, in-memory), ":memory_pebble:" (experimental), or disk path
 smt_store_path: $HOME/.pocket/smt
 metrics:
   enabled: true

--- a/docusaurus/docs/4_develop/developer_guide/walkthrough.md
+++ b/docusaurus/docs/4_develop/developer_guide/walkthrough.md
@@ -435,11 +435,8 @@ The following is an example config to get you started:
 ```bash
 cat <<🚀 >> shannon_relayminer_config.yaml
 default_signing_key_names: [ "shannon_supplier" ]
-# SMT store path options:
-# - ":memory:" - SimpleMap in-memory storage (fast, recommended for development)
-# - ":memory_pebble:" - Pebble in-memory storage (experimental)  
-# - "$HOME/.pocket/smt" - Disk-based persistent storage
 smt_store_path: $HOME/.pocket/smt
+smt_store_path: ":memory:"  # OR $HOME/.pocket/smt
 metrics:
   enabled: true
   addr: :9999 # you may need to change the metrics server port due to port conflicts.

--- a/localnet/kubernetes/values-relayminer-common.yaml
+++ b/localnet/kubernetes/values-relayminer-common.yaml
@@ -2,9 +2,11 @@ chainId: "pocket"
 grpcInsecure: true
 queryCaching: false
 config:
-  # TODO(#1734): Ensure that LocalNet and E2E tests are configured to have 1RM
-  # using an in-memory store and one using an on-disk persisted store.
-  # smt_store_path: /root/.pocket/smt
+  # TODO(#1734): Ensure that LocalNet and E2E tests are configured to have:
+  # - One RM using SimpleMap in-memory store (":memory:")
+  # - One RM using Pebble in-memory store (":memory_pebble:")  
+  # - One RM using on-disk persisted store (/root/.pocket/smt)
+  # Currently using SimpleMap in-memory (recommended for production)
   smt_store_path: ":memory:"
   metrics:
     enabled: true

--- a/localnet/pocketd/config/relayminer_config_full_example.yaml
+++ b/localnet/pocketd/config/relayminer_config_full_example.yaml
@@ -3,11 +3,7 @@
 default_signing_key_names: [supplier1]
 
 # Path to the SMT KV store.
-# Options:
-#   ":memory:" - SimpleMap in-memory storage (recommended for performance)
-#   ":memory_pebble:" - Pebble in-memory storage (experimental)
-#   "./path/to/smt_stores" - Disk-based persistent storage
-smt_store_path: ./path/to/smt_stores
+smt_store_path: ":memory:" # OR ./path/to/smt_stores
 
 # Prometheus exporter configuration
 metrics:

--- a/localnet/pocketd/config/relayminer_config_full_example.yaml
+++ b/localnet/pocketd/config/relayminer_config_full_example.yaml
@@ -2,7 +2,11 @@
 # These keys must correspond to the operator addresses of the suppliers.
 default_signing_key_names: [supplier1]
 
-# Relative path (on the relayminer's machine) to the SMT KV store data on disk.
+# Path to the SMT KV store.
+# Options:
+#   ":memory:" - SimpleMap in-memory storage (recommended for performance)
+#   ":memory_pebble:" - Pebble in-memory storage (experimental)
+#   "./path/to/smt_stores" - Disk-based persistent storage
 smt_store_path: ./path/to/smt_stores
 
 # Prometheus exporter configuration

--- a/makefiles/release.mk
+++ b/makefiles/release.mk
@@ -110,22 +110,17 @@ INFO_URL := https://dev.poktroll.com/explore/account_management/pocketd_cli?_hig
 
 define print_next_steps
 	$(call print_info_section,Next Steps)
-	@echo "$(BOLD)1.$(RESET) Push the new tag:"
-	@echo "   $(CYAN)git push origin $(1)$(RESET)"
-	@echo ""
-	@echo "$(BOLD)2.$(RESET) Draft a new release:"
-	$(call print_url,$(GITHUB_REPO_URL))
-	$(if $(2),@echo "   $(CYAN)- Mark it as a pre-release$(RESET)")
-	$(if $(2),@echo "   $(CYAN)- Include PR/branch information in the description$(RESET)")
+	@echo "  $(BOLD)1.$(RESET) Push the new tag: $(CYAN)git push origin $(1)$(RESET)"
+	@echo "  $(BOLD)2.$(RESET) Draft a new release here: $(CYAN)$(GITHUB_REPO_URL)$(RESET)"
+	$(if $(2),@echo "    $(CYAN)- Mark it as a pre-release$(RESET)")
+	$(if $(2),@echo "    $(CYAN)- Include PR/branch information in the description$(RESET)")
 	@echo ""
 endef
 
 define print_cleanup_commands
 	$(call print_info_section,If you need to delete the tag)
-	@echo "$(BOLD)Local:$(RESET)"
-	@echo "   $(CYAN)git tag -d $(1)$(RESET)"
-	@echo "$(BOLD)Remote:$(RESET)"
-	@echo "   $(CYAN)git push origin --delete $(1)$(RESET)"
+	@echo "  $(BOLD)Local:$(RESET) $(CYAN)git tag -d $(1)$(RESET)"
+	@echo "  $(BOLD)Remote:$(RESET) $(CYAN)git push origin --delete $(1)$(RESET)"
 	@echo ""
 endef
 
@@ -175,7 +170,7 @@ release_tag_dev: ## Tag a new dev release for unmerged PRs (e.g. v1.0.1-dev-feat
 	@$(eval BRANCH_CLEAN=$(shell echo $(CURRENT_BRANCH) | sed 's/[^a-zA-Z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-\|-$$//g'))
 	@$(eval NEW_TAG=$(LATEST_TAG)-dev-$(BRANCH_CLEAN)-$(SHORT_COMMIT))
 	@git tag $(NEW_TAG)
-	$(call print_success,Dev version tagged: $(NEW_TAG))
+	$(call print_success,Dev version tagged: ${CYAN}$(NEW_TAG)${RESET})
 	@echo "$(BOLD)Branch:$(RESET) $(CYAN)$(CURRENT_BRANCH)$(RESET)"
 	@echo "$(BOLD)Commit:$(RESET) $(CYAN)$(SHORT_COMMIT)$(RESET)"
 	@echo ""
@@ -200,7 +195,7 @@ release_tag_rc: ## Tag a new rc release (e.g. v0.1.28 -> v0.1.29-rc1, v0.1.29-rc
 			echo "$(NEXT_VERSION)-rc$$NEW_RC_NUM"; \
 		fi))
 	@git tag $(NEW_TAG)
-	$(call print_success,RC version tagged: $(NEW_TAG))
+	$(call print_success,RC version tagged: ${CYAN}$(NEW_TAG)${RESET})
 	$(call print_next_steps,$(NEW_TAG))
 	$(call print_cleanup_commands,$(NEW_TAG))
 	$(call print_additional_info)
@@ -210,7 +205,7 @@ release_tag_minor: ## Tag a new minor release (e.g. v1.0.1 -> v1.0.2)
 	@$(eval LATEST_TAG=$(shell git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$$' | head -n 1))
 	@$(eval NEW_TAG=$(shell echo $(LATEST_TAG) | awk -F. -v OFS=. '{ $$NF = sprintf("%d", $$NF + 1); print }'))
 	@git tag $(NEW_TAG)
-	$(call print_success,Bug fix version tagged: $(NEW_TAG))
+	$(call print_success,Bug fix version tagged: ${CYAN}$(NEW_TAG)${RESET})
 	$(call print_next_steps,$(NEW_TAG))
 	$(call print_cleanup_commands,$(NEW_TAG))
 	$(call print_additional_info)
@@ -220,7 +215,7 @@ release_tag_major: ## Tag a new major release (e.g. v1.0.0 -> v2.0.0)
 	@$(eval LATEST_TAG=$(shell git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$$' | head -n 1))
 	@$(eval NEW_TAG=$(shell echo $(LATEST_TAG) | awk -F. '{$$2 += 1; $$3 = 0; print $$1 "." $$2 "." $$3}'))
 	@git tag $(NEW_TAG)
-	$(call print_success,Minor release version tagged: $(NEW_TAG))
+	$(call print_success,Minor release version tagged: ${CYAN}$(NEW_TAG)${RESET})
 	$(call print_next_steps,$(NEW_TAG))
 	$(call print_cleanup_commands,$(NEW_TAG))
 	$(call print_additional_info)

--- a/makefiles/release.mk
+++ b/makefiles/release.mk
@@ -111,9 +111,11 @@ INFO_URL := https://dev.poktroll.com/explore/account_management/pocketd_cli?_hig
 define print_next_steps
 	$(call print_info_section,Next Steps)
 	@echo "  $(BOLD)1.$(RESET) Push the new tag: $(CYAN)git push origin $(1)$(RESET)"
-	@echo "  $(BOLD)2.$(RESET) Draft a new release here: $(CYAN)$(GITHUB_REPO_URL)$(RESET)"
-	$(if $(2),@echo "    $(CYAN)- Mark it as a pre-release$(RESET)")
-	$(if $(2),@echo "    $(CYAN)- Include PR/branch information in the description$(RESET)")
+	@echo "  $(BOLD)2.$(RESET) Draft the release with gh:"
+	@echo "     $(CYAN)gh release create $(1) $(if $(2),--prerelease,) --generate-notes$(RESET)"
+	@echo ""
+	@repo_url=$$(gh repo view --json url -q .url); \
+		echo "  $(BOLD)Release URL:$(RESET) $(CYAN)$${repo_url}/releases/tag/$(1)$(RESET)"
 	@echo ""
 endef
 

--- a/pkg/relayer/cmd/cmd_start.go
+++ b/pkg/relayer/cmd/cmd_start.go
@@ -152,28 +152,11 @@ Totals:
 
 	switch relayMinerConfig.SmtStorePath {
 	case session.InMemoryStoreFilename:
-		fmt.Printf(`
-🚨 WARNING: SMT configured for SimpleMap in-memory storage 🚨
-----------------------------------------------------------------
-• Using pure Go map-based storage (recommended in-memory option)
-• All session data will be LOST on RelayMiner restart
-• No session state persisted to disk
-• Unsubmitted Claims and Proofs will be lost
-• TODO(#1734): Add support for backing up in-memory session trees
-----------------------------------------------------------------
-`)
+		logger.Warn().Msg(`🚨 SMT configured for SimpleMap in-memory storage. All session data will be LOST on RelayMiner restart. See #1734 for more info.`)
 	case session.InMemoryPebbleStoreFilename:
-		fmt.Printf(`
-🚨 WARNING: SMT configured for Pebble in-memory storage (EXPERIMENTAL) 🚨
-----------------------------------------------------------------
-• Using Pebble database with in-memory VFS (experimental option)
-• Higher overhead than SimpleMap - consider using ":memory:" instead
-• All session data will be LOST on RelayMiner restart
-• No session state persisted to disk
-• Unsubmitted Claims and Proofs will be lost
-• TODO(#1734): Add support for backing up in-memory session trees
-----------------------------------------------------------------
-`)
+		logger.Warn().Msg(`🚨 SMT configured for Pebble in-memory storage (EXPERIMENTAL). All session data will be LOST on RelayMiner restart. See #1734 for more info.`)
+	default:
+		logger.Debug().Msgf("SMT configured for persistent storage at: %s", relayMinerConfig.SmtStorePath)
 	}
 
 	// --- Log flag values ---

--- a/pkg/relayer/cmd/cmd_start.go
+++ b/pkg/relayer/cmd/cmd_start.go
@@ -150,7 +150,8 @@ Totals:
 		return err
 	}
 
-	if relayMinerConfig.SmtStorePath == session.InMemoryStoreFilename {
+	switch relayMinerConfig.SmtStorePath {
+	case session.InMemoryStoreFilename:
 		fmt.Printf(`
 🚨 WARNING: SMT configured for SimpleMap in-memory storage 🚨
 ----------------------------------------------------------------
@@ -161,7 +162,7 @@ Totals:
 • TODO(#1734): Add support for backing up in-memory session trees
 ----------------------------------------------------------------
 `)
-	} else if relayMinerConfig.SmtStorePath == session.InMemoryPebbleStoreFilename {
+	case session.InMemoryPebbleStoreFilename:
 		fmt.Printf(`
 🚨 WARNING: SMT configured for Pebble in-memory storage (EXPERIMENTAL) 🚨
 ----------------------------------------------------------------

--- a/pkg/relayer/cmd/cmd_start.go
+++ b/pkg/relayer/cmd/cmd_start.go
@@ -152,8 +152,21 @@ Totals:
 
 	if relayMinerConfig.SmtStorePath == session.InMemoryStoreFilename {
 		fmt.Printf(`
-🚨 WARNING: SMT configured for in-memory storage 🚨
+🚨 WARNING: SMT configured for SimpleMap in-memory storage 🚨
 ----------------------------------------------------------------
+• Using pure Go map-based storage (recommended in-memory option)
+• All session data will be LOST on RelayMiner restart
+• No session state persisted to disk
+• Unsubmitted Claims and Proofs will be lost
+• TODO(#1734): Add support for backing up in-memory session trees
+----------------------------------------------------------------
+`)
+	} else if relayMinerConfig.SmtStorePath == session.InMemoryPebbleStoreFilename {
+		fmt.Printf(`
+🚨 WARNING: SMT configured for Pebble in-memory storage (EXPERIMENTAL) 🚨
+----------------------------------------------------------------
+• Using Pebble database with in-memory VFS (experimental option)
+• Higher overhead than SimpleMap - consider using ":memory:" instead
 • All session data will be LOST on RelayMiner restart
 • No session state persisted to disk
 • Unsubmitted Claims and Proofs will be lost

--- a/pkg/relayer/config/config.schema.yaml
+++ b/pkg/relayer/config/config.schema.yaml
@@ -38,7 +38,12 @@ properties:
 
   # SMT store path (required)
   smt_store_path:
-    description: "Path to the Sparse Merkle Tree store directory."
+    description: |
+      Path to the Sparse Merkle Tree store directory.
+      Special values:
+      - ":memory:" - Uses SimpleMap for pure in-memory storage (recommended for high performance)
+      - ":memory_pebble:" - Uses Pebble with in-memory VFS (experimental, higher overhead)
+      - Any other string - Path to disk directory for persistent storage
     type: string
 
   # Enable over servicing (optional)

--- a/pkg/relayer/interface.go
+++ b/pkg/relayer/interface.go
@@ -165,11 +165,17 @@ type SessionTree interface {
 	// a proof in byte format.
 	GetProofBz() []byte
 
-	// Flush gets the root hash of the SMST needed for submitting the claim;
-	// then commits the entire tree to disk and stops the KVStore.
-	// It should be called before submitting the claim onchain. This function frees up
-	// the in-memory resources used by the SMST that are no longer needed while waiting
-	// for the proof submission window to open.
+	// Flush should be used to safely free up resources used by the SMST without risking rewards.
+	// Flush can be seen as a safe version of "Stop" which is explicitly not exposed by this interface.
+	//
+	// It does the following:
+	// 1. Gets the root hash of the SMST needed for submitting the claim.
+	// 2. Commits the entire tree to disk (if disk storage is used)
+	// 3. Stops the KVStore.
+	//
+	// It should be called before submitting the claim onchain.
+	// This function frees up the in-memory resources used by the SMST that are
+	// no longer needed while waiting for the proof submission window to open.
 	Flush() (SMSTRoot []byte, err error)
 
 	// TODO_DISCUSS: This function should not be part of the interface as it is an optimization
@@ -190,10 +196,6 @@ type SessionTree interface {
 
 	// GetTrieSpec returns the trie spec of the SMST.
 	GetTrieSpec() smt.TrieSpec
-
-	// Stop stops the session tree and closes the KVStore.
-	// Calling Stop does not calculate the root hash of the SMST.
-	Stop() error
 }
 
 // RelayMeter is an interface that keeps track of the amount of stake consumed between

--- a/pkg/relayer/session/persistence.go
+++ b/pkg/relayer/session/persistence.go
@@ -194,8 +194,8 @@ func (rs *relayerSessionsManager) deletePersistedSessionTree(sessionSMT *proofty
 		"session_end_height", sessionEndHeight,
 	)
 
-	// If the session tree is not persisted to disk, there is nothing to delete.
-	if !rs.persistedSMT() {
+	// If the session tree is in-memory only, there is nothing to delete.
+	if rs.isInMemorySMT() {
 		logger.Debug().Msg("Skipping session tree deletion. RelayMiner is configured for in-memory mode.")
 		return nil
 	}
@@ -344,10 +344,7 @@ func getSessionStoreKey(supplierOperatorAddress string, sessionId string) []byte
 	return []byte(sessionStoreKeyStr)
 }
 
-// persistedSMT returns true if the session tree is persisted to disk (has a storePath),
-// false if it's in-memory only (either SimpleMap or Pebble in-memory).
-func (rs *relayerSessionsManager) persistedSMT() bool {
-	return rs.storesDirectoryPath != "" &&
-		rs.storesDirectoryPath != InMemoryStoreFilename &&
-		rs.storesDirectoryPath != InMemoryPebbleStoreFilename
+// isInMemorySMT returns true if the session tree is in-memory only (either SimpleMap or Pebble in-memory).
+func (rs *relayerSessionsManager) isInMemorySMT() bool {
+	return rs.storesDirectoryPath == InMemoryStoreFilename || rs.storesDirectoryPath == InMemoryPebbleStoreFilename
 }

--- a/pkg/relayer/session/persistence.go
+++ b/pkg/relayer/session/persistence.go
@@ -345,7 +345,9 @@ func getSessionStoreKey(supplierOperatorAddress string, sessionId string) []byte
 }
 
 // persistedSMT returns true if the session tree is persisted to disk (has a storePath),
-// false if it's in-memory only.
+// false if it's in-memory only (either SimpleMap or Pebble in-memory).
 func (rs *relayerSessionsManager) persistedSMT() bool {
-	return rs.storesDirectoryPath != "" && rs.storesDirectoryPath != InMemoryStoreFilename
+	return rs.storesDirectoryPath != "" &&
+		rs.storesDirectoryPath != InMemoryStoreFilename &&
+		rs.storesDirectoryPath != InMemoryPebbleStoreFilename
 }

--- a/pkg/relayer/session/session.go
+++ b/pkg/relayer/session/session.go
@@ -27,28 +27,27 @@ import (
 // Ensure the relayerSessionsManager implements the RelayerSessions interface.
 var _ relayer.RelayerSessionsManager = (*relayerSessionsManager)(nil)
 
-// TODO_TECHDEBT: We're currently experimenting with two different in-memory storage approaches:
-// 1. SimpleMap (":memory:") - Pure Go map with mutex, no background processes
-// 2. Pebble in-memory (":memory_pebble:") - Pebble database with in-memory VFS
+// Session tree storage mode constants.
 //
-// Eventually we need to either:
-// - Create a proper enum for storage types (disk, memory_simple, memory_pebble)
-// - Delete support for one of them based on performance/reliability testing
-//
-// Current recommendation: Use ":memory:" (SimpleMap) for production as it's more reliable
-// for ephemeral data and has no lifecycle management complexity.
+// TODO_TECHDEBT(#XXX): We're currently experimenting with dual in-memory storage approaches.
+// Eventually we should either:
+// - Formalize this into a proper enum for storage types (disk, memory_simple, memory_pebble)
+// - Remove support for one approach based on performance/reliability testing
+// Current recommendation: Use InMemoryStoreFilename for production as it's more reliable.
+const (
+	// InMemoryStoreFilename indicates SMTs should be stored using SimpleMap in memory.
+	// This provides pure Go map-based storage with no background processes or lifecycle management.
+	// Data will not be persisted to disk and will be lost on process restart.
+	// Selected to follow SQLite standards: https://www.sqlite.org/inmemorydb.html
+	InMemoryStoreFilename = ":memory:"
 
-// InMemoryStoreFilename indicates SMTs should be stored in memory using SimpleMap.
-// This is a pure Go map-based storage with no background processes or lifecycle management.
-// Data will not be persisted to disk and will be lost on process restart.
-// Selected to follow SQLite standards: https://www.sqlite.org/inmemorydb.html
-const InMemoryStoreFilename = ":memory:"
-
-// InMemoryPebbleStoreFilename indicates SMTs should be stored using Pebble's in-memory VFS.
-// This uses Pebble database engine but stores data in memory instead of disk.
-// Still has background processes and lifecycle management overhead.
-// Data will not be persisted to disk and will be lost on process restart.
-const InMemoryPebbleStoreFilename = ":memory_pebble:"
+	// InMemoryPebbleStoreFilename indicates SMTs should be stored using Pebble's in-memory VFS.
+	// This uses Pebble database engine but stores data in memory instead of disk.
+	// Has background processes and lifecycle management overhead compared to SimpleMap.
+	// Data will not be persisted to disk and will be lost on process restart.
+	// This is EXPERIMENTAL and should be used for testing/evaluation only.
+	InMemoryPebbleStoreFilename = ":memory_pebble:"
+)
 
 // SessionTreesMap is an alias type for a map of
 // supplierOperatorAddress ->  sessionEndHeight -> sessionId -> SessionTree.

--- a/pkg/relayer/session/session.go
+++ b/pkg/relayer/session/session.go
@@ -308,8 +308,8 @@ func (rs *relayerSessionsManager) Stop() {
 				}
 
 				// Stop the session tree process and underlying key-value store.
-				if err := sessionTree.Stop(); err != nil {
-					logger.Error().Err(err).Msg("❌️ Failed to stop session tree store during shutdown. ❗Check disk permissions and kvstore integrity. ❗Resources may not be properly cleaned up.")
+				if _, err := sessionTree.Flush(); err != nil {
+					logger.Error().Err(err).Msg("❌️ Failed to flush session tree store during shutdown. ❗Check disk permissions and kvstore integrity. ❗Resources may not be properly cleaned up.")
 				}
 
 				logger.Debug().Msg("💾 Successfully stored session tree to disk during shutdown")

--- a/pkg/relayer/session/session.go
+++ b/pkg/relayer/session/session.go
@@ -29,7 +29,7 @@ var _ relayer.RelayerSessionsManager = (*relayerSessionsManager)(nil)
 
 // Session tree storage mode constants.
 //
-// TODO_TECHDEBT(#XXX): We're currently experimenting with dual in-memory storage approaches.
+// TODO_TECHDEBT(#1734): We're currently experimenting with dual in-memory storage approaches.
 // Eventually we should either:
 // - Formalize this into a proper enum for storage types (disk, memory_simple, memory_pebble)
 // - Remove support for one approach based on performance/reliability testing

--- a/pkg/relayer/session/session.go
+++ b/pkg/relayer/session/session.go
@@ -29,23 +29,20 @@ var _ relayer.RelayerSessionsManager = (*relayerSessionsManager)(nil)
 
 // Session tree storage mode constants.
 //
-// TODO_TECHDEBT(#1734): We're currently experimenting with dual in-memory storage approaches.
-// Eventually we should either:
-// - Formalize this into a proper enum for storage types (disk, memory_simple, memory_pebble)
-// - Remove support for one approach based on performance/reliability testing
-// Current recommendation: Use InMemoryStoreFilename for production as it's more reliable.
+// TODO_TECHDEBT(#1734): Once in-memory modes are stabilized, do one of the following:
+// 1. Formalize this into a proper enum for storage types (disk, memory_simple, memory_pebble)
+// 2. Remove support for one approach based on performance/reliability testing
 const (
+	// ** DEV_NOTE: This is the current recommended mode for production. **
 	// InMemoryStoreFilename indicates SMTs should be stored using SimpleMap in memory.
 	// This provides pure Go map-based storage with no background processes or lifecycle management.
 	// Data will not be persisted to disk and will be lost on process restart.
-	// Selected to follow SQLite standards: https://www.sqlite.org/inmemorydb.html
 	InMemoryStoreFilename = ":memory:"
 
 	// InMemoryPebbleStoreFilename indicates SMTs should be stored using Pebble's in-memory VFS.
 	// This uses Pebble database engine but stores data in memory instead of disk.
 	// Has background processes and lifecycle management overhead compared to SimpleMap.
 	// Data will not be persisted to disk and will be lost on process restart.
-	// This is EXPERIMENTAL and should be used for testing/evaluation only.
 	InMemoryPebbleStoreFilename = ":memory_pebble:"
 )
 

--- a/pkg/relayer/session/session_persistence_test.go
+++ b/pkg/relayer/session/session_persistence_test.go
@@ -352,9 +352,9 @@ func (s *SessionPersistenceTestSuite) TestRestartAfterProofWindowClosed() {
 	s.relayerSessionsManager = s.setupNewRelayerSessionsManager()
 
 	// Calculate when the proof window closes for this session
-	proofWinodwCloseHeight := sharedtypes.GetProofWindowCloseHeight(&s.sharedParams, sessionEndHeight)
+	proofWindowCloseHeight := sharedtypes.GetProofWindowCloseHeight(&s.sharedParams, sessionEndHeight)
 	// Move past the proof window close height
-	s.advanceToBlock(proofWinodwCloseHeight + 1)
+	s.advanceToBlock(proofWindowCloseHeight + 1)
 
 	// Start the new relayer sessions manager
 	err := s.relayerSessionsManager.Start(s.ctx)

--- a/pkg/relayer/session/session_storage_mode_test.go
+++ b/pkg/relayer/session/session_storage_mode_test.go
@@ -1,0 +1,570 @@
+package session_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"cosmossdk.io/depinject"
+	coretypes "github.com/cometbft/cometbft/rpc/core/types"
+	cmttypes "github.com/cometbft/cometbft/types"
+	"github.com/gogo/status"
+	"github.com/pokt-network/smt"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+
+	"github.com/pokt-network/poktroll/pkg/client"
+	"github.com/pokt-network/poktroll/pkg/client/supplier"
+	"github.com/pokt-network/poktroll/pkg/crypto/protocol"
+	"github.com/pokt-network/poktroll/pkg/observable"
+	"github.com/pokt-network/poktroll/pkg/observable/channel"
+	"github.com/pokt-network/poktroll/pkg/polylog"
+	"github.com/pokt-network/poktroll/pkg/polylog/polyzero"
+	"github.com/pokt-network/poktroll/pkg/relayer"
+	"github.com/pokt-network/poktroll/pkg/relayer/session"
+	"github.com/pokt-network/poktroll/testutil/mockclient"
+	"github.com/pokt-network/poktroll/testutil/sample"
+	"github.com/pokt-network/poktroll/testutil/testclient/testblock"
+	"github.com/pokt-network/poktroll/testutil/testclient/testqueryclients"
+	"github.com/pokt-network/poktroll/testutil/testpolylog"
+	"github.com/pokt-network/poktroll/testutil/testrelayer"
+	prooftypes "github.com/pokt-network/poktroll/x/proof/types"
+	sessiontypes "github.com/pokt-network/poktroll/x/session/types"
+	sharedtypes "github.com/pokt-network/poktroll/x/shared/types"
+)
+
+// StorageModeTestSuite defines the test suite for different storage modes
+type StorageModeTestSuite struct {
+	suite.Suite
+	ctx        context.Context
+	storageDir string // For disk storage mode
+
+	deps                   depinject.Config
+	relayerSessionsManager relayer.RelayerSessionsManager
+	storesDirectoryPathOpt relayer.RelayerSessionsManagerOption
+
+	sessionTrees            session.SessionsTreesMap
+	activeSessionHeader     *sessiontypes.SessionHeader
+	supplierOperatorAddress string
+	service                 sharedtypes.Service
+	emptyBlockHash          []byte
+	claimToReturn           *prooftypes.Claim
+	createClaimCallCount    int
+	submitProofCallCount    int
+	latestBlock             client.Block
+
+	blockClient    client.BlockClient
+	blockPublishCh chan<- client.Block
+	blocksObs      observable.Observable[client.Block]
+
+	minedRelaysPublishCh chan<- *relayer.MinedRelay
+	minedRelaysObs       relayer.MinedRelaysObservable
+
+	sharedParams sharedtypes.Params
+	proofParams  prooftypes.Params
+
+	logger polylog.Logger
+}
+
+// TestStorageModeSimpleMap tests the ":memory:" (SimpleMap) storage mode
+func TestStorageModeSimpleMap(t *testing.T) {
+	suite.Run(t, &StorageModeTestSuite{storageDir: session.InMemoryStoreFilename})
+}
+
+// TestStorageModePebbleInMemory tests the ":memory_pebble:" storage mode
+func TestStorageModePebbleInMemory(t *testing.T) {
+	suite.Run(t, &StorageModeTestSuite{storageDir: session.InMemoryPebbleStoreFilename})
+}
+
+// TestStorageModeDisk tests the disk storage mode
+func TestStorageModeDisk(t *testing.T) {
+	suite.Run(t, &StorageModeTestSuite{storageDir: ""}) // Will be set to temp dir in SetupTest
+}
+
+// SetupTest prepares the test environment before each test execution
+func (s *StorageModeTestSuite) SetupTest() {
+	// Initialize logger and context
+	s.logger, s.ctx = testpolylog.NewLoggerWithCtx(context.Background(), polyzero.DebugLevel)
+
+	// Initialize test data and state
+	s.service = sharedtypes.Service{Id: "svc", ComputeUnitsPerRelay: 2000}
+	s.sharedParams = sharedtypes.DefaultParams()
+	s.proofParams = prooftypes.DefaultParams()
+	s.proofParams.ProofRequirementThreshold = uPOKTCoin(1)
+	s.supplierOperatorAddress = sample.AccAddressBech32()
+	s.emptyBlockHash = make([]byte, 32)
+
+	// Reset counters and state for each test
+	s.createClaimCallCount = 0
+	s.submitProofCallCount = 0
+	s.claimToReturn = nil
+	s.sessionTrees = make(session.SessionsTreesMap)
+	s.latestBlock = nil
+
+	// Set up storage directory path based on test mode
+	if s.storageDir == "" {
+		// Disk storage mode - create temporary directory
+		tmpDirPattern := fmt.Sprintf("%s_smt_kvstore", strings.ReplaceAll(s.T().Name(), "/", "_"))
+		tmpStoresDir, err := os.MkdirTemp("", tmpDirPattern)
+		require.NoError(s.T(), err)
+		s.storageDir = tmpStoresDir
+	}
+
+	s.storesDirectoryPathOpt = session.WithStoresDirectoryPath(s.storageDir)
+
+	// Configure test service and difficulty
+	testqueryclients.AddToExistingServices(s.T(), s.service)
+	testqueryclients.SetServiceRelayDifficultyTargetHash(s.T(), s.service.Id, protocol.BaseRelayDifficultyHashBz)
+
+	// Create a session header for testing
+	s.activeSessionHeader = &sessiontypes.SessionHeader{
+		SessionStartBlockHeight: 1,
+		SessionEndBlockHeight:   int64(s.sharedParams.NumBlocksPerSession),
+		ServiceId:               s.service.Id,
+		SessionId:               "sessionId",
+	}
+
+	// Set up dependencies for the relayer sessions manager
+	s.deps = s.setupSessionManagerDependencies()
+
+	// Create mined relays observable and channel for publishing
+	mrObs, minedRelaysPublishCh := channel.NewObservable[*relayer.MinedRelay]()
+	s.minedRelaysObs = relayer.MinedRelaysObservable(mrObs)
+	s.minedRelaysPublishCh = minedRelaysPublishCh
+
+	// Initialize and start the relayer sessions manager
+	s.relayerSessionsManager = s.setupNewRelayerSessionsManager()
+	s.advanceToBlock(1)
+	err := s.relayerSessionsManager.Start(s.ctx)
+	require.NoError(s.T(), err)
+
+	// Publish a test mined relay and wait for processing
+	s.minedRelaysPublishCh <- testrelayer.NewUnsignedMinedRelay(s.T(), s.activeSessionHeader, s.supplierOperatorAddress)
+	waitSimulateIO()
+
+	// Verify the session tree is correctly initialized
+	sessionTree := s.getActiveSessionTree()
+	require.Equal(s.T(), sessionTree.GetSessionHeader(), s.activeSessionHeader)
+
+	// Verify the session tree has one element (the mined relay)
+	smstRoot := sessionTree.GetSMSTRoot()
+	count, err := smstRoot.Count()
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), uint64(1), count)
+
+	// Log which storage mode we're testing
+	s.logger.Info().
+		Str("storage_mode", s.getStorageModeName()).
+		Str("storage_path", s.storageDir).
+		Msg("Testing storage mode")
+}
+
+// TearDownTest cleans up resources after each test execution
+func (s *StorageModeTestSuite) TearDownTest() {
+	// Stop the relayer sessions manager
+	s.relayerSessionsManager.Stop()
+
+	// Clean up temporary directory for disk storage only
+	if s.storageDir != session.InMemoryStoreFilename && s.storageDir != session.InMemoryPebbleStoreFilename {
+		_ = os.RemoveAll(s.storageDir)
+	}
+}
+
+// TestClaimAndProofSubmission tests the complete claim and proof submission lifecycle
+// This is the critical test that should reveal the bug in Pebble in-memory mode
+func (s *StorageModeTestSuite) TestClaimAndProofSubmission() {
+	// Get the session end height from the active session header
+	sessionEndHeight := s.activeSessionHeader.GetSessionEndBlockHeight()
+
+	// Calculate when the claim window opens for this session
+	claimWindowOpenHeight := sharedtypes.GetClaimWindowOpenHeight(&s.sharedParams, sessionEndHeight)
+	// Move to the block where the claim window opens (which should trigger claim creation)
+	s.advanceToBlock(claimWindowOpenHeight)
+
+	// Verify the session tree exists and a claim has been created
+	sessionTree := s.getActiveSessionTree()
+	claimRoot := sessionTree.GetClaimRoot()
+	require.NotNil(s.T(), claimRoot, "Claim root should be created for storage mode: %s", s.getStorageModeName())
+	require.Equal(s.T(), 1, s.createClaimCallCount, "CreateClaim should be called once for storage mode: %s", s.getStorageModeName())
+
+	// Verify the claim tree has exactly one claim
+	count, err := smt.MerkleSumRoot(claimRoot).Count()
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), uint64(1), count, "Claim tree should have exactly one relay for storage mode: %s", s.getStorageModeName())
+
+	// Calculate when the proof window closes for this session
+	proofWindowCloseHeight := sharedtypes.GetProofWindowCloseHeight(&s.sharedParams, sessionEndHeight)
+	// Move to one block before the proof window closes (which should trigger proof submission)
+	s.advanceToBlock(proofWindowCloseHeight)
+
+	// This is the critical assertion - verify that a proof was submitted
+	// Note: This test should pass for all storage modes with our current implementation
+	// To reproduce the original bug where Pebble in-memory failed, you would need to:
+	// 1. Revert the sessionSMT preservation fix in sessiontree.go Flush() method
+	// 2. Remove the sessionSMT restoration logic in ProveClosest() method
+	// 3. Then this assertion would fail for Pebble in-memory mode only
+	require.Equal(s.T(), 1, s.submitProofCallCount, "SubmitProof should be called once for storage mode: %s", s.getStorageModeName())
+
+	// Verify the session tree has been removed after proof submission
+	require.Len(s.T(), s.sessionTrees, 0, "Session tree should be removed after proof submission for storage mode: %s", s.getStorageModeName())
+}
+
+// TestRestartDuringClaimWindow tests session persistence when restarted during claim window
+func (s *StorageModeTestSuite) TestRestartDuringClaimWindow() {
+	// Get the session end height from the active session header
+	sessionEndHeight := s.activeSessionHeader.GetSessionEndBlockHeight()
+
+	// Calculate when the claim window opens for this session
+	claimWindowOpenHeight := sharedtypes.GetClaimWindowOpenHeight(&s.sharedParams, sessionEndHeight)
+	// Move to one block before the claim window opens
+	s.advanceToBlock(claimWindowOpenHeight - 1)
+
+	// Verify the session tree exists and no claims have been created yet
+	sessionTree := s.getActiveSessionTree()
+	require.Equal(s.T(), s.activeSessionHeader, sessionTree.GetSessionHeader())
+	require.Equal(s.T(), 0, s.createClaimCallCount)
+
+	// Stop and recreate the relayer sessions manager
+	s.relayerSessionsManager.Stop()
+	s.relayerSessionsManager = s.setupNewRelayerSessionsManager()
+
+	// Advance to the block where the claim window opens while the relayer sessions manager is stopped
+	s.blockPublishCh <- testblock.NewAnyTimesBlock(s.T(), s.emptyBlockHash, claimWindowOpenHeight)
+	s.advanceToBlock(claimWindowOpenHeight)
+
+	// Start the new relayer sessions manager
+	err := s.relayerSessionsManager.Start(s.ctx)
+	require.NoError(s.T(), err)
+	waitSimulateIO()
+
+	// For in-memory modes, we should only proceed if the session was restored
+	if s.storageDir == session.InMemoryStoreFilename || s.storageDir == session.InMemoryPebbleStoreFilename {
+		// In-memory modes don't persist across restarts, so session should be gone
+		require.Len(s.T(), s.sessionTrees, 0, "In-memory storage should not persist sessions across restarts for mode: %s", s.getStorageModeName())
+		return
+	}
+
+	// For disk storage, verify the session tree is still correctly loaded
+	sessionTree = s.getActiveSessionTree()
+	require.Equal(s.T(), s.activeSessionHeader, sessionTree.GetSessionHeader())
+
+	// Verify a claim root has been created after restart
+	claimRoot := sessionTree.GetClaimRoot()
+	require.NotNil(s.T(), claimRoot, "Claim root should be created after restart for storage mode: %s", s.getStorageModeName())
+
+	// Verify createClaim was called exactly once
+	require.Equal(s.T(), 1, s.createClaimCallCount, "CreateClaim should be called once after restart for storage mode: %s", s.getStorageModeName())
+}
+
+// TestOriginalBugReproduction demonstrates the original bug behavior when sessionSMT preservation is disabled
+// This test is designed to show how Pebble in-memory mode would fail without our fix
+// NOTE: This test will be skipped in normal runs since the fix is currently in place
+func (s *StorageModeTestSuite) TestOriginalBugReproduction() {
+	// Skip this test for all modes since our fix is in place
+	// To enable this test and see the original bug:
+	// 1. Comment out the sessionSMT preservation in sessiontree.go Flush() method
+	// 2. Comment out the sessionSMT restoration in ProveClosest() method
+	// 3. Remove this skip statement
+	s.T().Skip("Skipping bug reproduction test - fix is currently active. See comments above to reproduce original bug.")
+
+	// Only test Pebble in-memory mode since that's where the bug occurred
+	if s.storageDir != session.InMemoryPebbleStoreFilename {
+		s.T().Skip("Bug reproduction test only relevant for Pebble in-memory mode")
+		return
+	}
+
+	// Get the session end height from the active session header
+	sessionEndHeight := s.activeSessionHeader.GetSessionEndBlockHeight()
+
+	// Calculate when the claim window opens and proof window closes
+	claimWindowOpenHeight := sharedtypes.GetClaimWindowOpenHeight(&s.sharedParams, sessionEndHeight)
+	proofWindowCloseHeight := sharedtypes.GetProofWindowCloseHeight(&s.sharedParams, sessionEndHeight)
+
+	// Move to claim window and verify claim creation
+	s.advanceToBlock(claimWindowOpenHeight)
+	sessionTree := s.getActiveSessionTree()
+	claimRoot := sessionTree.GetClaimRoot()
+	require.NotNil(s.T(), claimRoot, "Claim should be created")
+	require.Equal(s.T(), 1, s.createClaimCallCount, "CreateClaim should be called once")
+
+	// Move to proof window
+	s.advanceToBlock(proofWindowCloseHeight)
+
+	// Without the fix, this assertion would FAIL for Pebble in-memory mode
+	// because the sessionSMT would be lost after Stop() during Flush()
+	// With the fix in place, this assertion passes
+	require.Equal(s.T(), 1, s.submitProofCallCount, "SubmitProof should be called - this would FAIL without the sessionSMT preservation fix")
+}
+
+// TestStorageSpecificBehavior tests storage-specific behaviors and edge cases
+func (s *StorageModeTestSuite) TestStorageSpecificBehavior() {
+	sessionTree := s.getActiveSessionTree()
+
+	switch s.storageDir {
+	case session.InMemoryStoreFilename:
+		// SimpleMap storage should work without calling Stop()
+		s.T().Log("Testing SimpleMap storage - should work without Stop()")
+
+	case session.InMemoryPebbleStoreFilename:
+		// Pebble in-memory requires proper lifecycle management
+		s.T().Log("Testing Pebble in-memory storage - requires Stop() for proper lifecycle")
+
+	default:
+		// Disk storage persists data
+		s.T().Log("Testing disk storage - data persists to disk")
+	}
+
+	// All storage modes should have the session tree at this point
+	require.NotNil(s.T(), sessionTree, "Session tree should exist for storage mode: %s", s.getStorageModeName())
+
+	// Verify session header matches
+	require.Equal(s.T(), s.activeSessionHeader, sessionTree.GetSessionHeader(), "Session header should match for storage mode: %s", s.getStorageModeName())
+}
+
+// getStorageModeName returns a human-readable name for the current storage mode
+func (s *StorageModeTestSuite) getStorageModeName() string {
+	switch s.storageDir {
+	case session.InMemoryStoreFilename:
+		return "SimpleMap"
+	case session.InMemoryPebbleStoreFilename:
+		return "PebbleInMemory"
+	default:
+		return "Disk"
+	}
+}
+
+// getActiveSessionTree retrieves the current active session tree for testing purposes
+func (s *StorageModeTestSuite) getActiveSessionTree() relayer.SessionTree {
+	// Extract session details from the active header
+	sessionEndHeight := s.activeSessionHeader.GetSessionEndBlockHeight()
+	sessionId := s.activeSessionHeader.GetSessionId()
+
+	// Get the specific session tree for this supplier
+	supplierSessionTrees, ok := s.sessionTrees[s.supplierOperatorAddress]
+	require.True(s.T(), ok)
+
+	// Get all session trees for this session end height
+	sessionTreesWithEndHeight, ok := supplierSessionTrees[sessionEndHeight]
+	require.True(s.T(), ok)
+
+	// Get all session trees for this session ID
+	sessionTree, ok := sessionTreesWithEndHeight[sessionId]
+	require.True(s.T(), ok)
+
+	return sessionTree
+}
+
+// setupNewRelayerSessionsManager creates and configures a new relayer sessions manager for testing
+func (s *StorageModeTestSuite) setupNewRelayerSessionsManager() relayer.RelayerSessionsManager {
+	// Initialize a new session trees map
+	s.sessionTrees = make(session.SessionsTreesMap)
+	// Create an inspector that will monitor the session trees for testing
+	sessionTreesInspector := session.WithSessionTreesInspector(&s.sessionTrees)
+
+	// Create a new replay observable for blocks
+	s.blocksObs, s.blockPublishCh = channel.NewReplayObservable[client.Block](s.ctx, 20)
+
+	// Set up a listener to update the latest block whenever a new block comes in
+	channel.ForEach(
+		context.Background(),
+		s.blocksObs,
+		func(ctx context.Context, block client.Block) {
+			s.latestBlock = block
+		},
+	)
+
+	// Create a new relayer sessions manager with the configured dependencies
+	relayerSessionsManager, err := session.NewRelayerSessions(s.deps, s.storesDirectoryPathOpt, sessionTreesInspector)
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), relayerSessionsManager)
+
+	// Insert the mined relays observable into the sessions manager
+	relayerSessionsManager.InsertRelays(s.minedRelaysObs)
+
+	return relayerSessionsManager
+}
+
+// setupSessionManagerDependencies configures all the mock dependencies needed by the relayer sessions manager
+func (s *StorageModeTestSuite) setupSessionManagerDependencies() depinject.Config {
+	ctrl := gomock.NewController(s.T())
+
+	// Set up all mock clients
+	supplierClientMock := s.setupMockSupplierClient(ctrl)
+	blockQueryClientMock := s.setupMockBlockQueryClient(ctrl)
+	proofQueryClientMock := s.setupMockProofQueryClient(ctrl)
+	s.blockClient = s.setupMockBlockClient(ctrl)
+
+	// Create a new replay observable for blocks
+	s.blocksObs, s.blockPublishCh = channel.NewReplayObservable[client.Block](s.ctx, 20)
+
+	// Create supplier client map and add the mock supplier client
+	supplierClientMap := supplier.NewSupplierClientMap()
+	supplierClientMap.SupplierClients[s.supplierOperatorAddress] = supplierClientMock
+
+	// Configure other required mock query clients
+	sharedQueryClientMock := testqueryclients.NewTestSharedQueryClient(s.T())
+	serviceQueryClientMock := testqueryclients.NewTestServiceQueryClient(s.T())
+	bankQueryClient := testqueryclients.NewTestBankQueryClientWithBalance(s.T(), 1000000)
+
+	// Create the dependency supply configuration
+	deps := depinject.Supply(
+		s.blockClient,
+		blockQueryClientMock,
+		supplierClientMap,
+		sharedQueryClientMock,
+		serviceQueryClientMock,
+		proofQueryClientMock,
+		bankQueryClient,
+		s.logger,
+	)
+
+	return deps
+}
+
+// setupMockSupplierClient creates and configures a mock supplier client for testing claim and proof submissions
+func (s *StorageModeTestSuite) setupMockSupplierClient(ctrl *gomock.Controller) *mockclient.MockSupplierClient {
+	// Configure mock supplier client
+	supplierClientMock := mockclient.NewMockSupplierClient(ctrl)
+
+	// Mock the OperatorAddress method to return the test supplier address
+	supplierClientMock.EXPECT().
+		OperatorAddress().
+		Return(s.supplierOperatorAddress).
+		AnyTimes()
+
+	// Mock the CreateClaims method to track claim creation
+	supplierClientMock.EXPECT().
+		CreateClaims(
+			gomock.Any(),
+			gomock.Any(),
+			gomock.AssignableToTypeOf(([]client.MsgCreateClaim)(nil)),
+		).
+		DoAndReturn(func(ctx context.Context, timeoutHeight int64, claimMsgs ...*prooftypes.MsgCreateClaim) error {
+			require.Len(s.T(), claimMsgs, 1)
+			s.claimToReturn = &prooftypes.Claim{
+				SupplierOperatorAddress: s.supplierOperatorAddress,
+				SessionHeader:           s.activeSessionHeader,
+				RootHash:                claimMsgs[0].GetRootHash(),
+			}
+			s.createClaimCallCount++
+			return nil
+		}).
+		AnyTimes()
+
+	// Mock the SubmitProofs method to track proof submission
+	supplierClientMock.EXPECT().
+		SubmitProofs(
+			gomock.Any(),
+			gomock.Any(),
+			gomock.AssignableToTypeOf(([]client.MsgSubmitProof)(nil)),
+		).
+		DoAndReturn(func(ctx context.Context, timeoutHeight int64, proofMsgs ...*prooftypes.MsgSubmitProof) error {
+			require.Len(s.T(), proofMsgs, 1)
+			s.submitProofCallCount++
+			return nil
+		}).
+		AnyTimes()
+
+	return supplierClientMock
+}
+
+// setupMockBlockQueryClient creates and configures a mock block query client for testing block retrieval
+func (s *StorageModeTestSuite) setupMockBlockQueryClient(ctrl *gomock.Controller) *mockclient.MockCometRPC {
+	// Configure mock block query client
+	blockQueryClientMock := mockclient.NewMockCometRPC(ctrl)
+	blockQueryClientMock.EXPECT().
+		Block(gomock.Any(), gomock.AssignableToTypeOf((*int64)(nil))).
+		DoAndReturn(
+			func(_ context.Context, height *int64) (*coretypes.ResultBlock, error) {
+				return &coretypes.ResultBlock{
+					BlockID: cmttypes.BlockID{Hash: s.emptyBlockHash},
+					Block: &cmttypes.Block{
+						Header: cmttypes.Header{Height: *height},
+					},
+				}, nil
+			},
+		).
+		AnyTimes()
+
+	return blockQueryClientMock
+}
+
+// setupMockProofQueryClient creates and configures a mock proof query client for testing proof and claim retrieval
+func (s *StorageModeTestSuite) setupMockProofQueryClient(ctrl *gomock.Controller) *mockclient.MockProofQueryClient {
+	// Configure mock proof query client
+	proofQueryClientMock := mockclient.NewMockProofQueryClient(ctrl)
+	proofQueryClientMock.EXPECT().
+		GetParams(gomock.Any()).
+		Return(&s.proofParams, nil).
+		AnyTimes()
+	proofQueryClientMock.EXPECT().
+		GetClaim(
+			gomock.AssignableToTypeOf(s.ctx),
+			gomock.Eq(s.supplierOperatorAddress),
+			gomock.Eq(s.activeSessionHeader.SessionId),
+		).
+		DoAndReturn(
+			func(_ any, _ any, _ any) (*prooftypes.Claim, error) {
+				if s.claimToReturn == nil {
+					return nil, status.Error(codes.NotFound, "claim not found")
+				}
+				return s.claimToReturn, nil
+			},
+		).
+		AnyTimes()
+
+	return proofQueryClientMock
+}
+
+// setupMockBlockClient creates and configures a mock block client for testing block sequence management
+func (s *StorageModeTestSuite) setupMockBlockClient(ctrl *gomock.Controller) *mockclient.MockBlockClient {
+	// Configure mock block client
+	blockClientMock := mockclient.NewMockBlockClient(ctrl)
+
+	// Mock the LastBlock method to return the current latest block
+	blockClientMock.EXPECT().LastBlock(gomock.Any()).
+		DoAndReturn(func(_ any) client.Block {
+			return s.latestBlock
+		}).AnyTimes()
+
+	// Mock the CommittedBlocksSequence method to return the blocks observable
+	blockClientMock.EXPECT().
+		CommittedBlocksSequence(gomock.Any()).
+		DoAndReturn(func(_ any) observable.Observable[client.Block] {
+			return s.blocksObs
+		}).
+		AnyTimes()
+
+	// Mock the Close method to close the block publish channel
+	blockClientMock.EXPECT().
+		Close().
+		DoAndReturn(func() {
+			close(s.blockPublishCh)
+		}).
+		AnyTimes()
+
+	return blockClientMock
+}
+
+// advanceToBlock advances the test chain to the specified height by publishing new blocks
+func (s *StorageModeTestSuite) advanceToBlock(height int64) {
+	// Get the current height
+	currentHeight := int64(0)
+	currentBlock := s.blockClient.LastBlock(s.ctx)
+	if currentBlock != nil {
+		currentHeight = currentBlock.Height()
+	}
+
+	// Publish blocks until we reach the target height
+	for currentHeight < height {
+		s.blockPublishCh <- testblock.NewAnyTimesBlock(s.T(), s.emptyBlockHash, currentHeight+1)
+		currentHeight++
+	}
+
+	// Wait for I/O operations to complete
+	waitSimulateIO()
+}

--- a/pkg/relayer/session/session_storage_mode_test.go
+++ b/pkg/relayer/session/session_storage_mode_test.go
@@ -113,7 +113,6 @@ func (s *StorageModeTestSuite) SetupTest() {
 		require.NoError(s.T(), err)
 		s.storageDir = tmpStoresDir
 	}
-
 	s.storesDirectoryPathOpt = session.WithStoresDirectoryPath(s.storageDir)
 
 	// Configure test service and difficulty
@@ -169,7 +168,7 @@ func (s *StorageModeTestSuite) TearDownTest() {
 	s.relayerSessionsManager.Stop()
 
 	// Clean up temporary directory for disk storage only
-	if s.storageDir != session.InMemoryStoreFilename && s.storageDir != session.InMemoryPebbleStoreFilename {
+	if !s.isInMemorySMT() {
 		_ = os.RemoveAll(s.storageDir)
 	}
 }
@@ -567,4 +566,8 @@ func (s *StorageModeTestSuite) advanceToBlock(height int64) {
 
 	// Wait for I/O operations to complete
 	waitSimulateIO()
+}
+
+func (s *StorageModeTestSuite) isInMemorySMT() bool {
+	return s.storageDir == session.InMemoryStoreFilename || s.storageDir == session.InMemoryPebbleStoreFilename
 }

--- a/pkg/relayer/session/sessiontree.go
+++ b/pkg/relayer/session/sessiontree.go
@@ -333,7 +333,7 @@ func (st *sessionTree) restoreSessionSMT() (smt.SparseMerkleSumTrie, error) {
 			return sessionSMT, nil
 		}
 		// Should never happen
-		return nil, fmt.Errorf("Cannot restore sessionSMT from SimpleMap store for session %s", st.sessionHeader.SessionId)
+		return nil, fmt.Errorf("cannot restore sessionSMT from SimpleMap store for session %s", st.sessionHeader.SessionId)
 
 	// Restoring from disk storage
 	default:

--- a/pkg/relayer/session/sessiontree.go
+++ b/pkg/relayer/session/sessiontree.go
@@ -89,12 +89,12 @@ func NewSessionTree(
 
 	switch storesDirectoryPath {
 	case InMemoryStoreFilename:
-		// In-memory storage using SimpleMap (pure Go map)
+		// SimpleMap in-memory storage (pure Go map)
 		logger.Info().Msg("⚠️ Using SimpleMap in-memory store for session tree. Data will not be persisted on restart. ⚠️")
 		treeStore = simplemap.NewSimpleMap()
 
 	case InMemoryPebbleStoreFilename:
-		// In-memory storage using Pebble with in-memory VFS
+		// Pebble in-memory storage (with in-memory VFS)
 		logger.Info().Msg("⚠️ Using Pebble in-memory store for session tree. Data will not be persisted on restart. ⚠️")
 		pebbleStore, err := pebble.NewKVStore("") // Empty string triggers in-memory VFS in Pebble
 		if err != nil {
@@ -103,7 +103,7 @@ func NewSessionTree(
 		treeStore = pebbleStore
 
 	default:
-		// Disk-based storage using Pebble
+		// Disk-based persistent storage using Pebble
 		// TODO_IMPROVE(#621): Use a single KV store instead of one per session for better RAM/IO efficiency.
 		// KV databases are optimized for single database writes with prefixed keys.
 		storePath = filepath.Join(storesDirectoryPath, supplierOperatorAddress, sessionHeader.SessionId)
@@ -269,15 +269,9 @@ func (st *sessionTree) ProveClosest(path []byte) (compactProof *smt.SparseCompac
 
 	// Handle restoration differently based on storage type
 	var sessionSMT smt.SparseMerkleSumTrie
-	if st.persistedSMT() {
-		// Disk-based storage: restore KVStore from disk
-		pebbleStore, pebbleErr := pebble.NewKVStore(st.storePath)
-		if pebbleErr != nil {
-			return nil, pebbleErr
-		}
-		st.treeStore = pebbleStore
-		sessionSMT = smt.ImportSparseMerkleSumTrie(st.treeStore, protocol.NewTrieHasher(), st.claimedRoot, protocol.SMTValueHasher())
-	} else if st.isSimpleMapStore() {
+
+	switch st.storePath {
+	case InMemoryStoreFilename:
 		// SimpleMap: sessionSMT should still be available (preserved during Flush)
 		if st.sessionSMT != nil {
 			sessionSMT = st.sessionSMT
@@ -285,7 +279,8 @@ func (st *sessionTree) ProveClosest(path []byte) (compactProof *smt.SparseCompac
 			// Fallback: reimport from the active SimpleMap store
 			sessionSMT = smt.ImportSparseMerkleSumTrie(st.treeStore, protocol.NewTrieHasher(), st.claimedRoot, protocol.SMTValueHasher())
 		}
-	} else if st.isPebbleInMemoryStore() {
+
+	case InMemoryPebbleStoreFilename:
 		// Pebble in-memory: use preserved sessionSMT (can't restore from disk)
 		if st.sessionSMT != nil {
 			sessionSMT = st.sessionSMT
@@ -298,8 +293,15 @@ func (st *sessionTree) ProveClosest(path []byte) (compactProof *smt.SparseCompac
 			st.treeStore = pebbleStore
 			sessionSMT = smt.ImportSparseMerkleSumTrie(st.treeStore, protocol.NewTrieHasher(), st.claimedRoot, protocol.SMTValueHasher())
 		}
-	} else {
-		return nil, fmt.Errorf("unknown storage type for session tree")
+
+	default:
+		// Disk-based persistent storage: restore KVStore from disk
+		pebbleStore, pebbleErr := pebble.NewKVStore(st.storePath)
+		if pebbleErr != nil {
+			return nil, pebbleErr
+		}
+		st.treeStore = pebbleStore
+		sessionSMT = smt.ImportSparseMerkleSumTrie(st.treeStore, protocol.NewTrieHasher(), st.claimedRoot, protocol.SMTValueHasher())
 	}
 
 	// Generate the proof and cache it along with the path for which it was generated.
@@ -360,19 +362,14 @@ func (st *sessionTree) Flush() (SMSTRoot []byte, err error) {
 	st.claimedRoot = st.sessionSMT.Root()
 
 	// Handle different storage types during flush
-	if st.persistedSMT() {
-		// Disk-based storage: stop and clear references (data will be restored from disk)
-		if err := st.Stop(); err != nil {
-			return nil, err
-		}
-		st.treeStore = nil
-		st.sessionSMT = nil
-	} else if st.isSimpleMapStore() {
-		// SimpleMap in-memory: keep everything active (no lifecycle management)
+	switch st.storePath {
+	case InMemoryStoreFilename:
+		// SimpleMap in-memory: keep everything active (no lifecycle management needed)
 		st.logger.Debug().Msg("Not stopping SimpleMap session tree KVStore - keeping data in memory for proof generation.")
-		// Keep both treeStore and sessionSMT references active
-	} else if st.isPebbleInMemoryStore() {
-		// Pebble in-memory: preserve the sessionSMT but stop the store
+		// Keep both treeStore and sessionSMT references active for proof generation
+
+	case InMemoryPebbleStoreFilename:
+		// Pebble in-memory: preserve sessionSMT but stop the store
 		// Unlike disk storage, we can't restore data from "disk" so we need to preserve the SMT
 		if err := st.Stop(); err != nil {
 			return nil, err
@@ -380,6 +377,14 @@ func (st *sessionTree) Flush() (SMSTRoot []byte, err error) {
 		st.treeStore = nil
 		// IMPORTANT: Keep sessionSMT for proof generation since we can't restore from disk
 		st.logger.Debug().Msg("Stopped Pebble in-memory session tree KVStore - preserved sessionSMT for proof generation.")
+
+	default:
+		// Disk-based persistent storage: stop and clear references (data will be restored from disk)
+		if err := st.Stop(); err != nil {
+			return nil, err
+		}
+		st.treeStore = nil
+		st.sessionSMT = nil
 	}
 
 	return st.claimedRoot, nil
@@ -421,17 +426,28 @@ func (st *sessionTree) Delete() error {
 	// This was intentionally removed to lower the IO load.
 	// When the database is closed, it is deleted it from disk right away.
 
+	// Handle stopping the KVStore if it's still active
 	if st.treeStore != nil {
-		// Handle stopping based on storage type
-		if st.persistedSMT() || st.isPebbleInMemoryStore() {
-			// For disk-based or Pebble in-memory stores, call Stop() if it's a PebbleKVStore
+		switch st.storePath {
+		case InMemoryStoreFilename:
+			// SimpleMap stores don't need to be stopped
+
+		case InMemoryPebbleStoreFilename:
+			// Pebble in-memory stores need to be stopped
+			if pebbleStore, ok := st.treeStore.(pebble.PebbleKVStore); ok {
+				if err := pebbleStore.Stop(); err != nil {
+					return err
+				}
+			}
+
+		default:
+			// Disk-based stores need to be stopped
 			if pebbleStore, ok := st.treeStore.(pebble.PebbleKVStore); ok {
 				if err := pebbleStore.Stop(); err != nil {
 					return err
 				}
 			}
 		}
-		// SimpleMap stores don't need to be stopped
 	} else {
 		st.logger.With(
 			"claim_root", fmt.Sprintf("%x", st.GetClaimRoot()),
@@ -439,20 +455,21 @@ func (st *sessionTree) Delete() error {
 	}
 
 	// Handle cleanup based on storage type
-	if st.persistedSMT() {
-		st.logger.Info().Msgf("Deleting session tree KVStore from disk at %s", st.storePath)
-		// Delete the KVStore from disk
-		return os.RemoveAll(st.storePath)
-	} else if st.isSimpleMapStore() {
-		// For SimpleMap, just clear the data
+	switch st.storePath {
+	case InMemoryStoreFilename:
+		// SimpleMap: clear the data from memory
 		st.logger.Info().Msg("Clearing SimpleMap in-memory session tree KVStore.")
 		return st.treeStore.ClearAll()
-	} else if st.isPebbleInMemoryStore() {
-		// For Pebble in-memory, the data is already cleared when stopped
+
+	case InMemoryPebbleStoreFilename:
+		// Pebble in-memory: data is already cleared when stopped
 		st.logger.Info().Msg("Pebble in-memory session tree KVStore already cleared.")
 		return nil
-	} else {
-		return fmt.Errorf("unknown storage type for session tree cleanup")
+
+	default:
+		// Disk-based persistent storage: delete the KVStore from disk
+		st.logger.Info().Msgf("Deleting session tree KVStore from disk at %s", st.storePath)
+		return os.RemoveAll(st.storePath)
 	}
 }
 
@@ -492,31 +509,23 @@ func (st *sessionTree) Stop() error {
 	}
 
 	// Handle stopping based on storage type
-	if st.persistedSMT() || st.isPebbleInMemoryStore() {
-		// For disk-based or Pebble in-memory stores, call Stop() if it's a PebbleKVStore
+	switch st.storePath {
+	case InMemoryStoreFilename:
+		// SimpleMap in-memory storage: no stopping required
+		return nil
+
+	case InMemoryPebbleStoreFilename:
+		// Pebble in-memory storage: call Stop() if it's a PebbleKVStore
 		if pebbleStore, ok := st.treeStore.(pebble.PebbleKVStore); ok {
 			return pebbleStore.Stop()
 		}
+		return nil
+
+	default:
+		// Disk-based persistent storage: call Stop() if it's a PebbleKVStore
+		if pebbleStore, ok := st.treeStore.(pebble.PebbleKVStore); ok {
+			return pebbleStore.Stop()
+		}
+		return nil
 	}
-
-	// For SimpleMap in-memory storage, there's nothing to stop
-	return nil
-}
-
-// persistedSMT returns true if the session tree is persisted to disk (has a storePath),
-// false if it's in-memory only (either SimpleMap or Pebble in-memory).
-func (st *sessionTree) persistedSMT() bool {
-	return st.storePath != "" &&
-		st.storePath != InMemoryStoreFilename &&
-		st.storePath != InMemoryPebbleStoreFilename
-}
-
-// isSimpleMapStore returns true if using SimpleMap in-memory storage.
-func (st *sessionTree) isSimpleMapStore() bool {
-	return st.storePath == InMemoryStoreFilename
-}
-
-// isPebbleInMemoryStore returns true if using Pebble in-memory storage.
-func (st *sessionTree) isPebbleInMemoryStore() bool {
-	return st.storePath == InMemoryPebbleStoreFilename
 }

--- a/pkg/relayer/session/sessiontree.go
+++ b/pkg/relayer/session/sessiontree.go
@@ -391,6 +391,7 @@ func (st *sessionTree) Flush() (SMSTRoot []byte, err error) {
 		}
 		// DEV_NOTE: DO NOT set st.sessionSMT to nil here or proof generation will fail.
 		st.treeStore = nil
+		// st.sessionSMT = nil
 		st.logger.Debug().Msg("Pebble in-memory session tree stopped - sessionSMT preserved for proof generation")
 
 	default:

--- a/pkg/relayer/session/sessiontree.go
+++ b/pkg/relayer/session/sessiontree.go
@@ -104,8 +104,8 @@ func NewSessionTree(
 
 	default:
 		// Treat anything else as disk-based persistent storage using Pebble
-		// TODO_IMPROVE(#621): Use a single KV store instead of one per session for better RAM/IO efficiency.
-		// KV databases are optimized for single database writes with prefixed keys.
+		// TODO_IMPROVE(#621): Use single KV store per supplier with prefixed keys instead of one per session.
+		// This would improve RAM/IO efficiency as KV databases are optimized for this pattern.
 
 		// Validate that this looks like a reasonable file path
 		if storesDirectoryPath == "" {
@@ -296,6 +296,7 @@ func (st *sessionTree) ProveClosest(path []byte) (compactProof *smt.SparseCompac
 				Str("store_path", st.storePath).
 				Str("session_id", st.sessionHeader.SessionId).
 				Str("supplier_operator_address", st.supplierOperatorAddress).
+				Int64("session_end_height", st.sessionHeader.SessionEndBlockHeight).
 				Str("claim_root", fmt.Sprintf("%x", st.claimedRoot)).
 				Msg("🚨🚨🚨 CRITICAL: sessionSMT is NULL for Pebble in-memory store! This indicates the session data was not preserved during Flush()! Attempting fallback but PROOF GENERATION WILL LIKELY FAIL! 🚨🚨🚨")
 


### PR DESCRIPTION
 _tldr Fix: RelayMiner claims creation without proof submission in Pebble in-memory mode_

---

## 🐛 Original Bug

- RelayMiner WAS creating claims
- RelayMiner WAS NOT submitting proof
- This resulted in lost rewards

## ✅ Root Cause

 - **Storage lifecycle mismatch**: Pebble in-memory mode required calling `Stop()` to flush data for claims, but this destroyed the store needed for subsequent proof generation.
 - **SimpleMap** didn't have this issue since it doesn't require explicit lifecycle management.

## 🔧 Solution

### 1. Dual Storage Mode Support

  - `:memory:` - Uses SimpleMap (pure Go map, recommended)
  - `:memory_pebble: `- Uses Pebble with in-memory VFS (experimental)

### 2. Smart Session Lifecycle Management

  - `SimpleMap`: Keep data in memory throughout the lifecycle
  - `Pebble in-memory`: Preserve session metadata after Stop() for proof generation
  - `Disk storage`: Restore data from disk as needed (unchanged)

### 3. Clean Architecture Refactoring

  - Replaced complex conditional chains with clear switch statements based on storage path
  - Enhanced logging with storage-mode-specific messages
  - Updated documentation to reflect dual in-memory support

##  📊 Impact

  - ✅ Bug Fixed: Pebble in-memory mode now successfully submits proofs
  - ✅ Performance: SimpleMap provides optimal in-memory performance
  - ✅ Flexibility: Users can choose storage modes based on needs
  - ✅ Reliability: Comprehensive test coverage prevents regressions