### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,43 @@ For technical documentation, visit [dev.poktroll.com](https://dev.poktroll.com).
 Documentation is maintained in the [docusaurus repo](./docusaurus) and is
 automatically deployed to the link above.
 
+# Prerequisites
+
+```bash
+# Install required tools
+brew install gnu-sed
+brew install grep
+brew install yq
+brew install kind
+brew install tilt
+
+# Verify Go version (must be 1.23.x, NOT 1.24+)
+go version
+# Expected output: go1.23.12 darwin/arm64 
+
+```
+
+
+
+# Quickstart (Localnet)
+```
+# Start the local network
+make localnet_up
+
+# Initialize accounts (required for relays & tests)
+make acc_initialize_pubkeys POCKET_NODE=http://localhost:26657
+```
+Troubleshooting
+
+If you see this error:
+
+It usually means you forgot to run the make acc_initialize_pubkeys step.
+```
+
+
+
 ## License
 
-This project is licensed under the MIT License; see the [LICENSE](https://github.com/pokt-network/poktroll/blob/main/LICENSE) file for details.
+This project is licensed under the MIT License.  
+See the [LICENSE](https://github.com/pokt-network/poktroll/blob/main/LICENSE) file for details.
+

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ make acc_initialize_pubkeys POCKET_NODE=http://localhost:26657
 ```
 Troubleshooting
 
-If you see this error:
+If you see this error:"Failed to receive any response from endpoints..."
 
 It usually means you forgot to run the make acc_initialize_pubkeys step.
 ```


### PR DESCRIPTION
## Summary

< Improve onboarding instructions by updating the README.md with clear prerequisites, quickstart steps, and troubleshooting notes for running make localnet_up.>



```bash
git --no-pager diff main  -- ':!*.pb.go' ':!*.json' ':!*.yaml' ':!*.yml' ':!*.gif' ':!*.lock' | diff2html -s side --format json -i stdin -o stdout | pbcopy
```

### Primary Changes:

- < Added Prerequisites section listing required tools (gnu-sed, grep, yq, kind, tilt) and the correct Go version (1.23.x).>
- < Added Quickstart (Localnet) section with commands to spin up the network and initialize accounts. >

### Secondary Changes:

- < Added a Troubleshooting note for the common relay error when make acc_initialize_pubkeys is not run. >


## Issue

- Issue_or_PR: #{N/A}

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ >] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ >] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ >] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ >] 'TODO's, configurations and other docs
