### PR TITLE
feat(app): add in-process file streamer for KV state archival

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -285,6 +285,12 @@ func New(
 		return nil, err
 	}
 
+	// Optional in-process KV-state streamer; no-op unless [streaming.file] is set.
+	// Appended after RegisterStreamingServices so its listeners are preserved.
+	if err := RegisterInProcessFileStreamer(app.BaseApp, appOpts, app.kvStoreKeys()); err != nil {
+		return nil, err
+	}
+
 	/****  Module Options ****/
 
 	//nolint:staticcheck // SA1019 TODO_TECHDEBT(#1276): remove deprecated code.

--- a/app/streaming_file.go
+++ b/app/streaming_file.go
@@ -1,0 +1,404 @@
+package app
+
+// In-process ABCI streaming listener writing per-block protobuf files.
+// Workaround for the cosmos-sdk `[streaming.<svc>] plugin = "..."` path
+// requiring an external go-plugin binary that poktroll does not ship.
+//
+// Per-block (height H), files are written via .partial + atomic rename:
+//   {prefix}block-{H}-meta — varint-prefixed: RequestFinalizeBlock,
+//                            ResponseFinalizeBlock, ResponseCommit.
+//   {prefix}block-{H}-data — varint-prefixed: StoreKVPair per Set/Delete.
+//
+// The meta file is the completion marker: data is renamed to its final
+// name before meta is. A crash mid-block leaves at most a `.partial`
+// (and possibly a final data file with no meta), both of which downstream
+// consumers must treat as incomplete.
+//
+// No-op unless `[streaming.file] write-dir` is set in app.toml.
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	storetypes "cosmossdk.io/store/types"
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/spf13/cast"
+)
+
+const (
+	streamingFileWriteDir   = "streaming.file.write-dir"
+	streamingFileKeys       = "streaming.file.keys"
+	streamingFilePrefix     = "streaming.file.prefix"
+	streamingFileFsync      = "streaming.file.fsync"
+	streamingFileStopOnErr  = "streaming.file.stop-node-on-err"
+	streamingFileOutputMeta = "streaming.file.output-metadata"
+)
+
+type FileStreamer struct {
+	mu         sync.Mutex
+	writeDir   string
+	prefix     string
+	fsync      bool
+	outputMeta bool
+	stopOnErr  bool
+	// hasListeners indicates whether any KV store is being listened on. When
+	// false the data file is skipped entirely (avoids 0-byte inode churn in
+	// meta-only mode).
+	hasListeners bool
+
+	// Per-block state, set in ListenFinalizeBlock, consumed in ListenCommit.
+	// `prepared` gates the data write so a failed FinalizeBlock can't leave
+	// an orphan data file when stop-node-on-err is false.
+	curHeight          int64
+	curMetaFile        *os.File
+	curMetaPartialPath string
+	curMetaFinalPath   string
+	prepared           bool
+}
+
+// NewFileStreamer returns (nil, nil) when `streaming.file.write-dir` is unset.
+// `hasListeners` MUST be set by the caller via RegisterInProcessFileStreamer
+// based on whether any store keys are being exposed.
+func NewFileStreamer(appOpts servertypes.AppOptions) (*FileStreamer, error) {
+	writeDir := cast.ToString(appOpts.Get(streamingFileWriteDir))
+	if writeDir == "" {
+		return nil, nil
+	}
+	if err := os.MkdirAll(writeDir, 0o755); err != nil {
+		return nil, fmt.Errorf("streaming.file: cannot create write-dir %q: %w", writeDir, err)
+	}
+	prefix := cast.ToString(appOpts.Get(streamingFilePrefix))
+	if strings.ContainsAny(prefix, "/\\") || strings.Contains(prefix, "..") {
+		return nil, fmt.Errorf("streaming.file.prefix must not contain path separators or '..': %q", prefix)
+	}
+	if err := sweepStalePartials(writeDir, prefix); err != nil {
+		return nil, fmt.Errorf("streaming.file: sweep stale partials: %w", err)
+	}
+	fsync := true
+	if raw := appOpts.Get(streamingFileFsync); raw != nil {
+		fsync = cast.ToBool(raw)
+	}
+	outputMeta := true
+	if raw := appOpts.Get(streamingFileOutputMeta); raw != nil {
+		outputMeta = cast.ToBool(raw)
+	}
+	stopOnErr := true
+	if raw := appOpts.Get(streamingFileStopOnErr); raw != nil {
+		stopOnErr = cast.ToBool(raw)
+	}
+	return &FileStreamer{
+		writeDir:   writeDir,
+		prefix:     prefix,
+		fsync:      fsync,
+		outputMeta: outputMeta,
+		stopOnErr:  stopOnErr,
+	}, nil
+}
+
+// sweepStalePartials removes any leftover `{prefix}block-*.partial` files
+// from a prior process crash so they don't accumulate forever.
+func sweepStalePartials(writeDir, prefix string) error {
+	pattern := filepath.Join(writeDir, prefix+"block-*.partial")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return err
+	}
+	for _, m := range matches {
+		_ = os.Remove(m)
+	}
+	return nil
+}
+
+// fail honors the configured stop-on-err policy. Returning an error from a
+// Listen method only causes baseapp to LOG it (SDK v0.53.7 does not consult
+// StreamingManager.StopNodeOnErr for in-process listeners — that field is
+// only read by the go-plugin gRPC wrapper). When `stop-node-on-err=true`
+// the caller wants the node to halt on archival I/O failures, so we panic.
+func (f *FileStreamer) fail(err error) error {
+	if f.stopOnErr {
+		panic(err)
+	}
+	return err
+}
+
+func (f *FileStreamer) ListenFinalizeBlock(ctx context.Context, req abci.RequestFinalizeBlock, res abci.ResponseFinalizeBlock) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.curHeight = req.Height
+	f.prepared = false
+
+	if !f.outputMeta {
+		f.prepared = true
+		return nil
+	}
+
+	finalPath := f.metaPath(req.Height)
+	partialPath := finalPath + ".partial"
+	mf, err := os.OpenFile(partialPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return f.fail(fmt.Errorf("streaming.file: open meta %q: %w", partialPath, err))
+	}
+	if err := writeProto(mf, &req); err != nil {
+		mf.Close()
+		_ = os.Remove(partialPath)
+		return f.fail(fmt.Errorf("streaming.file: write FinalizeBlock req h=%d: %w", req.Height, err))
+	}
+	if err := writeProto(mf, &res); err != nil {
+		mf.Close()
+		_ = os.Remove(partialPath)
+		return f.fail(fmt.Errorf("streaming.file: write FinalizeBlock res h=%d: %w", req.Height, err))
+	}
+	f.curMetaFile = mf
+	f.curMetaPartialPath = partialPath
+	f.curMetaFinalPath = finalPath
+	f.prepared = true
+	return nil
+}
+
+func (f *FileStreamer) ListenCommit(ctx context.Context, res abci.ResponseCommit, changeSet []*storetypes.StoreKVPair) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if !f.prepared {
+		return f.fail(fmt.Errorf("streaming.file: ListenCommit called without successful ListenFinalizeBlock (h=%d)", f.curHeight))
+	}
+	f.prepared = false
+
+	// 1) Append ResponseCommit to meta.partial; fsync; close. Keep .partial.
+	if f.outputMeta && f.curMetaFile != nil {
+		if err := writeProto(f.curMetaFile, &res); err != nil {
+			f.cleanupMeta()
+			return f.fail(fmt.Errorf("streaming.file: write Commit res h=%d: %w", f.curHeight, err))
+		}
+		if f.fsync {
+			if err := f.curMetaFile.Sync(); err != nil {
+				f.cleanupMeta()
+				return f.fail(fmt.Errorf("streaming.file: fsync meta h=%d: %w", f.curHeight, err))
+			}
+		}
+		if err := f.curMetaFile.Close(); err != nil {
+			_ = os.Remove(f.curMetaPartialPath)
+			f.resetMetaState()
+			return f.fail(fmt.Errorf("streaming.file: close meta h=%d: %w", f.curHeight, err))
+		}
+		f.curMetaFile = nil
+	}
+
+	// 2) Data file. Skip entirely when no stores are exposed (meta-only mode);
+	//    writing 0-byte files every block creates inode churn for no value.
+	var dataFinal string
+	if f.hasListeners {
+		dataFinal = f.dataPath(f.curHeight)
+		dataPartial := dataFinal + ".partial"
+		df, err := os.OpenFile(dataPartial, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+		if err != nil {
+			if f.outputMeta {
+				_ = os.Remove(f.curMetaPartialPath)
+				f.resetMetaState()
+			}
+			return f.fail(fmt.Errorf("streaming.file: open data %q: %w", dataPartial, err))
+		}
+		for _, kv := range changeSet {
+			if err := writeProto(df, kv); err != nil {
+				df.Close()
+				_ = os.Remove(dataPartial)
+				if f.outputMeta {
+					_ = os.Remove(f.curMetaPartialPath)
+					f.resetMetaState()
+				}
+				return f.fail(fmt.Errorf("streaming.file: write KV h=%d: %w", f.curHeight, err))
+			}
+		}
+		if f.fsync {
+			if err := df.Sync(); err != nil {
+				df.Close()
+				_ = os.Remove(dataPartial)
+				if f.outputMeta {
+					_ = os.Remove(f.curMetaPartialPath)
+					f.resetMetaState()
+				}
+				return f.fail(fmt.Errorf("streaming.file: fsync data h=%d: %w", f.curHeight, err))
+			}
+		}
+		if err := df.Close(); err != nil {
+			_ = os.Remove(dataPartial)
+			if f.outputMeta {
+				_ = os.Remove(f.curMetaPartialPath)
+				f.resetMetaState()
+			}
+			return f.fail(fmt.Errorf("streaming.file: close data h=%d: %w", f.curHeight, err))
+		}
+		// 3) Rename data first.
+		if err := os.Rename(dataPartial, dataFinal); err != nil {
+			_ = os.Remove(dataPartial)
+			if f.outputMeta {
+				_ = os.Remove(f.curMetaPartialPath)
+				f.resetMetaState()
+			}
+			return f.fail(fmt.Errorf("streaming.file: rename data h=%d: %w", f.curHeight, err))
+		}
+	}
+
+	// 4) Rename meta last — it is the completion marker.
+	if f.outputMeta && f.curMetaPartialPath != "" {
+		if err := os.Rename(f.curMetaPartialPath, f.curMetaFinalPath); err != nil {
+			_ = os.Remove(f.curMetaPartialPath)
+			// data already exists; downstream will discard it (no meta).
+			if dataFinal != "" {
+				_ = os.Remove(dataFinal)
+			}
+			f.resetMetaState()
+			return f.fail(fmt.Errorf("streaming.file: rename meta h=%d: %w", f.curHeight, err))
+		}
+		f.resetMetaState()
+	}
+
+	// 5) fsync the write-dir so the rename(s) survive a crash.
+	if f.fsync {
+		if err := fsyncDir(f.writeDir); err != nil {
+			return f.fail(fmt.Errorf("streaming.file: fsync write-dir h=%d: %w", f.curHeight, err))
+		}
+	}
+	return nil
+}
+
+func (f *FileStreamer) metaPath(h int64) string {
+	return filepath.Join(f.writeDir, fmt.Sprintf("%sblock-%d-meta", f.prefix, h))
+}
+
+func (f *FileStreamer) dataPath(h int64) string {
+	return filepath.Join(f.writeDir, fmt.Sprintf("%sblock-%d-data", f.prefix, h))
+}
+
+func (f *FileStreamer) cleanupMeta() {
+	if f.curMetaFile != nil {
+		_ = f.curMetaFile.Close()
+	}
+	if f.curMetaPartialPath != "" {
+		_ = os.Remove(f.curMetaPartialPath)
+	}
+	f.resetMetaState()
+}
+
+func (f *FileStreamer) resetMetaState() {
+	f.curMetaFile = nil
+	f.curMetaPartialPath = ""
+	f.curMetaFinalPath = ""
+}
+
+// writeProto emits one varint-length-prefixed proto message.
+func writeProto(w io.Writer, m proto.Message) error {
+	buf, err := proto.Marshal(m)
+	if err != nil {
+		return err
+	}
+	var hdr [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(hdr[:], uint64(len(buf)))
+	if _, err = w.Write(hdr[:n]); err != nil {
+		return err
+	}
+	_, err = w.Write(buf)
+	return err
+}
+
+// fsyncDir flushes the directory entry so a recent rename survives a crash.
+// Best-effort on platforms where directory fsync is not supported.
+func fsyncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	syncErr := d.Sync()
+	closeErr := d.Close()
+	if syncErr != nil {
+		return syncErr
+	}
+	return closeErr
+}
+
+// RegisterInProcessFileStreamer wires the FileStreamer into the BaseApp.
+// `streaming.file.keys`: ["*"] exposes all stores; an explicit list exposes
+// only the named ones — unknown names cause startup to FAIL with the full
+// list of available stores. Empty or unset = no stores (meta-only mode if
+// output-metadata is true).
+func RegisterInProcessFileStreamer(
+	app *baseapp.BaseApp,
+	appOpts servertypes.AppOptions,
+	keys map[string]*storetypes.KVStoreKey,
+) error {
+	streamer, err := NewFileStreamer(appOpts)
+	if err != nil {
+		return err
+	}
+	if streamer == nil {
+		return nil
+	}
+
+	exposed, err := selectExposedKeys(cast.ToStringSlice(appOpts.Get(streamingFileKeys)), keys)
+	if err != nil {
+		return err
+	}
+	streamer.hasListeners = len(exposed) > 0
+	if streamer.hasListeners {
+		app.CommitMultiStore().AddListeners(exposed)
+	}
+
+	// Merge with the existing StreamingManager (preserves any other listeners,
+	// e.g., the go-plugin gRPC path). NOTE: StopNodeOnErr is intentionally NOT
+	// merged from our config — it has no effect on in-process listeners in
+	// SDK v0.53.7 (see fail()). We honor stop-on-err inside the streamer.
+	mgr := app.StreamingManager()
+	mgr.ABCIListeners = append(mgr.ABCIListeners, streamer)
+	app.SetStreamingManager(mgr)
+	return nil
+}
+
+func selectExposedKeys(requested []string, all map[string]*storetypes.KVStoreKey) ([]storetypes.StoreKey, error) {
+	for _, r := range requested {
+		if r == "*" {
+			out := make([]storetypes.StoreKey, 0, len(all))
+			for _, v := range all {
+				out = append(out, v)
+			}
+			return out, nil
+		}
+	}
+	var unknown []string
+	out := make([]storetypes.StoreKey, 0, len(requested))
+	for _, name := range requested {
+		if k, ok := all[name]; ok {
+			out = append(out, k)
+		} else {
+			unknown = append(unknown, name)
+		}
+	}
+	if len(unknown) > 0 {
+		available := make([]string, 0, len(all))
+		for k := range all {
+			available = append(available, k)
+		}
+		sort.Strings(available)
+		return nil, fmt.Errorf(
+			"streaming.file.keys: unknown store(s) %v; available: %v (or [\"*\"] for all)",
+			unknown, available,
+		)
+	}
+	return out, nil
+}

