### PR TITLE
[SCRIPTS][SERVICE][APPLICATION][KEYS] Adding helper scripts from `pocket-knife` to `poktroll`

### DIFF
--- a/tools/scripts/add-update-services.sh
+++ b/tools/scripts/add-update-services.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+# Script to add or modify services on Pocket Network
+# Usage: ./add-services.sh [OPTIONS] <SERVICES_FILE> <NETWORK> <ADDRESS> [HOME_DIR]
+# Example: ./add-services.sh services.txt beta my-key
+# Example: ./add-services.sh services.txt main my-key ~/.poktroll
+
+# Function to display help
+show_help() {
+    echo "Usage: $0 [OPTIONS] <SERVICES_FILE> <NETWORK> <ADDRESS> [HOME_DIR]"
+    echo
+    echo "Add or modify services on Pocket Network using pocketd from a tab-separated or whitespace-separated file"
+    echo
+    echo "Arguments:"
+    echo "  SERVICES_FILE  Path to tab-separated or whitespace-separated file with columns: service_id, service_description, CUTTM"
+    echo "  NETWORK        Network to use: 'main' or 'beta'"
+    echo "                 - main: https://shannon-grove-rpc.mainnet.poktroll.com (pocket)"
+    echo "                 - beta: https://shannon-testnet-grove-rpc.beta.poktroll.com (pocket-beta)"
+    echo "  ADDRESS        Address/key name for the --from flag (e.g., my-key)"
+    echo "  HOME_DIR       Directory path for the --home flag (default: ~/.pocket)"
+    echo
+    echo "Options:"
+    echo "  --dry-run      Show commands that would be executed without running them"
+    echo "  -h, --help     Show this help message and exit"
+    echo
+    echo "Services file format (tab-separated or whitespace-separated):"
+    echo "  service_id<TAB>service_description<TAB>CUTTM"
+    echo "  OR"
+    echo "  service_id service_description CUTTM"
+    echo "  Example:"
+    echo "    eth	Ethereum	1"
+    echo "    bitcoin	Bitcoin	2"
+    echo "    polygon \"Polygon Network\" 3"
+    echo
+    echo "IMPORTANT: Check current fees for adding/modifying services by running:"
+    echo "  pocketd query service params --node <NODE_URL>"
+    echo "  This script uses a default fee of 20000upokt which may not be current."
+    echo
+    echo "Example:"
+    echo "  $0 services.txt beta my-key"
+    echo "  $0 services.txt main my-key ~/.poktroll"
+    echo "  $0 --dry-run services.txt beta my-key"
+    echo
+}
+
+# Initialize variables
+DRY_RUN=false
+
+# Parse options
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        -*)
+            echo "Error: Unknown option $1"
+            echo
+            show_help
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+# Check if minimum required arguments are provided
+if [ $# -lt 3 ]; then
+  echo "Error: Missing required arguments"
+  echo
+  show_help
+  exit 1
+fi
+
+# Assign arguments to variables
+SERVICES_FILE=$1
+NETWORK=$2
+ADDRESS=$3
+HOME_DIR=${4:-~/.pocket}
+
+# Validate network and set corresponding values
+case $NETWORK in
+    main)
+        NODE_URL="https://shannon-grove-rpc.mainnet.poktroll.com"
+        CHAIN_ID="pocket"
+        ;;
+    beta)
+        NODE_URL="https://shannon-testnet-grove-rpc.beta.poktroll.com"
+        CHAIN_ID="pocket-beta"
+        ;;
+    *)
+        echo "Error: Invalid network '$NETWORK'. Must be 'main' or 'beta'"
+        exit 1
+        ;;
+esac
+
+# Check if services file exists
+if [ ! -f "$SERVICES_FILE" ]; then
+    echo "Error: Services file '$SERVICES_FILE' not found"
+    exit 1
+fi
+
+# Check if services file is readable
+if [ ! -r "$SERVICES_FILE" ]; then
+    echo "Error: Cannot read services file '$SERVICES_FILE'"
+    exit 1
+fi
+
+# Display configuration
+if [ "$DRY_RUN" = true ]; then
+    echo "DRY RUN MODE - Commands will be displayed but not executed"
+    echo ""
+fi
+
+echo "Adding or modifying services on Pocket Network using pocketd..."
+echo "Using SERVICES_FILE: $SERVICES_FILE"
+echo "Using NETWORK: $NETWORK"
+echo "Using NODE: $NODE_URL"
+echo "Using CHAIN_ID: $CHAIN_ID"
+echo "Using HOME: $HOME_DIR"
+echo "Using ADDRESS: $ADDRESS"
+echo ""
+
+# Counter for tracking services
+service_count=0
+success_count=0
+error_count=0
+
+# Read the services file and process each line
+while IFS=$'\t' read -r service_id service_description cuttm || [[ -n "$service_id" ]]; do
+    # Skip empty lines and lines starting with #
+    if [[ -z "$service_id" || "$service_id" =~ ^[[:space:]]*# ]]; then
+        continue
+    fi
+    
+    # If tab parsing didn't work (no tabs), try space parsing
+    if [[ -z "$service_description" || -z "$cuttm" ]]; then
+        # Fall back to space-separated parsing for lines without tabs
+        read -r service_id service_description cuttm <<< "$service_id"
+    fi
+    
+    # Skip if we don't have all required fields
+    if [[ -z "$service_id" || -z "$service_description" || -z "$cuttm" ]]; then
+        echo "Warning: Skipping invalid line: $service_id $service_description $cuttm"
+        continue
+    fi
+    
+    # Increment counter
+    ((service_count++))
+    
+    # Build the command
+    cmd="pocketd tx service add-service \"$service_id\" \"$service_description\" $cuttm --node $NODE_URL --fees 20000upokt --from $ADDRESS --chain-id $CHAIN_ID --home $HOME_DIR --unordered --timeout-duration=60s --yes"
+    
+    if [ "$DRY_RUN" = true ]; then
+        echo "[$service_count] $cmd"
+    else
+        echo "[$service_count] Adding/modifying service: $service_id ($service_description) with CUTTM: $cuttm"
+        
+        # Capture the command output
+        output=$(eval $cmd 2>&1)
+        exit_code=$?
+        
+        # Check if the command succeeded and doesn't contain meaningful raw_log (which indicates an error)
+        if [ $exit_code -eq 0 ] && (! echo "$output" | grep -q "raw_log" || echo "$output" | grep -q 'raw_log: ""'); then
+            ((success_count++))
+            echo "  ✅ Success"
+            # Extract and display transaction hash
+            tx_hash=$(echo "$output" | grep -o 'txhash: [A-Fa-f0-9]*' | cut -d' ' -f2)
+            if [ -n "$tx_hash" ]; then
+                echo "  Transaction hash: $tx_hash"
+            fi
+        else
+            ((error_count++))
+            echo "  ❌ Failed"
+            if echo "$output" | grep -q "raw_log" && ! echo "$output" | grep -q 'raw_log: ""'; then
+                echo "  Error details: $(echo "$output" | grep "raw_log" | head -1)"
+            elif [ $exit_code -ne 0 ]; then
+                echo "  Command failed with exit code: $exit_code"
+                # Show some of the error output for debugging
+                echo "  Error output: $(echo "$output" | head -3 | tr '\n' ' ')"
+            fi
+        fi
+        echo ""
+        
+        # Wait 5 seconds between each transaction with a loader animation
+        echo "  Waiting 5 seconds before next transaction..."
+        for i in {1..5}; do
+            printf "\r  [%d/5] %s" $i "$(printf '%*s' $((i % 4 + 1)) | tr ' ' '|/-\\')"
+            sleep 1
+        done
+        printf "\r  [5/5] ✓ Ready for next transaction\n"
+    fi
+    
+done < "$SERVICES_FILE"
+
+# Display summary
+echo ""
+echo "Summary:"
+echo "  Total services processed: $service_count"
+if [ "$DRY_RUN" = false ]; then
+    echo "  Successful operations: $success_count"
+    echo "  Failed operations: $error_count"
+fi
+
+if [ "$DRY_RUN" = true ]; then
+    echo ""
+    echo "DRY RUN completed. Use the script without --dry-run to execute the commands."
+elif [ $error_count -gt 0 ]; then
+    echo ""
+    echo "Some services failed to be added/modified. Please check the output above for details."
+    exit 1
+else
+    echo ""
+    echo "All services have been added/modified successfully!"
+fi

--- a/tools/scripts/export-keys.sh
+++ b/tools/scripts/export-keys.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+
+show_help() {
+    cat << EOF
+🔐 Key Export Script 🔐
+
+Usage: $0 <keyfile> [OPTIONS]
+
+Export keys from a file containing a list of keynames or addresses.
+
+⚠️  🚨 CRITICAL SECURITY WARNING 🚨 ⚠️
+This script exports UNENCRYPTED PRIVATE KEYS in plain text format!
+The exported keys will be displayed in your terminal and may be:
+- 👀 Visible to anyone looking at your screen
+- 📝 Logged in your shell history
+- 💾 Saved in terminal scrollback buffers
+- 🔍 Accessible to other processes on your system
+
+ONLY use this script if you:
+- 🧠 Fully understand the security implications
+- 🔒 Are in a secure, private environment
+- 🎯 Have a specific need for raw key material
+- 💪 Are confident in handling private keys safely
+
+❌ DO NOT use this script on shared/public computers!
+❌ DO NOT use this script over remote connections!
+❌ DO NOT leave exported keys in terminal history!
+
+Arguments:
+    <keyfile> 📄   Path to file containing keynames or addresses (one per line)
+
+Options:
+    -h, --help 🆘                    Show this help message
+    --keyring-backend <backend>      Select keyring's backend (os|file|kwallet|pass|test|memory)
+    --output <format> 📊             Output format (raw|file)
+                                     • raw: Private keys only, one per line
+                                     • file: Raw keys to file (requires --file)
+    -f, --file <path> 📝             Output file path (required for file)
+
+Examples:
+    $0 keys.txt 📁
+    $0 keys.txt --output raw 🔢
+    $0 keys.txt --output file --file exported_keys.txt 📄
+    $0 keys.txt --keyring-backend file --output raw 🗂️
+
+The keyfile should contain one keyname per line, e.g.:
+    big-wallet2
+    eth-app3
+    company-gateway
+
+🔒 Remember: With great keys comes great responsibility! 🔒
+
+EOF
+}
+
+# Initialize variables
+KEYFILE=""
+KEYRING_BACKEND=""
+OUTPUT_FORMAT="default"
+OUTPUT_FILE=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        --keyring-backend)
+            if [[ -n "$2" ]]; then
+                KEYRING_BACKEND="$2"
+                shift 2
+            else
+                echo "❌ Error: --keyring-backend requires a value"
+                exit 1
+            fi
+            ;;
+        --output)
+            if [[ -n "$2" ]]; then
+                case "$2" in
+                    raw|file)
+                        OUTPUT_FORMAT="$2"
+                        shift 2
+                        ;;
+                    *)
+                        echo "❌ Error: Invalid output format '$2'. Valid options: raw, file"
+                        exit 1
+                        ;;
+                esac
+            else
+                echo "❌ Error: --output requires a value (raw|file)"
+                exit 1
+            fi
+            ;;
+        -f|--file)
+            if [[ -n "$2" ]]; then
+                OUTPUT_FILE="$2"
+                shift 2
+            else
+                echo "❌ Error: --file requires a file path"
+                exit 1
+            fi
+            ;;
+        *)
+            if [[ -z "$KEYFILE" ]]; then
+                KEYFILE="$1"
+                shift
+            else
+                echo "❌ Error: Unknown argument '$1'"
+                echo "💡 Use -h or --help for usage information"
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+# Check if file argument is provided
+if [[ -z "$KEYFILE" ]]; then
+    echo "❌ Error: No keyfile provided"
+    echo "💡 Use -h or --help for usage information"
+    exit 1
+fi
+
+# Check if file exists
+if [[ ! -f "$KEYFILE" ]]; then
+    echo "❌ Error: File '$KEYFILE' not found"
+    exit 1
+fi
+
+# Check if file is readable
+if [[ ! -r "$KEYFILE" ]]; then
+    echo "❌ Error: File '$KEYFILE' is not readable"
+    exit 1
+fi
+
+# Validate file output requirements
+if [[ "$OUTPUT_FORMAT" == "file" ]]; then
+    if [[ -z "$OUTPUT_FILE" ]]; then
+        echo "❌ Error: --file is required when using --output file"
+        exit 1
+    fi
+fi
+
+# Clear output file if using file output mode
+if [[ "$OUTPUT_FORMAT" == "file" ]]; then
+    > "$OUTPUT_FILE"
+    echo "📝 Writing keys to: $OUTPUT_FILE"
+fi
+
+# Count total keys to export
+total_keys=0
+while IFS= read -r line || [[ -n "$line" ]]; do
+    # Skip empty lines and lines starting with #
+    if [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]]; then
+        continue
+    fi
+    ((total_keys++))
+done < "$KEYFILE"
+
+# Show summary for raw output
+if [[ "$OUTPUT_FORMAT" == "raw" ]]; then
+    echo "🔑 Exporting $total_keys keys..." >&2
+fi
+
+# Read file and export each key
+while IFS= read -r keyname || [[ -n "$keyname" ]]; do
+    # Skip empty lines and lines starting with #
+    if [[ -z "$keyname" || "$keyname" =~ ^[[:space:]]*# ]]; then
+        continue
+    fi
+
+    # Trim whitespace
+    keyname=$(echo "$keyname" | xargs)
+
+    # Show progress for non-raw modes
+    if [[ "$OUTPUT_FORMAT" != "raw" ]]; then
+        echo "🔑 Exporting key: $keyname"
+    fi
+
+    # Build the export command with optional keyring backend
+    export_cmd="pocketd keys export \"$keyname\" --unsafe --unarmored-hex --yes"
+    if [[ -n "$KEYRING_BACKEND" ]]; then
+        export_cmd="$export_cmd --keyring-backend $KEYRING_BACKEND"
+    fi
+
+    # Execute the export command and capture output
+    private_key=$(eval "$export_cmd" 2>/dev/null)
+
+    # Check if export was successful
+    if [[ $? -ne 0 || -z "$private_key" ]]; then
+        echo "❌ Failed to export key: $keyname" >&2
+        continue
+    fi
+
+    # Handle different output formats
+    case "$OUTPUT_FORMAT" in
+        "raw")
+            echo "$private_key"
+            ;;
+        "file")
+            echo "$private_key" >> "$OUTPUT_FILE"
+            ;;
+        "default")
+            # Default behavior - show the full pocketd output
+            eval "$export_cmd"
+            ;;
+    esac
+done < "$KEYFILE"

