### PR TITLE
Open PR for recovery-30oct25

### DIFF
--- a/x/migration/recovery/recovery_allowlist.go
+++ b/x/migration/recovery/recovery_allowlist.go
@@ -643,6 +643,9 @@ var knownRecoveryRequestedAllowlist = []string{
 
 	// https://github.com/pokt-network/poktroll/issues/1852
 	"CB6C69F82B3B360E200DF877604DE2704985D24F",
+
+	// https://github.com/pokt-network/poktroll/issues/1856
+	"9AA50E763273629780EAA930A613BBFF15F84708",
 }
 
 var moduleAccountsAllowlist = []string{


### PR DESCRIPTION
This pull request makes a minor update to the recovery allowlist in `x/migration/recovery/recovery_allowlist.go`. The change adds a new entry to the `knownRecoveryRequestedAllowlist` to address an additional recovery request.

* Added the identifier `9AA50E763273629780EAA930A613BBFF15F84708` to the `knownRecoveryRequestedAllowlist` for issue #1856.