### PR TITLE
[Testing] fix: flags test

### DIFF
--- a/cmd/rpc_test.go
+++ b/cmd/rpc_test.go
@@ -62,21 +62,6 @@ func testRunE(cmd *cobra.Command, _ []string) error {
 }
 
 func TestNetworkRelatedFlags(t *testing.T) {
-	testCmd := &cobra.Command{
-		Use:     "test",
-		Short:   "Test",
-		Long:    `Test`,
-		PreRunE: testPreRunE,
-		RunE:    testRunE,
-	}
-
-	// Register relevant flags for testing, defaulting to empty values.
-	testCmd.Flags().String(flags.FlagNetwork, "", "network flag")
-	testCmd.Flags().String(cosmosflags.FlagGRPC, "", "grpc addr flag")
-	testCmd.Flags().String(cosmosflags.FlagGRPCInsecure, "", "grpc insecure flag")
-	testCmd.Flags().String(flags.FlagFaucetBaseURL, "", "faucet base url flag")
-	cosmosflags.AddTxFlagsToCmd(testCmd)
-
 	testCases := []struct {
 		networkFlagValue               string
 		expectedChainIDFlagValue       string
@@ -122,15 +107,28 @@ func TestNetworkRelatedFlags(t *testing.T) {
 	for _, test := range testCases {
 		desc := fmt.Sprintf("with %q network flag value", test.networkFlagValue)
 		t.Run(desc, func(t *testing.T) {
-			// Set flags and execute as if invoked from the command line.
-			err := testCmd.Flag(flags.FlagNetwork).Value.Set("test")
-			require.NoError(t, err)
+			// Create a fresh command for each test to avoid flag state pollution
+			testCmd := &cobra.Command{
+				Use:     "test",
+				Short:   "Test",
+				Long:    `Test`,
+				PreRunE: testPreRunE,
+				RunE:    testRunE,
+			}
 
+			// Register relevant flags for testing, defaulting to empty values.
+			testCmd.Flags().String(flags.FlagNetwork, "", "network flag")
+			testCmd.Flags().String(cosmosflags.FlagGRPC, "", "grpc addr flag")
+			testCmd.Flags().String(cosmosflags.FlagGRPCInsecure, "", "grpc insecure flag")
+			testCmd.Flags().String(flags.FlagFaucetBaseURL, "", "faucet base url flag")
+			cosmosflags.AddTxFlagsToCmd(testCmd)
+
+			// Set flags and execute as if invoked from the command line.
 			testCmd.SetArgs([]string{
 				fmt.Sprintf("--%s=%s", flags.FlagNetwork, test.networkFlagValue),
 			})
 
-			err = testCmd.ExecuteContext(t.Context())
+			err := testCmd.ExecuteContext(t.Context())
 			require.NoError(t, err)
 
 			t.Logf("test log buffer:\n%s", testLogBuffer.String())


### PR DESCRIPTION
## Summary

Fix the flag tests in cmd/rpc_test.go, broken in #1765.

TL;DR, the test command needs to be reset in-between test cases.

## Issue

- N/A

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