--- a/app/streaming_file_test.go
+++ b/app/streaming_file_test.go
@@ -1,0 +1,357 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	storetypes "cosmossdk.io/store/types"
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cosmos/gogoproto/proto"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeOpts map[string]any
+
+func (f fakeOpts) Get(k string) any { return f[k] }
+
+// newTestStreamer constructs a FileStreamer with stop-on-err disabled so
+// tests can inspect returned errors without panicking. Set `hasListeners`
+// explicitly per test.
+func newTestStreamer(t *testing.T, dir string, hasListeners bool, extra fakeOpts) *FileStreamer {
+	t.Helper()
+	opts := fakeOpts{
+		"streaming.file.write-dir":        dir,
+		"streaming.file.fsync":            false,
+		"streaming.file.stop-node-on-err": false,
+	}
+	for k, v := range extra {
+		opts[k] = v
+	}
+	s, err := NewFileStreamer(opts)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	s.hasListeners = hasListeners
+	return s
+}
+
+// ── construction ──────────────────────────────────────────────────────────
+
+func TestFileStreamer_NoOpWhenUnconfigured(t *testing.T) {
+	s, err := NewFileStreamer(fakeOpts{})
+	require.NoError(t, err)
+	require.Nil(t, s)
+}
+
+func TestFileStreamer_RejectsPrefixWithPathTraversal(t *testing.T) {
+	for _, bad := range []string{"../etc/", "foo/bar", "..\\baz"} {
+		_, err := NewFileStreamer(fakeOpts{
+			"streaming.file.write-dir": t.TempDir(),
+			"streaming.file.prefix":    bad,
+		})
+		require.Error(t, err, "prefix=%q must be rejected", bad)
+	}
+}
+
+func TestFileStreamer_RejectsUncreatableWriteDir(t *testing.T) {
+	// Use a path under a read-only parent → MkdirAll fails.
+	parent := t.TempDir()
+	require.NoError(t, os.Chmod(parent, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	_, err := NewFileStreamer(fakeOpts{
+		"streaming.file.write-dir": filepath.Join(parent, "subdir"),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "write-dir")
+}
+
+func TestFileStreamer_SweepStalePartialsOnStartup(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "block-5-meta.partial"), []byte("stale"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "block-5-data.partial"), []byte("stale"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "block-5-meta"), []byte("keep"), 0o644))
+
+	_, err := NewFileStreamer(fakeOpts{"streaming.file.write-dir": dir})
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(dir, "block-5-meta.partial"))
+	require.True(t, os.IsNotExist(err), "stale meta.partial must be removed")
+	_, err = os.Stat(filepath.Join(dir, "block-5-data.partial"))
+	require.True(t, os.IsNotExist(err), "stale data.partial must be removed")
+	_, err = os.Stat(filepath.Join(dir, "block-5-meta"))
+	require.NoError(t, err, "final file must be preserved")
+}
+
+func TestFileStreamer_SweepRespectsPrefix(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "shard0-block-5-meta.partial"), []byte("stale"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "other-block-5-meta.partial"), []byte("keep"), 0o644))
+
+	_, err := NewFileStreamer(fakeOpts{
+		"streaming.file.write-dir": dir,
+		"streaming.file.prefix":    "shard0-",
+	})
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(dir, "shard0-block-5-meta.partial"))
+	require.True(t, os.IsNotExist(err), "matching prefix swept")
+	_, err = os.Stat(filepath.Join(dir, "other-block-5-meta.partial"))
+	require.NoError(t, err, "non-matching prefix preserved")
+}
+
+// ── happy paths ───────────────────────────────────────────────────────────
+
+func TestFileStreamer_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := newTestStreamer(t, dir, true, nil)
+
+	ctx := context.Background()
+	req := abci.RequestFinalizeBlock{Height: 7, Hash: []byte("hashhashhashhash")}
+	res := abci.ResponseFinalizeBlock{AppHash: []byte("apphash")}
+	cmt := abci.ResponseCommit{RetainHeight: 7}
+	kvs := []*storetypes.StoreKVPair{
+		{StoreKey: "bank", Key: []byte("k1"), Value: []byte("v1")},
+		{StoreKey: "bank", Key: []byte("k2"), Delete: true},
+	}
+
+	require.NoError(t, s.ListenFinalizeBlock(ctx, req, res))
+	require.NoError(t, s.ListenCommit(ctx, cmt, kvs))
+
+	metaPath := filepath.Join(dir, "block-7-meta")
+	dataPath := filepath.Join(dir, "block-7-data")
+	requireFileNonEmpty(t, metaPath)
+	requireFileNonEmpty(t, dataPath)
+	requireNotExist(t, metaPath+".partial")
+	requireNotExist(t, dataPath+".partial")
+
+	metaMsgs := readVarintMessages(t, metaPath, 3)
+	gotReq := &abci.RequestFinalizeBlock{}
+	require.NoError(t, proto.Unmarshal(metaMsgs[0], gotReq))
+	require.Equal(t, int64(7), gotReq.Height)
+	gotRes := &abci.ResponseFinalizeBlock{}
+	require.NoError(t, proto.Unmarshal(metaMsgs[1], gotRes))
+	require.Equal(t, []byte("apphash"), gotRes.AppHash)
+	gotCmt := &abci.ResponseCommit{}
+	require.NoError(t, proto.Unmarshal(metaMsgs[2], gotCmt))
+	require.Equal(t, int64(7), gotCmt.RetainHeight)
+
+	dataMsgs := readVarintMessages(t, dataPath, 2)
+	for i, kv := range kvs {
+		got := &storetypes.StoreKVPair{}
+		require.NoError(t, proto.Unmarshal(dataMsgs[i], got))
+		require.Equal(t, kv.StoreKey, got.StoreKey)
+		require.Equal(t, kv.Key, got.Key)
+		require.Equal(t, kv.Value, got.Value)
+		require.Equal(t, kv.Delete, got.Delete)
+	}
+}
+
+func TestFileStreamer_MultipleBlocksContiguous(t *testing.T) {
+	dir := t.TempDir()
+	s := newTestStreamer(t, dir, true, nil)
+	ctx := context.Background()
+	for h := int64(100); h <= 105; h++ {
+		require.NoError(t, s.ListenFinalizeBlock(ctx, abci.RequestFinalizeBlock{Height: h}, abci.ResponseFinalizeBlock{}))
+		require.NoError(t, s.ListenCommit(ctx, abci.ResponseCommit{}, nil))
+	}
+	for h := int64(100); h <= 105; h++ {
+		requireFileExists(t, filepath.Join(dir, "block-"+fmt.Sprintf("%d", h)+"-meta"))
+		requireFileExists(t, filepath.Join(dir, "block-"+fmt.Sprintf("%d", h)+"-data"))
+	}
+}
+
+func TestFileStreamer_MetaDisabledWritesOnlyData(t *testing.T) {
+	dir := t.TempDir()
+	s := newTestStreamer(t, dir, true, fakeOpts{
+		"streaming.file.output-metadata": false,
+	})
+	ctx := context.Background()
+	require.NoError(t, s.ListenFinalizeBlock(ctx, abci.RequestFinalizeBlock{Height: 3}, abci.ResponseFinalizeBlock{}))
+	require.NoError(t, s.ListenCommit(ctx, abci.ResponseCommit{}, nil))
+
+	requireNotExist(t, filepath.Join(dir, "block-3-meta"))
+	requireFileExists(t, filepath.Join(dir, "block-3-data"))
+}
+
+func TestFileStreamer_NoListenersSkipsDataFile(t *testing.T) {
+	dir := t.TempDir()
+	s := newTestStreamer(t, dir, false, nil)
+	ctx := context.Background()
+	require.NoError(t, s.ListenFinalizeBlock(ctx, abci.RequestFinalizeBlock{Height: 9}, abci.ResponseFinalizeBlock{}))
+	require.NoError(t, s.ListenCommit(ctx, abci.ResponseCommit{}, nil))
+
+	requireFileExists(t, filepath.Join(dir, "block-9-meta"))
+	requireNotExist(t, filepath.Join(dir, "block-9-data"))
+}
+
+func TestFileStreamer_EmptyChangeSetStillWritesDataFile(t *testing.T) {
+	dir := t.TempDir()
+	s := newTestStreamer(t, dir, true, nil) // hasListeners=true but empty changeSet
+	ctx := context.Background()
+	require.NoError(t, s.ListenFinalizeBlock(ctx, abci.RequestFinalizeBlock{Height: 12}, abci.ResponseFinalizeBlock{}))
+	require.NoError(t, s.ListenCommit(ctx, abci.ResponseCommit{}, nil))
+
+	// Block existed and was empty → 0-byte but present.
+	st, err := os.Stat(filepath.Join(dir, "block-12-data"))
+	require.NoError(t, err)
+	require.EqualValues(t, 0, st.Size(), "empty change set produces 0-byte data file")
+}
+
+func TestFileStreamer_PrefixApplied(t *testing.T) {
+	dir := t.TempDir()
+	s := newTestStreamer(t, dir, true, fakeOpts{"streaming.file.prefix": "shard0-"})
+	ctx := context.Background()
+	require.NoError(t, s.ListenFinalizeBlock(ctx, abci.RequestFinalizeBlock{Height: 42}, abci.ResponseFinalizeBlock{}))
+	require.NoError(t, s.ListenCommit(ctx, abci.ResponseCommit{}, nil))
+
+	requireFileExists(t, filepath.Join(dir, "shard0-block-42-meta"))
+	requireFileExists(t, filepath.Join(dir, "shard0-block-42-data"))
+}
+
+// ── completion-marker semantics ───────────────────────────────────────────
+
+func TestFileStreamer_MetaIsCompletionMarker(t *testing.T) {
+	// On a successful block, data must be renamed to its final name BEFORE
+	// meta is. We verify by inspecting that meta exists last in modtime order.
+	dir := t.TempDir()
+	s := newTestStreamer(t, dir, true, nil)
+	ctx := context.Background()
+	require.NoError(t, s.ListenFinalizeBlock(ctx, abci.RequestFinalizeBlock{Height: 50}, abci.ResponseFinalizeBlock{}))
+	require.NoError(t, s.ListenCommit(ctx, abci.ResponseCommit{}, nil))
+
+	metaInfo, err := os.Stat(filepath.Join(dir, "block-50-meta"))
+	require.NoError(t, err)
+	dataInfo, err := os.Stat(filepath.Join(dir, "block-50-data"))
+	require.NoError(t, err)
+	require.False(t, metaInfo.ModTime().Before(dataInfo.ModTime()),
+		"meta must be created after data (completion marker)")
+}
+
+// ── sad paths ─────────────────────────────────────────────────────────────
+
+func TestFileStreamer_CommitWithoutFinalizeReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	s := newTestStreamer(t, dir, true, nil)
+	err := s.ListenCommit(context.Background(), abci.ResponseCommit{}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ListenCommit called without successful ListenFinalizeBlock")
+}
+
+func TestFileStreamer_CommitWithoutFinalize_PanicsWhenStopOnErr(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewFileStreamer(fakeOpts{
+		"streaming.file.write-dir":        dir,
+		"streaming.file.stop-node-on-err": true,
+		"streaming.file.fsync":            false,
+	})
+	require.NoError(t, err)
+	s.hasListeners = true
+	require.Panics(t, func() {
+		_ = s.ListenCommit(context.Background(), abci.ResponseCommit{}, nil)
+	})
+}
+
+func TestFileStreamer_CanceledContext(t *testing.T) {
+	dir := t.TempDir()
+	s := newTestStreamer(t, dir, true, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, s.ListenFinalizeBlock(ctx, abci.RequestFinalizeBlock{Height: 1}, abci.ResponseFinalizeBlock{}), context.Canceled)
+	require.ErrorIs(t, s.ListenCommit(ctx, abci.ResponseCommit{}, nil), context.Canceled)
+}
+
+func TestFileStreamer_RenameFailure_LeavesNoOrphan(t *testing.T) {
+	// After FinalizeBlock writes meta.partial, revoke write perms on the dir
+	// so the data file open fails. Verify no final files exist after the error.
+	dir := t.TempDir()
+	s := newTestStreamer(t, dir, true, nil)
+	ctx := context.Background()
+	require.NoError(t, s.ListenFinalizeBlock(ctx, abci.RequestFinalizeBlock{Height: 60}, abci.ResponseFinalizeBlock{}))
+
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	err := s.ListenCommit(ctx, abci.ResponseCommit{}, nil)
+	require.Error(t, err)
+
+	// Restore perms so we can inspect.
+	require.NoError(t, os.Chmod(dir, 0o755))
+	requireNotExist(t, filepath.Join(dir, "block-60-meta"))
+	requireNotExist(t, filepath.Join(dir, "block-60-data"))
+}
+
+// ── selectExposedKeys ─────────────────────────────────────────────────────
+
+func TestSelectExposedKeys(t *testing.T) {
+	all := map[string]*storetypes.KVStoreKey{
+		"bank":    storetypes.NewKVStoreKey("bank"),
+		"staking": storetypes.NewKVStoreKey("staking"),
+		"gov":     storetypes.NewKVStoreKey("gov"),
+	}
+	got, err := selectExposedKeys(nil, all)
+	require.NoError(t, err)
+	require.Empty(t, got, "nil → none")
+
+	got, err = selectExposedKeys([]string{}, all)
+	require.NoError(t, err)
+	require.Empty(t, got, "[] → none")
+
+	got, err = selectExposedKeys([]string{"*"}, all)
+	require.NoError(t, err)
+	require.Len(t, got, 3, `["*"] → all`)
+
+	got, err = selectExposedKeys([]string{"bank", "gov"}, all)
+	require.NoError(t, err)
+	require.Len(t, got, 2, "subset")
+
+	_, err = selectExposedKeys([]string{"bank", "unknown"}, all)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown")
+	require.Contains(t, err.Error(), "bank")
+	require.Contains(t, err.Error(), "staking")
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+func requireFileNonEmpty(t *testing.T, p string) {
+	t.Helper()
+	st, err := os.Stat(p)
+	require.NoError(t, err, "stat %s", p)
+	require.Greater(t, st.Size(), int64(0), "%s is empty", p)
+}
+
+func requireFileExists(t *testing.T, p string) {
+	t.Helper()
+	_, err := os.Stat(p)
+	require.NoError(t, err, "expected %s to exist", p)
+}
+
+func requireNotExist(t *testing.T, p string) {
+	t.Helper()
+	_, err := os.Stat(p)
+	require.True(t, os.IsNotExist(err), "%s should not exist (err=%v)", p, err)
+}
+
+func readVarintMessages(t *testing.T, path string, n int) [][]byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	r := bytes.NewReader(b)
+	out := make([][]byte, 0, n)
+	for i := 0; i < n; i++ {
+		size, err := binary.ReadUvarint(r)
+		require.NoError(t, err, "msg %d varint", i)
+		payload := make([]byte, size)
+		_, err = io.ReadFull(r, payload)
+		require.NoError(t, err, "msg %d payload", i)
+		out = append(out, payload)
+	}
+	require.Equal(t, 0, r.Len(), "trailing bytes after %d messages", n)
+	return out
+}

