### PR TITLE
docs: close supplier onboarding gaps from dogfooding report

### DIFF
--- a/docusaurus/docs/1_operate/1_cheat_sheets/4_supplier_cheatsheet.md
+++ b/docusaurus/docs/1_operate/1_cheat_sheets/4_supplier_cheatsheet.md
@@ -138,6 +138,21 @@ flowchart TB
 - [Stake or find a `service`](1_service_cheatsheet.md)
 - [Review hardware requirements](../4_faq/6_hardware_requirements.md)
 
+:::warning You must run a backend node for each service you serve
+
+Staking POKT is not enough. A `Supplier` must **run, sync, and maintain a backend
+node of every chain it serves** (e.g. an Ethereum, Base, or Solana node). The
+`RelayMiner` only proxies relays to that backend — it does not provide the chain data
+itself.
+
+This cheat sheet uses a local **Anvil** node as a stand-in backend so you can complete
+the flow quickly. Serving a real mainnet service (e.g. `eth`, `base`) means standing
+up that chain's full node separately, which is typically the largest cost of running a
+Supplier. See [Hardware Requirements → Backend Service Node](../4_faq/6_hardware_requirements.md#backend-service-node)
+before staking for a real service.
+
+:::
+
 :::note Optional Vultr Setup
 
 The instructions on this page assume you have experience maintaining backend services.

--- a/docusaurus/docs/1_operate/3_configs/4_relayminer_config.md
+++ b/docusaurus/docs/1_operate/3_configs/4_relayminer_config.md
@@ -505,6 +505,16 @@ The URL of the service that the `RelayMiner` will forward the requests to when
 a relay is received, also known as **data node** or **service node**.
 It MUST be a valid URL (not just a host) and be reachable from the `RelayMiner` instance.
 
+:::note You must run this backend node yourself
+
+`backend_url` points to a full node of the chain you are serving (e.g. an Ethereum or
+Base node). This node is **separate infrastructure that you run, sync, and maintain** —
+it is not provided by Pocket or the `RelayMiner`, and its hardware footprint is usually
+far larger than the `RelayMiner` itself. See
+[Backend Service Node sizing](../4_faq/6_hardware_requirements.md#backend-service-node).
+
+:::
+
 #### `authentication`
 
 _`Optional`_

--- a/docusaurus/docs/1_operate/4_faq/10_transaction_troubleshooting.md
+++ b/docusaurus/docs/1_operate/4_faq/10_transaction_troubleshooting.md
@@ -1,0 +1,131 @@
+---
+title: Transaction Troubleshooting
+sidebar_position: 10
+---
+
+## Transaction Troubleshooting <!-- omit in toc -->
+
+Common errors when broadcasting `pocketd` transactions, and how to recover from them.
+
+- [`account sequence mismatch`](#account-sequence-mismatch)
+- [`insufficient fees` / `out of gas`](#insufficient-fees--out-of-gas)
+- [`account ... not found`](#account--not-found)
+- [`key not found` / wrong keyring backend](#key-not-found--wrong-keyring-backend)
+- [A transaction "sent with errors"](#a-transaction-sent-with-errors)
+
+---
+
+## `account sequence mismatch`
+
+```text
+account sequence mismatch, expected 42, got 41: incorrect account sequence
+```
+
+Every account has a monotonically increasing `sequence` (nonce). Each transaction
+must use the next expected sequence. This error means the sequence you signed with
+does not match what the chain expects — almost always because a **previous
+transaction already consumed the sequence** (and likely succeeded), or because two
+transactions were signed/broadcast in quick succession before the chain (or your
+wallet UI) refreshed.
+
+:::warning Check before re-sending — the first transaction may have succeeded
+
+Do **not** blindly resubmit. Check on-chain state first; a confused resend can result
+in a **double-send**.
+
+:::
+
+1. Check the current account state (note the `sequence`):
+
+   ```bash
+   pocketd query auth account <your_address> --network=main
+   ```
+
+2. Check the balance / recipient to see whether the prior transaction already landed:
+
+   ```bash
+   pocketd query bank balances <your_address> --network=main
+   ```
+
+3. If the prior transaction succeeded, you are done. If it genuinely failed, re-broadcast.
+   The CLI normally fills the sequence automatically; to set it explicitly, use
+   `--sequence <N>` (and `--account-number <N>` when offline-signing).
+
+:::danger Do not "fix" this with `--unordered`
+
+`--unordered` changes transaction ordering semantics and is **not** a workaround for a
+sequence mismatch. Resolve the actual sequence state instead.
+
+:::
+
+---
+
+## `insufficient fees` / `out of gas`
+
+```text
+insufficient fees; got: 1upokt required: 100upokt
+out of gas in location: ...; gasWanted: 200000, gasUsed: 210000
+```
+
+The transaction did not pay enough fee, or under-estimated gas.
+
+- Let the CLI estimate gas and price it:
+
+  ```bash
+  pocketd tx ... --gas=auto --gas-prices=1upokt --gas-adjustment=1.5
+  ```
+
+- For `Proof` submissions specifically, the operator must also hold enough balance to
+  cover the `proof_submission_fee` (failure to submit a required proof can lead to
+  **slashing**). See the [RelayMiner Config → Payable Proof Submissions](../3_configs/4_relayminer_config.md#payable-proof-submissions).
+
+---
+
+## `account ... not found`
+
+```text
+account pokt1... not found
+```
+
+The address has never appeared on-chain (it has no `account_number` yet). An account
+is only created when it **first receives funds** or signs its first transaction.
+
+- Fund the address (faucet on test networks, or a transfer on mainnet), then retry.
+- Note a related gotcha for suppliers: an operator account can exist but still lack an
+  **on-chain public key** until it signs its first transaction. A supplier whose
+  operator has no on-chain public key cannot sign relay responses. See the
+  [Supplier cheat sheet → Suppliers staked on behalf of Owners](../1_cheat_sheets/4_supplier_cheatsheet.md#4-suppliers-staked-on-behalf-of-owners).
+
+---
+
+## `key not found` / wrong keyring backend
+
+```text
+<name>.info: key not found
+```
+
+The key exists in a **different keyring backend** than the one the command is using.
+Keys added under `--keyring-backend file` are not visible to `--keyring-backend test`,
+and vice versa.
+
+- List keys for the backend you are actually using:
+
+  ```bash
+  pocketd keys list --keyring-backend file
+  ```
+
+- Make the backend the default to avoid passing the flag every time. See
+  [Configuring the keyring backend](../../2_explore/2_account_management/1_pocketd_cli.md#configuring-the-keyring-backend).
+
+---
+
+## A transaction "sent with errors"
+
+Some wallets report a **failed** transaction with a "sent with errors" style message
+and a long stack trace. A transaction that fails `CheckTx` (e.g. a sequence mismatch)
+is **rejected and not included** — it did not spend funds.
+
+- Read the **first** line of the error (e.g. `account sequence mismatch`,
+  `insufficient fees`) — that is the actionable cause; the trailing stack trace is noise.
+- Confirm on-chain state (`query auth account`, `query bank balances`) before retrying,
+  per the sequence-mismatch guidance above.

--- a/docusaurus/docs/1_operate/4_faq/6_hardware_requirements.md
+++ b/docusaurus/docs/1_operate/4_faq/6_hardware_requirements.md
@@ -5,16 +5,20 @@ sidebar_position: 6
 
 ## Hardware Requirements <!-- omit in toc -->
 
-:::warning
-We are continuously evaluating the hardware requirements as we work on the next version of Pocket Network.
+:::info Last reviewed: 2026-06-01
 
-TODO_MAINNET: Update this document prior to MainNet release
+The numbers below are the canonical hardware reference for this repository's
+components. They are reviewed periodically; values for the backend chain node you
+serve are owned by that chain's own client documentation (see
+[Backend Service Node](#backend-service-node)).
+
 :::
 
 - [Recommended Environment](#recommended-environment)
 - [Validator / Full Node](#validator--full-node)
 - [RPC Node](#rpc-node)
 - [RelayMiner](#relayminer)
+- [Backend Service Node (per served chain)](#backend-service-node)
 - [PATH Gateway](#path-gateway)
 - [Additional Considerations](#additional-considerations)
 
@@ -73,6 +77,39 @@ Note that resource requirements for RelayMiner scale linearly with load:
 TODO_POST_MAINNET(@okdas): Provide benchmarks for relayminers handling different traffic amounts.
 
 :::
+
+### Backend Service Node (per served chain) {#backend-service-node}
+
+:::critical The biggest, most-often-missed requirement
+
+A `Supplier` earns by proxying relays to a **backend node of the chain it serves**
+(e.g. an Ethereum, Base, or Solana node). The `RelayMiner` itself is lightweight
+(see the table above), but the backend node it forwards to is **separate
+infrastructure that you must run, sync, and maintain** — and it is almost always the
+largest cost of operating a Supplier.
+
+The RelayMiner's `5GB` storage figure above does **NOT** include this backend node.
+
+:::
+
+Backend node sizing depends entirely on the chain you serve and grows over time, so
+there is no single number. Treat the chain's own client documentation as the source
+of truth, and budget for growth. Rough orders of magnitude (verify before deploying):
+
+| Backend chain type           | Typical disk                              | Notes                              |
+| ---------------------------- | ----------------------------------------- | ---------------------------------- |
+| EVM L1 (e.g. Ethereum)       | hundreds of GB pruned, ~1.2TB+ archive    | Grows continuously                 |
+| EVM L2 (e.g. Base, Arbitrum) | ~600GB–2TB+ and growing                   | Fast-growing; size for headroom    |
+| Cosmos SDK chains            | tens to hundreds of GB                    | Varies widely by chain and pruning |
+
+Practical guidance:
+
+- Size the disk for **target + 6–12 months of growth**, and prefer providers that
+  let you attach or expand block storage after provisioning.
+- Sync from a **snapshot** where the chain provides one — a from-genesis sync can
+  take days.
+- Run the backend node on its own volume (or host) so it does not compete with the
+  RelayMiner's claim/proof (`SMT`) storage.
 
 ### PATH Gateway
 

--- a/docusaurus/docs/2_explore/2_account_management/1_pocketd_cli.md
+++ b/docusaurus/docs/2_explore/2_account_management/1_pocketd_cli.md
@@ -94,6 +94,37 @@ The source code for the Homebrew formula can be found at [homebrew-pocketd](http
 
 ---
 
+## Configuring the keyring backend
+
+`pocketd` stores keys using a configurable keyring backend (`os`, `file`, `test`, etc.).
+For a funds-holding node, prefer `file` (encrypted, prompts for a passphrase) or `os`
+over `test`.
+
+Set it with `pocketd config set`:
+
+```bash
+pocketd config set client keyring-backend file
+```
+
+Verify it took effect:
+
+```bash
+pocketd config get client keyring-backend
+# "file"
+```
+
+:::warning `pocketd config keyring-backend <value>` is a silent no-op
+
+Running `pocketd config keyring-backend file` does **not** set anything. It is parsed
+as an unknown subcommand, so it just prints the `config` help text and exits `0` —
+giving the false impression that it worked. Always use the
+`pocketd config set client keyring-backend <value>` form above, or pass
+`--keyring-backend <value>` explicitly on each command.
+
+:::
+
+---
+
 ## Alternative Methods
 
 ### Using release binaries

--- a/tools/scripts/pocketd-install.sh
+++ b/tools/scripts/pocketd-install.sh
@@ -15,6 +15,20 @@
 #
 #   (You can find available versions, including dev-releases, at https://github.com/pokt-network/poktroll/releases)
 #
+# SECURITY: This script is piped from the internet into your shell. To inspect it
+# before running, download it first and read it:
+#
+#     curl -sSL https://raw.githubusercontent.com/pokt-network/poktroll/main/tools/scripts/pocketd-install.sh -o pocketd-install.sh
+#     less pocketd-install.sh   # review, then:
+#     bash pocketd-install.sh
+#
+# The downloaded release tarball is verified against the published `release_checksum`
+# (SHA256) before installation; a checksum mismatch aborts the install.
+#
+# SCOPE: This installs ONLY the `pocketd` CLI binary into /usr/local/bin. It does
+# NOT set up a full node, Cosmovisor, or a systemd service. To run a full node, see:
+#     https://dev.poktroll.com/operate/cheat_sheets/full_node_cheatsheet
+#
 # Flags:
 #   -u, --upgrade   Force reinstallation of the latest (or specified) version by removing the existing binary first.
 #   --tag <tag>     Install a specific release version (e.g., v0.1.12-dev1).
@@ -47,6 +61,57 @@ done
 
 command_exists() {
     command -v "$1" >/dev/null 2>&1
+}
+
+# Function to verify a downloaded tarball against the published SHA256 checksum.
+#
+# - Downloads the `release_checksum` file (standard sha256sum format) from the same release.
+# - If the checksum file (or a matching entry) is absent (e.g. older releases predating
+#   published checksums), warns and continues.
+# - If an entry exists but does NOT match, aborts the installation.
+verify_checksum() {
+    local tarball="$1"
+    local checksum_file="release_checksum"
+
+    echo "🔐 Verifying download against published SHA256 checksum..."
+
+    if ! curl -sSfLO "${BASE_URL}/${checksum_file}" 2>/dev/null; then
+        echo "⚠️  Could not download ${checksum_file} from ${BASE_URL}."
+        echo "    Skipping checksum verification (this release may predate published checksums)."
+        return 0
+    fi
+
+    local expected
+    expected=$(awk -v f="${tarball}" '$2 == f {print $1}' "${checksum_file}")
+
+    if [ -z "${expected}" ]; then
+        echo "⚠️  No checksum entry for ${tarball} in ${checksum_file}; skipping verification."
+        rm -f "${checksum_file}"
+        return 0
+    fi
+
+    local actual
+    if command_exists sha256sum; then
+        actual=$(sha256sum "${tarball}" | awk '{print $1}')
+    elif command_exists shasum; then
+        actual=$(shasum -a 256 "${tarball}" | awk '{print $1}')
+    else
+        echo "❌ Neither sha256sum nor shasum is available; cannot verify checksum. Aborting."
+        rm -f "${checksum_file}" "${tarball}"
+        exit 1
+    fi
+
+    if [ "${expected}" != "${actual}" ]; then
+        echo "❌ Checksum verification FAILED for ${tarball}"
+        echo "    expected: ${expected}"
+        echo "    actual:   ${actual}"
+        echo "    Refusing to install a tarball that does not match the published checksum."
+        rm -f "${checksum_file}" "${tarball}"
+        exit 1
+    fi
+
+    echo "✅ Checksum verified: ${actual}"
+    rm -f "${checksum_file}"
 }
 
 # Function to install pocketd if not present
@@ -117,6 +182,9 @@ install_pocketd() {
     # Download the appropriate tarball
     curl -LO "${BASE_URL}/${TARBALL}"
 
+    # Verify the downloaded tarball against the published SHA256 checksum before installing.
+    verify_checksum "${TARBALL}"
+
     # Create directory for binary if it doesn't exist
     sudo mkdir -p /usr/local/bin
 
@@ -130,8 +198,12 @@ install_pocketd() {
     # Clean up the downloaded tarball
     rm "${TARBALL}"
 
-    echo "🌿 Successfully installed pocketd version:"
+    echo "🌿 Successfully installed the pocketd CLI version:"
     pocketd version
+    echo ""
+    echo "ℹ️  This installed the pocketd CLI binary ONLY."
+    echo "   It did NOT set up a full node, Cosmovisor, or a systemd service."
+    echo "   To run a full node, follow: https://dev.poktroll.com/operate/cheat_sheets/full_node_cheatsheet"
 }
 
 install_pocketd

--- a/tools/scripts/upgrades/upgrade_tx_v0.1.34_alpha.json
+++ b/tools/scripts/upgrades/upgrade_tx_v0.1.34_alpha.json
@@ -1,0 +1,15 @@
+{
+  "body": {
+    "messages": [
+      {
+        "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+        "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+        "plan": {
+          "name": "v0.1.34",
+          "height": "UPDATE_ME",
+          "info": "{\"binaries\":{\"linux/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_linux_amd64.tar.gz\",\"linux/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_linux_arm64.tar.gz\",\"darwin/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_darwin_amd64.tar.gz\",\"darwin/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_darwin_arm64.tar.gz\"}}"
+        }
+      }
+    ]
+  }
+}

--- a/tools/scripts/upgrades/upgrade_tx_v0.1.34_beta.json
+++ b/tools/scripts/upgrades/upgrade_tx_v0.1.34_beta.json
@@ -1,0 +1,15 @@
+{
+  "body": {
+    "messages": [
+      {
+        "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+        "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+        "plan": {
+          "name": "v0.1.34",
+          "height": "348821",
+          "info": "{\"binaries\":{\"linux/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_linux_amd64.tar.gz\",\"linux/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_linux_arm64.tar.gz\",\"darwin/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_darwin_amd64.tar.gz\",\"darwin/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_darwin_arm64.tar.gz\"}}"
+        }
+      }
+    ]
+  }
+}

--- a/tools/scripts/upgrades/upgrade_tx_v0.1.34_local.json
+++ b/tools/scripts/upgrades/upgrade_tx_v0.1.34_local.json
@@ -1,0 +1,15 @@
+{
+  "body": {
+    "messages": [
+      {
+        "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+        "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+        "plan": {
+          "name": "v0.1.34",
+          "height": "UPDATE_ME",
+          "info": "{\"binaries\":{\"linux/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_linux_amd64.tar.gz\",\"linux/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_linux_arm64.tar.gz\",\"darwin/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_darwin_amd64.tar.gz\",\"darwin/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_darwin_arm64.tar.gz\"}}"
+        }
+      }
+    ]
+  }
+}

--- a/tools/scripts/upgrades/upgrade_tx_v0.1.34_main.json
+++ b/tools/scripts/upgrades/upgrade_tx_v0.1.34_main.json
@@ -1,0 +1,15 @@
+{
+  "body": {
+    "messages": [
+      {
+        "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+        "authority": "pokt10d07y265gmmuvt4z0w9aw880jnsr700j8yv32t",
+        "plan": {
+          "name": "v0.1.34",
+          "height": "UPDATE_ME",
+          "info": "{\"binaries\":{\"linux/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_linux_amd64.tar.gz\",\"linux/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_linux_arm64.tar.gz\",\"darwin/amd64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_darwin_amd64.tar.gz\",\"darwin/arm64\":\"https://github.com/pokt-network/poktroll/releases/download/v0.1.34/pocket_darwin_arm64.tar.gz\"}}"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Closes documentation/UX gaps surfaced by the Shannon mainnet **supplier + RelayMiner dogfooding exercise** that this repo (dev.poktroll.com docs + install script) actually owns. Gaps on docs.pocket.network / api.pocket.network / the blog are out of scope here.

Gaps addressed: **G-004, G-005, G-007, G-014, G-016, G-017, G-024**.

## Changes

- **Install script** (`tools/scripts/pocketd-install.sh`) — G-014, G-016
  - Verify the release tarball SHA256 against the published `release_checksum` before install (hard-fail on mismatch; warn-and-continue if a release predates published checksums).
  - Add an inspect-first note for the `curl | bash` flow.
  - State plainly that the script installs the **CLI binary only** — not a full node, Cosmovisor, or systemd — and link the full-node cheat sheet.
- **Hardware requirements** (`…/4_faq/6_hardware_requirements.md`) — G-004, G-005
  - Replace the vague TODO warning with a dated "Last reviewed" note.
  - Add a **Backend Service Node (per served chain)** section: per-chain disk/growth/snapshot guidance, and an explicit callout that the RelayMiner's 5GB figure does **not** include the backend node (the most-missed requirement).
- **Supplier cheat sheet + RelayMiner config** (`…/1_cheat_sheets/4_supplier_cheatsheet.md`, `…/3_configs/4_relayminer_config.md`) — G-005, G-007
  - Loud callout that a Supplier must run/sync a backend node of every chain it serves; Anvil is only a local stand-in.
- **pocketd CLI install** (`…/2_account_management/1_pocketd_cli.md`) — G-017
  - Document the correct `pocketd config set client keyring-backend <value>` form.
  - Warn that `pocketd config keyring-backend <value>` is a **silent no-op** (prints help, exits 0).
- **New: Transaction Troubleshooting FAQ** (`…/4_faq/10_transaction_troubleshooting.md`) — G-024
  - `account sequence mismatch` (check-before-resend; do **not** use `--unordered`), fees/gas, `account not found`, wrong keyring backend, and "sent with errors".

## Verification

- Confirmed `release_checksum` is uploaded to GitHub releases (`release-artifacts.yml` → `files: release/*`), so checksum verification is real, not aspirational.
- Confirmed `pocketd config set client keyring-backend file` works and `config get` reflects it; confirmed the bare form is a no-op.
- `bash -n` clean on the install script; all cross-links point at existing files + anchors.

## Out of scope (other properties / not addressed here)

G-027 (L2→L1 dependency) intentionally **excluded**. api.pocket.network listing (G-031/G-032), blog/Medium fragmentation (G-023/G-025), Soothe Vault (G-022), Vultr UX (G-009/G-012/G-013/G-020), and strategic items (G-029/G-030) live elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)