### PR TITLE
docs: clarify operator-only permissions for revenue share updates

### DIFF
--- a/docusaurus/docs/1_operate/1_cheat_sheets/4_supplier_cheatsheet.md
+++ b/docusaurus/docs/1_operate/1_cheat_sheets/4_supplier_cheatsheet.md
@@ -262,14 +262,14 @@ services:
 🚀
 ```
 
-:::warning Replace `service_id`
+:::note Replace `service_id`
 
 The example uses `service_id: anvil`.
 Use your own service_id or [create a new one](1_service_cheatsheet.md).
 
 :::
 
-:::warning Revenue Share Update Permissions
+:::warning Revenue Share Update Permissions (Operator-Only Updates)
 
 **Revenue share addresses and percentages CAN ONLY be updated by the OPERATOR account.**
 

--- a/docusaurus/docs/1_operate/3_configs/3_supplier_staking_config.md
+++ b/docusaurus/docs/1_operate/3_configs/3_supplier_staking_config.md
@@ -30,6 +30,7 @@ You can find a fully featured example configuration at [supplier_staking_config.
       - [`publicly_exposed_url`](#publicly_exposed_url)
       - [`rpc_type`](#rpc_type)
     - [`rev_share_percent`](#rev_share_percent)
+    - [`rev_share_percent` configuration details](#rev_share_percent-configuration-details)
 - [Staking Modes](#staking-modes)
   - [1. Stake Only Updates](#1-stake-only-updates)
   - [2. Service Configuration Updates](#2-service-configuration-updates)
@@ -158,7 +159,7 @@ owner_address: <address>
 ```
 
 The `owner_address` is the address of the account that owns the `Supplier`s staked
-funds, which will be transferred to this account's balannce when the `Supplier`
+funds, which will be transferred to this account's balance when the `Supplier`
 unstakes and finishes unbonding.
 
 For custodial staking, the `owner_address` is the same as the `operator_address`.
@@ -369,29 +370,16 @@ It overrides the `default_rev_share_percent` if defined for the `service`.
 This map cannot be empty but can be omitted, in which case it falls back to the
 `default_rev_share_percent` top-level configuration entry.
 
-:::warning Operator-Only Updates
-
-**Revenue share addresses and percentages can only be updated by the operator account.**
-The owner cannot modify revenue share configurations - only the operator has permission
-to update service configurations, which includes revenue share settings.
-
-:::
-
-:::note
+#### `rev_share_percent` configuration details
 
 The `shareholder_address`s MUST be valid Pocket addresses.
 
-The revenue share values MUST be strictly positive decimals with a maximum value
-of 100 and a total sum of 100 across all the `shareholder_address`es.
+The revenue share values MUST be strictly positive floats with a maximum value of
+100 and a total sum of 100 across all the `shareholder_address`es.
 
-:::
-
-:::warning
-
-If `rev_share_percent` is defined for a `service`, then the `owner_address` of the
-`Supplier` MUST be **explicitly** defined in the map if they are to receive a share.
-
-:::
+If `default_rev_share_percent` is defined, then the `owner_address` of the `Supplier`
+MUST be **explicitly** defined in the map if they are to receive a share on the
+`service`s that fall back to the default.
 
 ## Staking Modes
 


### PR DESCRIPTION
## Summary

Clarifies that **revenue share addresses and percentages can only be updated by the operator account**.

## Changes

- Added warnings to supplier staking config documentation explaining operator-only permissions for revenue share updates
- Updated supplier cheatsheet to clarify permissions for custodial vs non-custodial staking

## Technical Details

Based on code analysis, only operators can update service configurations (which include revenue share settings). Owners can only update stake amounts when services section is empty.

## Impact

Addresses the critical distinction that owners cannot modify revenue share configurations - only operators have permission to update service configurations.