--- a/tools/scripts/import-keys.sh
+++ b/tools/scripts/import-keys.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+
+show_help() {
+    cat << EOF
+🔐 Key Import Script 🔐
+
+Usage: $0 <keyfile> [OPTIONS]
+
+Import private keys from a file containing hex private keys and names.
+
+⚠️  🚨 CRITICAL SECURITY WARNING 🚨 ⚠️
+This script imports UNENCRYPTED PRIVATE KEYS from plain text format!
+The private keys in your file are sensitive and should be:
+- 🔒 Stored securely and privately
+- 🗑️  Deleted after import if no longer needed
+- 👀 Never shared or exposed publicly
+- 💾 Backed up safely before import
+
+ONLY use this script if you:
+- 🧠 Fully understand the security implications
+- 🔒 Are in a secure, private environment
+- 🎯 Have verified the private keys are valid
+- 💪 Trust the source of the private keys
+
+❌ DO NOT use this script on shared/public computers!
+❌ DO NOT use this script over remote connections!
+❌ DO NOT leave private keys in plain text files!
+
+Arguments:
+    <keyfile> 📄   Path to file containing private keys and names
+
+Options:
+    -h, --help 🆘                    Show this help message
+    --keyring-backend <backend>      Select keyring's backend (os|file|kwallet|pass|test|memory)
+    --key-type <type>               Private key signing algorithm (default: secp256k1)
+
+Examples:
+    $0 keys.txt 📁
+    $0 keys.txt --keyring-backend file 🗂️
+    $0 keys.txt --keyring-backend os --key-type secp256k1 💻
+
+The keyfile should contain one private key and name per line:
+    a1b2c3d4e5f6... big-wallet2
+    f6e5d4c3b2a1... eth-app3
+    1a2b3c4d5e6f... company-gateway
+
+🔒 Remember: Secure key management is critical! 🔒
+
+EOF
+}
+
+# Initialize variables
+KEYFILE=""
+KEYRING_BACKEND=""
+KEY_TYPE="secp256k1"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        --keyring-backend)
+            if [[ -n "$2" ]]; then
+                KEYRING_BACKEND="$2"
+                shift 2
+            else
+                echo "❌ Error: --keyring-backend requires a value"
+                exit 1
+            fi
+            ;;
+        --key-type)
+            if [[ -n "$2" ]]; then
+                KEY_TYPE="$2"
+                shift 2
+            else
+                echo "❌ Error: --key-type requires a value"
+                exit 1
+            fi
+            ;;
+        *)
+            if [[ -z "$KEYFILE" ]]; then
+                KEYFILE="$1"
+                shift
+            else
+                echo "❌ Error: Unknown argument '$1'"
+                echo "💡 Use -h or --help for usage information"
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+# Check if file argument is provided
+if [[ -z "$KEYFILE" ]]; then
+    echo "❌ Error: No keyfile provided"
+    echo "💡 Use -h or --help for usage information"
+    exit 1
+fi
+
+# Check if file exists
+if [[ ! -f "$KEYFILE" ]]; then
+    echo "❌ Error: File '$KEYFILE' not found"
+    exit 1
+fi
+
+# Check if file is readable
+if [[ ! -r "$KEYFILE" ]]; then
+    echo "❌ Error: File '$KEYFILE' is not readable"
+    exit 1
+fi
+
+# Check dependencies
+if ! command -v pocketd &> /dev/null; then
+    echo "❌ Error: pocketd command not found"
+    exit 1
+fi
+
+# Count total keys to import
+total_keys=0
+while IFS= read -r line || [[ -n "$line" ]]; do
+    # Skip empty lines and lines starting with #
+    if [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]]; then
+        continue
+    fi
+    ((total_keys++))
+done < "$KEYFILE"
+
+echo "🔑 Importing $total_keys keys..."
+echo "📁 Reading from: $KEYFILE"
+if [[ -n "$KEYRING_BACKEND" ]]; then
+    echo "🗂️  Using keyring backend: $KEYRING_BACKEND"
+fi
+echo "🔐 Using key type: $KEY_TYPE"
+echo ""
+
+# Initialize counters
+imported_count=0
+failed_count=0
+skipped_count=0
+
+# Read file and import each key
+while IFS= read -r line || [[ -n "$line" ]]; do
+    # Skip empty lines and lines starting with #
+    if [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]]; then
+        continue
+    fi
+
+    # Parse line: <private_key> <name>
+    if [[ "$line" =~ ^([a-fA-F0-9]+)[[:space:]]+(.+)$ ]]; then
+        private_key="${BASH_REMATCH[1]}"
+        keyname="${BASH_REMATCH[2]}"
+
+        # Trim whitespace from keyname
+        keyname=$(echo "$keyname" | xargs)
+
+        echo "🔑 Importing key: $keyname"
+
+        # Build the import command with optional keyring backend
+        import_cmd="pocketd keys import-hex \"$keyname\" \"$private_key\""
+        if [[ -n "$KEYRING_BACKEND" ]]; then
+            import_cmd="$import_cmd --keyring-backend $KEYRING_BACKEND"
+        fi
+        if [[ -n "$KEY_TYPE" ]]; then
+            import_cmd="$import_cmd --key-type $KEY_TYPE"
+        fi
+
+        # Execute the import command
+        if eval "$import_cmd" 2>/dev/null; then
+            echo "✅ Successfully imported: $keyname"
+            ((imported_count++))
+        else
+            echo "❌ Failed to import: $keyname"
+            ((failed_count++))
+        fi
+        echo ""
+    else
+        echo "⚠️  Skipping invalid line format: $line"
+        ((skipped_count++))
+    fi
+done < "$KEYFILE"
+
+echo "========================================="
+echo "📊 Import Summary:"
+echo "✅ Successfully imported: $imported_count"
+echo "❌ Failed imports: $failed_count"
+echo "⚠️  Skipped lines: $skipped_count"
+echo "📈 Total processed: $((imported_count + failed_count + skipped_count))"
+echo "========================================="
+
+# Exit with appropriate code
+if [[ $failed_count -gt 0 ]]; then
+    exit 1
+else
+    exit 0
+fi

