### PR TITLE
[Cleanup] Removed duplicated authorization entries in localnet genesis

### DIFF
--- a/tools/scripts/authz/localnet_genesis_authorizations.json
+++ b/tools/scripts/authz/localnet_genesis_authorizations.json
@@ -148,42 +148,6 @@
     "grantee": "pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw",
     "authorization": {
       "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
-      "msg": "/pocket.gateway.MsgUpdateParam"
-    },
-    "expiration": "2500-01-01T00:00:00Z"
-  },
-  {
-    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
-    "grantee": "pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw",
-    "authorization": {
-      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
-      "msg": "/pocket.application.MsgUpdateParam"
-    },
-    "expiration": "2500-01-01T00:00:00Z"
-  },
-  {
-    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
-    "grantee": "pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw",
-    "authorization": {
-      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
-      "msg": "/pocket.supplier.MsgUpdateParam"
-    },
-    "expiration": "2500-01-01T00:00:00Z"
-  },
-  {
-    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
-    "grantee": "pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw",
-    "authorization": {
-      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
-      "msg": "/pocket.session.MsgUpdateParam"
-    },
-    "expiration": "2500-01-01T00:00:00Z"
-  },
-  {
-    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
-    "grantee": "pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw",
-    "authorization": {
-      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
       "msg": "/pocket.migration.MsgImportMorseClaimableAccounts"
     },
     "expiration": "2500-01-01T00:00:00Z"
@@ -311,15 +275,6 @@
     "authorization": {
       "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
       "msg": "/cosmos.authz.v1beta1.MsgRevoke"
-    },
-    "expiration": "2500-01-01T00:00:00Z"
-  },
-  {
-    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
-    "grantee": "pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw",
-    "authorization": {
-      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
-      "msg": "/pocket.migration.MsgUpdateParams"
     },
     "expiration": "2500-01-01T00:00:00Z"
   },


### PR DESCRIPTION
Removed multiple repeated authorization entries related to MsgUpdateParam

## Summary

All these were duplicated:

```json
{
    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
    "grantee": "pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw",
    "authorization": {
      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
      "msg": "/pocket.session.MsgUpdateParam"
    },
    "expiration": "2500-01-01T00:00:00Z"
  },

    {
    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
    "grantee": "pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw",
    "authorization": {
      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
      "msg": "/pocket.gateway.MsgUpdateParam"
    },
    "expiration": "2500-01-01T00:00:00Z"
  },

    {
    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
    "grantee": "pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw",
    "authorization": {
      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
      "msg": "/pocket.application.MsgUpdateParam"
    },
    "expiration": "2500-01-01T00:00:00Z"
  },

    {
    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
    "grantee": "pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw",
    "authorization": {
      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
      "msg": "/pocket.supplier.MsgUpdateParam"
    },
    "expiration": "2500-01-01T00:00:00Z"
  },
    {
    "granter": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
    "grantee": "pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw",
    "authorization": {
      "@type": "/cosmos.authz.v1beta1.GenericAuthorization",
      "msg": "/pocket.migration.MsgUpdateParams"
    },
    "expiration": "2500-01-01T00:00:00Z"
  },
```