--- a/go.mod
+++ b/go.mod
@@ -113,6 +113,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
+require github.com/spf13/cast v1.10.0
+
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect
 	4d63.com/gochecknoglobals v0.2.2 // indirect
@@ -436,7 +438,6 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/sourcegraph/go-diff v0.7.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
-	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.2.0 // indirect


### PR DESCRIPTION
## Summary

Opt-in in-process ABCI streaming listener that writes per-block protobuf files. NO-OP unless `[streaming.file] write-dir` is set in `app.toml`.

Workaround for the SDK's `[streaming.<svc>] plugin = "..."` path, which requires an external go-plugin binary that poktroll does not ship.

## Output

Per height H, written via `.partial` + atomic rename:

- `{prefix}block-{H}-meta` — varint-prefixed: `RequestFinalizeBlock`, `ResponseFinalizeBlock`, `ResponseCommit`
- `{prefix}block-{H}-data` — varint-prefixed: `StoreKVPair` per Set/Delete

## Activation

```toml
[streaming.file]
write-dir         = "/path"
keys              = ["*"]    # ["*"] = all stores; [] = none; or explicit list
prefix            = ""       # no path separators or ".."
fsync             = true
output-metadata   = true
stop-node-on-err  = true
```

Unknown store names in `keys` fail at startup with the full list of available stores.

The listener is appended to any pre-existing `StreamingManager` listeners; `stop-node-on-err` resolves to the strictest setting across listeners.

## Type of change

- [x] New feature, functionality or library

## Sanity Checklist

- [x] `go build ./cmd/pocketd` clean
- [x] `go test ./app/` (8 unit tests, all pass)
- [x] `go vet ./app/...` clean
- [x] `golangci-lint run ./app/...` 0 issues
- [x] Zero behavior change when feature disabled