--- a/tools/scripts/stake-apps.sh
+++ b/tools/scripts/stake-apps.sh
@@ -1,0 +1,536 @@
+#!/bin/bash
+
+# Pocket Shannon Application Staking Script
+# This script stakes applications on the Pocket network
+# Usage: ./stake-apps.sh <address> <amount> <service_id> [flags]
+#        ./stake-apps.sh --file <file> [flags]
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_color() {
+    printf "${1}${2}${NC}\n"
+}
+
+# Function to show usage and help
+show_help() {
+    cat << EOF
+$(print_color $BLUE "Pocket Shannon Application Staking Script")
+
+$(print_color $YELLOW "USAGE:")
+    Single mode:  $0 <address> <amount> <service_id> [OPTIONS]
+    Batch mode:   $0 --file <file> [OPTIONS]
+
+$(print_color $YELLOW "ARGUMENTS (Single mode):")
+    address         Application address to stake from
+    amount          Amount to stake (without upokt suffix)
+    service_id      Service ID to stake for
+
+$(print_color $YELLOW "OPTIONS:")
+    --file FILE, -f FILE           Batch stake from file (format: address service_id amount per line)
+    --delegate GATEWAY_ADDR        Delegate to gateway after staking (60s delay)
+    --dry-run                     Show commands that would be executed without running them
+    --node RPC_ENDPOINT           Custom RPC endpoint for pocketd
+    --home DIR                    Home directory for pocketd (pocketd default if not specified)
+    --keyring-backend BACKEND     Keyring backend (pocketd default if not specified)
+    --chain-id CHAIN              Chain ID (default: pocket)
+    --help, -h                    Show this help message
+
+$(print_color $YELLOW "EXAMPLES:")
+    Single stake:
+    $0 pokt1abc123... 1000000 anvil
+
+    Single stake with custom flags:
+    $0 pokt1abc123... 1000000 anvil --node https://rpc.pocket.network --chain-id mainnet
+
+    Batch stake from file:
+    $0 --file stakes.txt
+
+    Stake and delegate:
+    $0 pokt1abc123... 1000000 anvil --delegate pokt1gateway456...
+
+    Dry run:
+    $0 pokt1abc123... 1000000 anvil --dry-run
+
+    Batch dry run:
+    $0 --file stakes.txt --dry-run
+
+$(print_color $YELLOW "FILE FORMAT (for --file option):")
+    Each line should contain: address service_id amount
+    Example:
+    pokt1abc123... anvil 1000000
+    pokt1def456... ethereum 2000000
+    pokt1ghi789... polygon 1500000
+
+$(print_color $RED "NOTES:")
+    - Amount should be specified without 'upokt' suffix (will be added automatically)
+    - Fees of 200000upokt are automatically added to stake commands
+    - Delegation fees of 20000upokt are automatically added to delegate commands
+    - 60 second delay is enforced between staking and delegation
+EOF
+}
+
+# Initialize variables
+address=""
+amount=""
+service_id=""
+file_path=""
+delegate_addr=""
+node_flag=""
+home_dir=""
+keyring_backend=""
+chain_id="pocket"
+dry_run=false
+
+# Function to build pocketd flags
+build_pocketd_flags() {
+    local flags=""
+    
+    if [[ -n $node_flag ]]; then
+        flags="$flags --node=$node_flag"
+    fi
+    
+    if [[ -n $home_dir ]]; then
+        flags="$flags --home=$home_dir"
+    fi
+    
+    if [[ -n $keyring_backend ]]; then
+        flags="$flags --keyring-backend=$keyring_backend"
+    fi
+    
+    flags="$flags --chain-id=$chain_id"
+    
+    echo "$flags"
+}
+
+# Function to create stake config file
+create_stake_config() {
+    local stake_amount="$1"
+    local stake_service_id="$2"
+    local config_file="/tmp/stake_app_config.yaml"
+    
+    if [[ "$dry_run" == true ]]; then
+        print_color $YELLOW "🔍 [DRY RUN] Would create stake configuration file: $config_file"
+        print_color $BLUE "📄 Config content would be:"
+        cat <<🚀
+stake_amount: ${stake_amount}upokt
+service_ids:
+  - "${stake_service_id}"
+🚀
+        return 0
+    fi
+    
+    print_color $BLUE "📝 Creating stake configuration file..."
+    
+    cat <<🚀 > "$config_file"
+stake_amount: ${stake_amount}upokt
+service_ids:
+  - "${stake_service_id}"
+🚀
+
+    if [[ $? -eq 0 ]]; then
+        print_color $GREEN "✅ Configuration file created successfully: $config_file"
+        return 0
+    else
+        print_color $RED "❌ Failed to create configuration file"
+        return 1
+    fi
+}
+
+# Function to stake application
+stake_application() {
+    local from_addr="$1"
+    local stake_amount="$2"
+    local stake_service_id="$3"
+    
+    if [[ "$dry_run" == true ]]; then
+        print_color $YELLOW "🔍 [DRY RUN] Would stake application for $from_addr"
+        print_color $BLUE "   Amount: ${stake_amount}upokt"
+        print_color $BLUE "   Service ID: $stake_service_id"
+    else
+        print_color $BLUE "🚀 Staking application for $from_addr..."
+        print_color $YELLOW "   Amount: ${stake_amount}upokt"
+        print_color $YELLOW "   Service ID: $stake_service_id"
+    fi
+    
+    # Create config file
+    if ! create_stake_config "$stake_amount" "$stake_service_id"; then
+        return 1
+    fi
+    
+    # Build command flags
+    local pocketd_flags=$(build_pocketd_flags)
+    
+    # Execute stake command
+    local stake_cmd="pocketd tx application stake-application --config=/tmp/stake_app_config.yaml --from=$from_addr $pocketd_flags --fees=200000upokt --yes"
+    
+    if [[ "$dry_run" == true ]]; then
+        print_color $YELLOW "🔍 [DRY RUN] Would execute:"
+        print_color $BLUE "   $stake_cmd"
+        print_color $GREEN "✅ [DRY RUN] Would successfully stake application for $from_addr"
+        return 0
+    fi
+    
+    print_color $BLUE "🔨 Executing: $stake_cmd"
+    
+    if eval "$stake_cmd"; then
+        print_color $GREEN "✅ Successfully staked application for $from_addr"
+        return 0
+    else
+        print_color $RED "❌ Failed to stake application for $from_addr"
+        return 1
+    fi
+}
+
+# Function to delegate to gateway
+delegate_to_gateway() {
+    local from_addr="$1"
+    local gateway_addr="$2"
+    local skip_wait="${3:-false}"
+    
+    if [[ "$dry_run" == true ]]; then
+        if [[ "$skip_wait" != true ]]; then
+            print_color $YELLOW "🔍 [DRY RUN] Would wait 60 seconds before delegation..."
+        fi
+        print_color $YELLOW "🔍 [DRY RUN] Would delegate $from_addr to gateway $gateway_addr"
+        
+        # Build command flags
+        local pocketd_flags=$(build_pocketd_flags)
+        
+        # Show delegate command
+        local delegate_cmd="pocketd tx application delegate-to-gateway $gateway_addr --from=$from_addr $pocketd_flags --fees=20000upokt"
+        
+        print_color $YELLOW "🔍 [DRY RUN] Would execute:"
+        print_color $BLUE "   $delegate_cmd"
+        print_color $GREEN "✅ [DRY RUN] Would successfully delegate $from_addr to gateway $gateway_addr"
+        return 0
+    fi
+    
+    if [[ "$skip_wait" != true ]]; then
+        print_color $BLUE "⏳ Waiting 60 seconds before delegation..."
+        sleep 60
+    fi
+    
+    print_color $BLUE "🔗 Delegating $from_addr to gateway $gateway_addr..."
+    
+    # Build command flags
+    local pocketd_flags=$(build_pocketd_flags)
+    
+    # Execute delegate command
+    local delegate_cmd="pocketd tx application delegate-to-gateway $gateway_addr --from=$from_addr $pocketd_flags --fees=20000upokt --yes"
+    
+    print_color $BLUE "🔨 Executing: $delegate_cmd"
+    
+    if eval "$delegate_cmd"; then
+        print_color $GREEN "✅ Successfully delegated $from_addr to gateway $gateway_addr"
+        return 0
+    else
+        print_color $RED "❌ Failed to delegate $from_addr to gateway $gateway_addr"
+        return 1
+    fi
+}
+
+# Function to process batch file
+process_batch_file() {
+    local file="$1"
+    local total_lines=0
+    local successful_stakes=0
+    local failed_stakes=0
+    local successful_delegations=0
+    local failed_delegations=0
+    local staked_addresses=()
+    
+    print_color $BLUE "📂 Processing batch file: $file"
+    
+    if [[ ! -f "$file" ]]; then
+        print_color $RED "❌ File not found: $file"
+        return 1
+    fi
+    
+    # Count total lines
+    total_lines=$(wc -l < "$file")
+    print_color $YELLOW "📊 Total lines to process: $total_lines"
+    echo
+    
+    print_color $BLUE "🚀 PHASE 1: STAKING APPLICATIONS"
+    print_color $BLUE "================================"
+    echo
+    
+    local line_num=0
+    while IFS= read -r line; do
+        line_num=$((line_num + 1))
+        
+        # Skip empty lines and comments
+        if [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]]; then
+            continue
+        fi
+        
+        # Parse line
+        read -r line_address line_service_id line_amount <<< "$line"
+        
+        if [[ -z "$line_address" || -z "$line_service_id" || -z "$line_amount" ]]; then
+            print_color $RED "❌ Line $line_num: Invalid format - $line"
+            failed_stakes=$((failed_stakes + 1))
+            continue
+        fi
+        
+        print_color $BLUE "🔄 Processing line $line_num/$total_lines..."
+        
+        # Stake application
+        if stake_application "$line_address" "$line_amount" "$line_service_id"; then
+            successful_stakes=$((successful_stakes + 1))
+            staked_addresses+=("$line_address")
+        else
+            failed_stakes=$((failed_stakes + 1))
+        fi
+        
+        echo
+    done < "$file"
+    
+    # Delegation phase
+    if [[ -n "$delegate_addr" && ${#staked_addresses[@]} -gt 0 ]]; then
+        echo
+        print_color $BLUE "🔗 PHASE 2: DELEGATING TO GATEWAY"
+        print_color $BLUE "================================="
+        echo
+        
+        print_color $YELLOW "Will delegate ${#staked_addresses[@]} successfully staked addresses to gateway: $delegate_addr"
+        
+        if [[ "$dry_run" == true ]]; then
+            print_color $YELLOW "🔍 [DRY RUN] Would wait 60 seconds before starting delegations..."
+        else
+            print_color $BLUE "⏳ Waiting 60 seconds before starting delegations..."
+            sleep 60
+        fi
+        
+        echo
+        
+        for address in "${staked_addresses[@]}"; do
+            if delegate_to_gateway "$address" "$delegate_addr" true; then
+                successful_delegations=$((successful_delegations + 1))
+            else
+                failed_delegations=$((failed_delegations + 1))
+            fi
+            echo
+        done
+    elif [[ -n "$delegate_addr" && ${#staked_addresses[@]} -eq 0 ]]; then
+        echo
+        print_color $YELLOW "⚠️  No successful stakes to delegate"
+    fi
+    
+    # Generate report
+    echo "========================================="
+    print_color $GREEN "📊 BATCH PROCESSING REPORT"
+    echo "========================================="
+    print_color $BLUE "Total lines processed: $total_lines"
+    print_color $GREEN "Successful stakes: $successful_stakes"
+    print_color $RED "Failed stakes: $failed_stakes"
+    
+    if [[ -n "$delegate_addr" ]]; then
+        print_color $GREEN "Successful delegations: $successful_delegations"
+        print_color $RED "Failed delegations: $failed_delegations"
+    fi
+    echo "========================================="
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        --file|-f)
+            if [[ -n $2 && $2 != -* ]]; then
+                file_path="$2"
+                shift 2
+            else
+                print_color $RED "Error: --file requires a file path"
+                exit 1
+            fi
+            ;;
+        --delegate)
+            if [[ -n $2 && $2 != -* ]]; then
+                delegate_addr="$2"
+                shift 2
+            else
+                print_color $RED "Error: --delegate requires a gateway address"
+                exit 1
+            fi
+            ;;
+        --dry-run)
+            dry_run=true
+            shift
+            ;;
+        --node)
+            if [[ -n $2 && $2 != -* ]]; then
+                node_flag="$2"
+                shift 2
+            else
+                print_color $RED "Error: --node requires an RPC endpoint"
+                exit 1
+            fi
+            ;;
+        --node=*)
+            node_flag="${1#*=}"
+            shift
+            ;;
+        --home)
+            if [[ -n $2 && $2 != -* ]]; then
+                home_dir="$2"
+                shift 2
+            else
+                print_color $RED "Error: --home requires a directory path"
+                exit 1
+            fi
+            ;;
+        --home=*)
+            home_dir="${1#*=}"
+            shift
+            ;;
+        --keyring-backend)
+            if [[ -n $2 && $2 != -* ]]; then
+                keyring_backend="$2"
+                shift 2
+            else
+                print_color $RED "Error: --keyring-backend requires a backend type"
+                exit 1
+            fi
+            ;;
+        --keyring-backend=*)
+            keyring_backend="${1#*=}"
+            shift
+            ;;
+        --chain-id)
+            if [[ -n $2 && $2 != -* ]]; then
+                chain_id="$2"
+                shift 2
+            else
+                print_color $RED "Error: --chain-id requires a chain ID"
+                exit 1
+            fi
+            ;;
+        --chain-id=*)
+            chain_id="${1#*=}"
+            shift
+            ;;
+        -*)
+            print_color $RED "Error: Unknown option $1"
+            print_color $BLUE "Use --help or -h for usage information"
+            exit 1
+            ;;
+        *)
+            # Positional arguments for single mode
+            if [[ -z "$file_path" ]]; then
+                if [[ -z $address ]]; then
+                    address="$1"
+                elif [[ -z $amount ]]; then
+                    amount="$1"
+                elif [[ -z $service_id ]]; then
+                    service_id="$1"
+                else
+                    print_color $RED "Error: Too many positional arguments"
+                    print_color $BLUE "Use --help or -h for usage information"
+                    exit 1
+                fi
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Set default home directory if not specified
+# (Removed - let pocketd use its own default)
+
+# Validate mode and arguments
+if [[ -n "$file_path" ]]; then
+    # Batch mode
+    if [[ -n "$address" || -n "$amount" || -n "$service_id" ]]; then
+        print_color $RED "Error: Cannot use positional arguments with --file option"
+        exit 1
+    fi
+    
+    print_color $BLUE "======================================="
+    print_color $BLUE "  Pocket Application Staking (Batch)"
+    print_color $BLUE "======================================="
+    echo
+    
+    print_color $YELLOW "Configuration:"
+    print_color $BLUE "  Mode: Batch"
+    print_color $BLUE "  File: $file_path"
+    print_color $BLUE "  Home directory: $home_dir"
+    print_color $BLUE "  Keyring backend: $keyring_backend"
+    print_color $BLUE "  Chain ID: $chain_id"
+    if [[ -n "$node_flag" ]]; then
+        print_color $BLUE "  Node: $node_flag"
+    fi
+    if [[ -n "$delegate_addr" ]]; then
+        print_color $BLUE "  Delegate to: $delegate_addr"
+    fi
+    echo
+    
+    process_batch_file "$file_path"
+    
+else
+    # Single mode
+    if [[ -z $address || -z $amount || -z $service_id ]]; then
+        print_color $RED "Error: Missing required arguments for single mode"
+        print_color $BLUE "Usage: $0 <address> <amount> <service_id> [OPTIONS]"
+        print_color $BLUE "Use --help or -h for detailed usage information"
+        exit 1
+    fi
+    
+    # Validate amount is numeric
+    if ! [[ $amount =~ ^[0-9]+$ ]]; then
+        print_color $RED "Error: Amount must be a positive integer"
+        exit 1
+    fi
+    
+    print_color $BLUE "======================================="
+    print_color $BLUE "  Pocket Application Staking (Single)"
+    print_color $BLUE "======================================="
+    echo
+    
+    print_color $YELLOW "Configuration:"
+    print_color $BLUE "  Mode: Single"
+    print_color $BLUE "  Address: $address"
+    print_color $BLUE "  Amount: ${amount}upokt"
+    print_color $BLUE "  Service ID: $service_id"
+    print_color $BLUE "  Home directory: $home_dir"
+    print_color $BLUE "  Keyring backend: $keyring_backend"
+    print_color $BLUE "  Chain ID: $chain_id"
+    if [[ -n "$node_flag" ]]; then
+        print_color $BLUE "  Node: $node_flag"
+    fi
+    if [[ -n "$delegate_addr" ]]; then
+        print_color $BLUE "  Delegate to: $delegate_addr"
+    fi
+    echo
+    
+    # Stake application
+    if stake_application "$address" "$amount" "$service_id"; then
+        # Delegate if specified
+        if [[ -n "$delegate_addr" ]]; then
+            delegate_to_gateway "$address" "$delegate_addr"
+        fi
+        
+        echo
+        print_color $GREEN "🎉 Single stake operation completed successfully!"
+    else
+        echo
+        print_color $RED "💥 Single stake operation failed!"
+        exit 1
+    fi
+fi
+
+# Cleanup
+if [[ "$dry_run" != true ]]; then
+    rm -f /tmp/stake_app_config.yaml
+else
+    print_color $YELLOW "🔍 [DRY RUN] Would cleanup temporary files"
+fi


