### PR TITLE
Add comprehensive Telegram broadcast bot documentation

### DIFF
--- a/.github/TELEGRAM_BROADCAST.md
+++ b/.github/TELEGRAM_BROADCAST.md
@@ -15,8 +15,7 @@ make telegram_broadcast_msg MSG_FILE=message.html
 ## Message Format
 
 Use HTML for formatting:
-- `<b>bold</b>`, `<i>italic</i>`, `<code>code</code>`
-- `<a href="url">link</a>`, `<br>` for line breaks
+Non-exhaustive examples: `<b>bold</b>`, `<i>italic</i>`, `<code>code</code>`, `<a href="url">link</a>`, `<br>`. etc.
 
 **Example:**
 ```html


### PR DESCRIPTION
## Summary

Added documentation for the Telegram broadcast bot in `.github/TELEGRAM_BROADCAST.md`.

## What's included

- Quick start commands for test and production broadcasts
- HTML message formatting guide with example
- List of broadcast targets (18 groups: exchanges + community)
- Safety rules (test first, no recalls, get approval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)