### PR TITLE
chore: remove unused min func

### DIFF
--- a/tools/iavl-tree-diff/main.go
+++ b/tools/iavl-tree-diff/main.go
@@ -148,12 +148,6 @@ func getLatestVersion(dir string, prefix string) (int64, error) {
 	return tree.Version(), nil
 }
 
-func min(a, b int64) int64 {
-	if a < b {
-		return a
-	}
-	return b
-}
 
 func ReadTree(dir string, version int64, prefix []byte) (*iavl.MutableTree, dbm.DB, error) {
 	db, err := OpenDB(dir)


### PR DESCRIPTION
## Summary

Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in function with the same names. 


You can use the following as input for an LLM of your choice to autogenerate a summary (ignoring any additional files needed):

```bash
git --no-pager diff main  -- ':!*.pb.go' ':!*.json' ':!*.yaml' ':!*.yml' ':!*.gif' ':!*.lock' | diff2html -s side --format json -i stdin -o stdout | pbcopy
```

### Primary Changes:

- < Change 1 >
- < Change 2 >

### Secondary Changes:

- < Change 1 >
- < Change 2 >

## Issue

- Issue_or_PR: #{ISSUE_OR_PR_NUMBER}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