### PR DESCRIPTION
## Summary

Adds several helper scripts to `poktroll` to enhance the Gateway operator experience.

### Primary Changes:

 • `tools/scripts/export-keys.sh`
  - Export private keys from keyring with multiple output formats
  - Supports `--output raw` (clean stdout) and `--output file` (to file)
  - `--keyring-backend` support for different keyring types
  - Big security warnings about handling unencrypted private keys
  - Emoji-enhanced UI with progress tracking
  - Input: file with key names (one per line)

  • `tools/scripts/import-keys.sh`
  - Import hex private keys using `pocketd` keys import-hex
  - Input format: `<private_key> <name>` per line
  - `--keyring-backend` and `--key-type` support
  - Comprehensive security warnings and error handling
  - Batch processing with success/failure reporting
  - Complements export script for key migration workflows

  • `tools/scripts/add-update-services.sh`
  - Service management utilities

  • `tools/scripts/stake-apps.sh`
  - Application staking utilities 

  **Key Enhancements Made**

  • Export Script: Enhanced with flexible output modes, keyring backend support, clean raw output for copy-paste
  • Import Script: Completely rewritten for hex key import with modern UX and security features
  • Security Focus: Both scripts include prominent warnings about private key handling
  • Developer UX: Emoji-enhanced interface, comprehensive help, and clear error messages

## Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [x] Other (specify): Tooling

## Sanity Checklist

- [x] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [ ] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [x] 'TODO's, configurations and other docs
