### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/tools/scripts/docusaurus/generate_docs_params.go
+++ b/tools/scripts/docusaurus/generate_docs_params.go
@@ -103,14 +103,14 @@ func prepareGovernanceParamsDocs(protoFilesRootDir string, templates *template.T
 	for moduleName, fieldNodes := range paramsFieldNodesByModule {
 		for _, fieldNode := range fieldNodes {
 			// Uncomment and concatenate the field's comment lines.
-			comment := ""
+			var comment strings.Builder
 			for commentIdx, commentLine := range fieldNode.LeadingComments() {
 				var commentFmt = " %s"
 				if commentIdx == 0 {
 					commentFmt = "%s"
 				}
 
-				comment += fmt.Sprintf(commentFmt, strings.Trim(commentLine.Text, " /"))
+				comment.WriteString(fmt.Sprintf(commentFmt, strings.Trim(commentLine.Text, " /")))
 			}
 
 			// Extract the field's type information.
@@ -118,7 +118,7 @@ func prepareGovernanceParamsDocs(protoFilesRootDir string, templates *template.T
 				Module:  moduleName,
 				Type:    string(fieldNode.FldType.AsIdentifier()),
 				Name:    fieldNode.Name.Val,
-				Comment: comment,
+				Comment: comment.String(),
 			})
 		}
 	}


### PR DESCRIPTION
## Summary

use strings.Builder to improve performance


### Primary Changes:

strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)



### Secondary Changes:



## Issue

- No

## Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Sanity Checklist

- [ ] I have updated the GitHub Issue Metadata: `assignees`, `reviewers`, `labels`, `project`, `iteration` and `milestone`
- [ ] For docs: `make docusaurus_start`
- [x] For small changes: `make go_develop_and_test` and `make test_e2e`
- [ ] For major changes: `devnet-test-e2e` label to run E2E tests in CI
- [ ] For migration changes: `make test_e2e_oneshot`
- [ ] 'TODO's, configurations and other docs
