### PR TITLE
[Code health] Fix `IsSessionEndHeight`

### DIFF
--- a/x/application/keeper/unbond_applications.go
+++ b/x/application/keeper/unbond_applications.go
@@ -19,7 +19,7 @@ func (k Keeper) EndBlockerUnbondApplications(ctx context.Context) error {
 	currentHeight := sdkCtx.BlockHeight()
 
 	// Only process unbonding applications at the end of the session.
-	if sharedtypes.IsSessionEndHeight(&sharedParams, currentHeight) {
+	if !sharedtypes.IsSessionEndHeight(&sharedParams, currentHeight) {
 		return nil
 	}
 

--- a/x/gateway/keeper/unbond_gateways.go
+++ b/x/gateway/keeper/unbond_gateways.go
@@ -19,7 +19,7 @@ func (k Keeper) EndBlockerUnbondGateways(ctx context.Context) (numUnbondedGatewa
 	currentHeight := sdkCtx.BlockHeight()
 
 	// Only process unbonding gateways at the end of the session.
-	if sharedtypes.IsSessionEndHeight(&sharedParams, currentHeight) {
+	if !sharedtypes.IsSessionEndHeight(&sharedParams, currentHeight) {
 		return numUnbondedGateways, nil
 	}
 

--- a/x/shared/types/session.go
+++ b/x/shared/types/session.go
@@ -158,7 +158,7 @@ func GetNextSessionStartHeight(sharedParams *Params, queryHeight int64) int64 {
 
 // IsSessionEndHeight returns true if the queryHeight is the last block of the session.
 func IsSessionEndHeight(sharedParams *Params, queryHeight int64) bool {
-	return queryHeight != GetSessionEndHeight(sharedParams, queryHeight)
+	return queryHeight == GetSessionEndHeight(sharedParams, queryHeight)
 }
 
 // IsSessionStartHeight returns true if the height is the first block of the session.

--- a/x/supplier/keeper/unbond_suppliers.go
+++ b/x/supplier/keeper/unbond_suppliers.go
@@ -17,7 +17,7 @@ func (k Keeper) EndBlockerUnbondSuppliers(ctx context.Context) (numUnbondedSuppl
 	currentHeight := sdkCtx.BlockHeight()
 
 	// Only process unbonding suppliers at the end of the session.
-	if sharedtypes.IsSessionEndHeight(&sharedParams, currentHeight) {
+	if !sharedtypes.IsSessionEndHeight(&sharedParams, currentHeight) {
 		return numUnbondedSuppliers, nil
 	}
 


### PR DESCRIPTION
Minor fix whereby `IsSessionEndHeight` was being incorrectly used.