### PR TITLE
fix: --network flag not working

### DIFF
--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -91,6 +91,8 @@ func setNetworkRelatedFlags(cmd *cobra.Command, chainId, nodeUrl, grpcAddr, grpc
 			if err := chainIDFlag.Value.Set(chainId); err != nil {
 				return err
 			}
+			// Mark the flag as changed so Cosmos SDK recognizes the new value
+			chainIDFlag.Changed = true
 		}
 	}
 
@@ -100,6 +102,8 @@ func setNetworkRelatedFlags(cmd *cobra.Command, chainId, nodeUrl, grpcAddr, grpc
 			if err := nodeFlag.Value.Set(nodeUrl); err != nil {
 				return err
 			}
+			// Mark the flag as changed so Cosmos SDK recognizes the new value
+			nodeFlag.Changed = true
 		}
 	}
 
@@ -109,6 +113,8 @@ func setNetworkRelatedFlags(cmd *cobra.Command, chainId, nodeUrl, grpcAddr, grpc
 			if err := grpcFlag.Value.Set(grpcAddr); err != nil {
 				return err
 			}
+			// Mark the flag as changed so Cosmos SDK recognizes the new value
+			grpcFlag.Changed = true
 		}
 	}
 
@@ -118,6 +124,8 @@ func setNetworkRelatedFlags(cmd *cobra.Command, chainId, nodeUrl, grpcAddr, grpc
 			if err := grpcInsecureFlag.Value.Set(grpcInsecure); err != nil {
 				return err
 			}
+			// Mark the flag as changed so Cosmos SDK recognizes the new value
+			grpcInsecureFlag.Changed = true
 		}
 	}
 
@@ -127,6 +135,8 @@ func setNetworkRelatedFlags(cmd *cobra.Command, chainId, nodeUrl, grpcAddr, grpc
 			if err := faucetBaseURLFlag.Value.Set(faucetBaseUrl); err != nil {
 				return err
 			}
+			// Mark the flag as changed so Cosmos SDK recognizes the new value
+			faucetBaseURLFlag.Changed = true
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fix a bug causing the --network flag to be ineffective.

## Issue

- N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
