### PR TITLE
fix: Uppercased Addresses in Recovery list.

### DIFF
--- a/x/migration/recovery/recovery_allowlist.go
+++ b/x/migration/recovery/recovery_allowlist.go
@@ -638,8 +638,8 @@ var knownRecoveryRequestedAllowlist = []string{
 	"BFA5E910FF9024B6D1B62741078605FFB0EA18AB",
 
 	// https://github.com/pokt-network/poktroll/issues/1814
-    "3B5E804B37BFF591F9F86E307C81D21FDB5355D4",
-    "18CC4D01FB572B07A7286A16CC23EDD0DFA7FC1D",
+	"3B5E804B37BFF591F9F86E307C81D21FDB5355D4",
+	"18CC4D01FB572B07A7286A16CC23EDD0DFA7FC1D",
 
 	// https://github.com/pokt-network/poktroll/issues/1852
 	"CB6C69F82B3B360E200DF877604DE2704985D24F",
@@ -1110,8 +1110,7 @@ var ledgerAllowlist = []string{
 	"2A5907A0C3D6C092B82FF4EE4730A564578A2E16",
 
 	// https://github.com/pokt-network/poktroll/issues/1816
-	"19e18bc48a1662c60e94939bbedabb7c988094b5", // Did not work in v0.1.30 because it was not uppercased
-	"19E18BC48A1662C60E94939BBEDABB7C988094B5", // Will only be available in v0.1.31+
+	"19E18BC48A1662C60E94939BBEDABB7C988094B5",
 }
 
 var exchangesAllowlist = []string{


### PR DESCRIPTION
This pull request makes a minor update to the `knownRecoveryRequestedAllowlist` in `x/migration/recovery/recovery_allowlist.go` by changing the casing of two address entries to uppercase. This ensures addresses can be recovered.