### PR TITLE
fix(supplier): only owner can cancel an in-progress unstake

### DIFF
--- a/x/supplier/keeper/msg_server_stake_supplier.go
+++ b/x/supplier/keeper/msg_server_stake_supplier.go
@@ -218,6 +218,21 @@ func (k Keeper) StakeSupplier(
 
 		// If the supplier has initiated an unstake action, cancel it since they are staking again.
 		if supplier.UnstakeSessionEndHeight != sharedtypes.SupplierNotUnstaking {
+			// Only the owner is allowed to cancel an in-progress unbonding.
+			// The owner controls the staked funds, so cancellation authority is
+			// restricted to the owner. Without this guard, an operator could repeatedly
+			// re-stake (paying only the staking fee, since the stake amount is unchanged)
+			// to cancel an owner-initiated unstake, preventing the owner from ever
+			// reclaiming their escrowed stake.
+			if !msg.IsSigner(supplier.OwnerAddress) {
+				err = sharedtypes.ErrSharedUnauthorizedSupplierUpdate.Wrapf(
+					"signer %q is not allowed to cancel the unbonding of supplier with owner %q; only the owner can cancel an in-progress unstake",
+					msg.Signer, supplier.OwnerAddress,
+				)
+				logger.Info(fmt.Sprintf("ERROR: %s", err))
+				return nil, status.Error(codes.PermissionDenied, err.Error())
+			}
+
 			wasSupplierUnbonding = true
 			supplier.UnstakeSessionEndHeight = sharedtypes.SupplierNotUnstaking
 		}

--- a/x/supplier/keeper/msg_server_unstake_supplier_test.go
+++ b/x/supplier/keeper/msg_server_unstake_supplier_test.go
@@ -286,6 +286,62 @@ func TestMsgServer_UnstakeSupplier_CancelUnbondingIfRestaked(t *testing.T) {
 	require.False(t, foundSupplier.IsUnbonding())
 }
 
+// TestMsgServer_UnstakeSupplier_OnlyOwnerCanCancelUnbonding verifies that once an
+// unstake has been initiated, only the owner may cancel the unbonding by re-staking.
+// Cancellation authority is restricted to the owner because the owner controls the
+// staked funds. Without this guard, the operator could re-stake (paying only the
+// staking fee) to cancel an owner-initiated unstake, preventing the owner from
+// reclaiming their escrowed stake.
+func TestMsgServer_UnstakeSupplier_OnlyOwnerCanCancelUnbonding(t *testing.T) {
+	supplierModuleKeepers, ctx := keepertest.SupplierKeeper(t)
+	srv := keeper.NewMsgServerImpl(*supplierModuleKeepers.Keeper)
+
+	// Generate distinct owner and operator addresses.
+	ownerAddr := sample.AccAddressBech32()
+	operatorAddr := sample.AccAddressBech32()
+
+	// Stake the supplier (operator signs the initial stake since it carries services).
+	initialStake := suppliertypes.DefaultMinStake.Amount.Int64()
+	stakeMsg, _ := newSupplierStakeMsg(ownerAddr, operatorAddr, initialStake, serviceID)
+	_, err := srv.StakeSupplier(ctx, stakeMsg)
+	require.NoError(t, err)
+
+	// Owner initiates the unstake.
+	unstakeMsg := &suppliertypes.MsgUnstakeSupplier{
+		Signer:          ownerAddr,
+		OperatorAddress: operatorAddr,
+	}
+	_, err = srv.UnstakeSupplier(ctx, unstakeMsg)
+	require.NoError(t, err)
+
+	foundSupplier, isSupplierFound := supplierModuleKeepers.GetSupplier(ctx, operatorAddr)
+	require.True(t, isSupplierFound)
+	require.True(t, foundSupplier.IsUnbonding())
+
+	// Operator attempts to cancel the unbonding by re-staking. This MUST fail.
+	operatorRestakeMsg, _ := newSupplierStakeMsg(ownerAddr, operatorAddr, initialStake)
+	setStakeMsgSigner(operatorRestakeMsg, operatorAddr)
+	_, err = srv.StakeSupplier(ctx, operatorRestakeMsg)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "only the owner can cancel an in-progress unstake")
+
+	// The supplier MUST still be unbonding after the operator's failed attempt.
+	foundSupplier, isSupplierFound = supplierModuleKeepers.GetSupplier(ctx, operatorAddr)
+	require.True(t, isSupplierFound)
+	require.True(t, foundSupplier.IsUnbonding())
+
+	// Owner re-stakes to cancel the unbonding. This MUST succeed.
+	ownerRestakeMsg, _ := newSupplierStakeMsg(ownerAddr, operatorAddr, initialStake)
+	setStakeMsgSigner(ownerRestakeMsg, ownerAddr)
+	_, err = srv.StakeSupplier(ctx, ownerRestakeMsg)
+	require.NoError(t, err)
+
+	// The supplier MUST no longer be unbonding.
+	foundSupplier, isSupplierFound = supplierModuleKeepers.GetSupplier(ctx, operatorAddr)
+	require.True(t, isSupplierFound)
+	require.False(t, foundSupplier.IsUnbonding())
+}
+
 func TestMsgServer_UnstakeSupplier_FailIfNotStaked(t *testing.T) {
 	supplierModuleKeepers, ctx := keepertest.SupplierKeeper(t)
 	srv := keeper.NewMsgServerImpl(*supplierModuleKeepers.Keeper)


### PR DESCRIPTION
## Summary

Once a supplier begins unbonding, an **operator** could cancel the owner's unstake by simply re-staking during the unbonding period. Re-staking with an unchanged stake amount transfers no funds (`reconcileSupplierStakeDiff` no-ops) and only costs the staking fee, so an operator could repeatedly cancel an owner-initiated unstake and prevent the owner — who controls the escrowed stake — from ever reclaiming their funds.

Both the owner and the operator can *initiate* an unstake (`msg_server_unstake_supplier.go:55`), and previously any re-stake by either party silently cleared `UnstakeSessionEndHeight` (`msg_server_stake_supplier.go:219`). There was no tracking of who initiated the unstake, so the operator could always override the owner.

## Fix

Restrict cancellation of an in-progress unbonding to the **owner**. In `StakeSupplier`, when a re-stake would cancel an active unbonding, the signer must be the owner; otherwise it fails with `PermissionDenied`.

- Operator can still *initiate* an unstake (unchanged).
- Operator can no longer cancel an unbonding — including undoing their own accidental unstake. The owner must re-stake, or the supplier unbonds fully.
- No proto or state change; no migration.

## Scope

Only the **supplier** actor has an owner/operator split, so it's the only place this vector exists. `application` and `gateway` have the same re-stake-cancels-unbonding mechanic but are keyed on a single address that is also the signer, so there is no second party to override — no equivalent issue.

## Consensus

This is a state-machine behavior change and is **consensus-breaking**. It must be gated behind a version upgrade (`app/upgrades/`) — not included in this PR. No state migration is required, only the version gate.

## Testing

- New `TestMsgServer_UnstakeSupplier_OnlyOwnerCanCancelUnbonding`: distinct owner/operator; operator re-stake during unbonding → `PermissionDenied` and supplier stays unbonding; owner re-stake → cancels.
- Existing `TestMsgServer_UnstakeSupplier_CancelUnbondingIfRestaked` still passes (owner == operator there).
- `go test ./x/supplier/...` green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)